### PR TITLE
Add basic cors policy to nextjs example repo

### DIFF
--- a/examples/cat_facts/web-nextjs/next.config.js
+++ b/examples/cat_facts/web-nextjs/next.config.js
@@ -25,4 +25,30 @@ module.exports = {
 
     return nextConfig;
   },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value:
+              "default-src 'self' 'unsafe-inline' 'unsafe-eval' catfact.ninja *.tenor.com aws.random.cat *.dream.io cdn.jsdelivr.net",
+          },
+          {
+            key: "Referrer-Policy",
+            value: "origin-when-cross-origin",
+          },
+        ],
+      },
+    ];
+  },
+  async rewrites() {
+    return [
+      {
+        source: "/",
+        destination: "https://aws.random.cat/meow",
+      },
+    ];
+  },
 };


### PR DESCRIPTION
Right now the cat facts example is showing a runtime error when we start the repo locally:

<img width="1273" alt="Screenshot 2022-11-23 at 11 39 05" src="https://user-images.githubusercontent.com/107130662/203537924-aa9d7e7c-6d47-490e-b4ec-951a6b672921.png">

The reason why is that Nextjs implements a Same Origin Policy by default and so our attempt to return an image from aws.random.cat/meow is met with a 503. 

This PR adds a basic cors policy as part of our nextjs config to remove this error.