### PR TITLE
Fix Android code generation for any package name

### DIFF
--- a/crux_core/src/typegen.rs
+++ b/crux_core/src/typegen.rs
@@ -161,16 +161,19 @@ impl TypeGen {
         let generator = serde_generate::java::CodeGenerator::new(&config);
         generator.write_source_files(path.as_ref().to_path_buf(), registry)?;
 
-        let extensions_dir =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("typegen_extensions/java");
-
         let package_path = package_name.replace('.', "/");
-        fs::copy(
-            extensions_dir.join(&package_path).join("Requests.java"),
+
+        let requests = format!(
+            "package {package_name};\n\n{}",
+            include_str!("../typegen_extensions/java/Requests.java")
+        );
+
+        fs::write(
             path.as_ref()
                 .to_path_buf()
                 .join(&package_path)
                 .join("Requests.java"),
+            requests,
         )?;
 
         Ok(())

--- a/crux_core/typegen_extensions/java/Requests.java
+++ b/crux_core/typegen_extensions/java/Requests.java
@@ -1,5 +1,3 @@
-package com.redbadger.crux_core.shared_types;
-
 public final class Requests {
 
   public static java.util.List<Request> bcsDeserialize(byte[] input) throws com.novi.serde.DeserializationError {

--- a/examples/cat_facts/Android/app/src/main/java/com/example/android/MainActivity.kt
+++ b/examples/cat_facts/Android/app/src/main/java/com/example/android/MainActivity.kt
@@ -21,15 +21,15 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil.compose.rememberAsyncImagePainter
 import com.example.android.ui.theme.AndroidTheme
-import com.redbadger.crux_core.shared.*
-import com.redbadger.crux_core.shared_types.Msg
-import com.redbadger.crux_core.shared_types.PlatformMsg
-import com.redbadger.crux_core.shared_types.Request as Req
-import com.redbadger.crux_core.shared_types.Requests
-import com.redbadger.crux_core.shared_types.RequestBody as ReqBody
-import com.redbadger.crux_core.shared_types.Response as Res
-import com.redbadger.crux_core.shared_types.ResponseBody as ResBody
-import com.redbadger.crux_core.shared_types.ViewModel as MyViewModel
+import com.redbadger.catfacts.shared.*
+import com.redbadger.catfacts.shared_types.Msg
+import com.redbadger.catfacts.shared_types.PlatformMsg
+import com.redbadger.catfacts.shared_types.Request as Req
+import com.redbadger.catfacts.shared_types.Requests
+import com.redbadger.catfacts.shared_types.RequestBody as ReqBody
+import com.redbadger.catfacts.shared_types.Response as Res
+import com.redbadger.catfacts.shared_types.ResponseBody as ResBody
+import com.redbadger.catfacts.shared_types.ViewModel as MyViewModel
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter

--- a/examples/cat_facts/Android/shared/build.gradle
+++ b/examples/cat_facts/Android/shared/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 android {
-    namespace 'com.redbadger.crux_core.shared'
+    namespace 'com.redbadger.catfacts.shared'
     compileSdk 32
     ndkVersion '25.1.8937393'
 

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared/shared.kt
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared/shared.kt
@@ -3,7 +3,7 @@
 
 @file:Suppress("NAME_SHADOWING")
 
-package com.redbadger.crux_core.shared
+package com.redbadger.catfacts.shared
 
 // Common helper code.
 //

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/CatImage.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/CatImage.java
@@ -1,4 +1,4 @@
-package com.redbadger.crux_core.shared_types;
+package com.redbadger.catfacts.shared_types;
 
 
 public final class CatImage {

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/Msg.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/Msg.java
@@ -1,4 +1,4 @@
-package com.redbadger.crux_core.shared_types;
+package com.redbadger.catfacts.shared_types;
 
 
 public abstract class Msg {

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/PlatformMsg.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/PlatformMsg.java
@@ -1,4 +1,4 @@
-package com.redbadger.crux_core.shared_types;
+package com.redbadger.catfacts.shared_types;
 
 
 public abstract class PlatformMsg {

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/Request.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/Request.java
@@ -1,4 +1,4 @@
-package com.redbadger.crux_core.shared_types;
+package com.redbadger.catfacts.shared_types;
 
 
 public final class Request {

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/RequestBody.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/RequestBody.java
@@ -1,19 +1,20 @@
-package com.redbadger.crux_core.shared_types;
+package com.redbadger.catfacts.shared_types;
 
 
-public abstract class ResponseBody {
+public abstract class RequestBody {
 
     abstract public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError;
 
-    public static ResponseBody deserialize(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
+    public static RequestBody deserialize(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
         int index = deserializer.deserialize_variant_index();
         switch (index) {
-            case 0: return Http.load(deserializer);
-            case 1: return Time.load(deserializer);
+            case 0: return Time.load(deserializer);
+            case 1: return Http.load(deserializer);
             case 2: return Platform.load(deserializer);
             case 3: return KVRead.load(deserializer);
             case 4: return KVWrite.load(deserializer);
-            default: throw new com.novi.serde.DeserializationError("Unknown variant index for ResponseBody: " + index);
+            case 5: return Render.load(deserializer);
+            default: throw new com.novi.serde.DeserializationError("Unknown variant index for RequestBody: " + index);
         }
     }
 
@@ -23,37 +24,75 @@ public abstract class ResponseBody {
         return serializer.get_bytes();
     }
 
-    public static ResponseBody bcsDeserialize(byte[] input) throws com.novi.serde.DeserializationError {
+    public static RequestBody bcsDeserialize(byte[] input) throws com.novi.serde.DeserializationError {
         if (input == null) {
              throw new com.novi.serde.DeserializationError("Cannot deserialize null array");
         }
         com.novi.serde.Deserializer deserializer = new com.novi.bcs.BcsDeserializer(input);
-        ResponseBody value = deserialize(deserializer);
+        RequestBody value = deserialize(deserializer);
         if (deserializer.get_buffer_offset() < input.length) {
              throw new com.novi.serde.DeserializationError("Some input bytes were not read");
         }
         return value;
     }
 
-    public static final class Http extends ResponseBody {
-        public final java.util.List<@com.novi.serde.Unsigned Byte> value;
+    public static final class Time extends RequestBody {
+        public Time() {
+        }
 
-        public Http(java.util.List<@com.novi.serde.Unsigned Byte> value) {
+        public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
+            serializer.increase_container_depth();
+            serializer.serialize_variant_index(0);
+            serializer.decrease_container_depth();
+        }
+
+        static Time load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
+            deserializer.increase_container_depth();
+            Builder builder = new Builder();
+            deserializer.decrease_container_depth();
+            return builder.build();
+        }
+
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null) return false;
+            if (getClass() != obj.getClass()) return false;
+            Time other = (Time) obj;
+            return true;
+        }
+
+        public int hashCode() {
+            int value = 7;
+            return value;
+        }
+
+        public static final class Builder {
+            public Time build() {
+                return new Time(
+                );
+            }
+        }
+    }
+
+    public static final class Http extends RequestBody {
+        public final String value;
+
+        public Http(String value) {
             java.util.Objects.requireNonNull(value, "value must not be null");
             this.value = value;
         }
 
         public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
             serializer.increase_container_depth();
-            serializer.serialize_variant_index(0);
-            TraitHelpers.serialize_vector_u8(value, serializer);
+            serializer.serialize_variant_index(1);
+            serializer.serialize_str(value);
             serializer.decrease_container_depth();
         }
 
         static Http load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
             deserializer.increase_container_depth();
             Builder builder = new Builder();
-            builder.value = TraitHelpers.deserialize_vector_u8(deserializer);
+            builder.value = deserializer.deserialize_str();
             deserializer.decrease_container_depth();
             return builder.build();
         }
@@ -74,7 +113,7 @@ public abstract class ResponseBody {
         }
 
         public static final class Builder {
-            public java.util.List<@com.novi.serde.Unsigned Byte> value;
+            public String value;
 
             public Http build() {
                 return new Http(
@@ -84,74 +123,19 @@ public abstract class ResponseBody {
         }
     }
 
-    public static final class Time extends ResponseBody {
-        public final String value;
-
-        public Time(String value) {
-            java.util.Objects.requireNonNull(value, "value must not be null");
-            this.value = value;
-        }
-
-        public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
-            serializer.increase_container_depth();
-            serializer.serialize_variant_index(1);
-            serializer.serialize_str(value);
-            serializer.decrease_container_depth();
-        }
-
-        static Time load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
-            deserializer.increase_container_depth();
-            Builder builder = new Builder();
-            builder.value = deserializer.deserialize_str();
-            deserializer.decrease_container_depth();
-            return builder.build();
-        }
-
-        public boolean equals(Object obj) {
-            if (this == obj) return true;
-            if (obj == null) return false;
-            if (getClass() != obj.getClass()) return false;
-            Time other = (Time) obj;
-            if (!java.util.Objects.equals(this.value, other.value)) { return false; }
-            return true;
-        }
-
-        public int hashCode() {
-            int value = 7;
-            value = 31 * value + (this.value != null ? this.value.hashCode() : 0);
-            return value;
-        }
-
-        public static final class Builder {
-            public String value;
-
-            public Time build() {
-                return new Time(
-                    value
-                );
-            }
-        }
-    }
-
-    public static final class Platform extends ResponseBody {
-        public final String value;
-
-        public Platform(String value) {
-            java.util.Objects.requireNonNull(value, "value must not be null");
-            this.value = value;
+    public static final class Platform extends RequestBody {
+        public Platform() {
         }
 
         public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
             serializer.increase_container_depth();
             serializer.serialize_variant_index(2);
-            serializer.serialize_str(value);
             serializer.decrease_container_depth();
         }
 
         static Platform load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
             deserializer.increase_container_depth();
             Builder builder = new Builder();
-            builder.value = deserializer.deserialize_str();
             deserializer.decrease_container_depth();
             return builder.build();
         }
@@ -161,31 +145,26 @@ public abstract class ResponseBody {
             if (obj == null) return false;
             if (getClass() != obj.getClass()) return false;
             Platform other = (Platform) obj;
-            if (!java.util.Objects.equals(this.value, other.value)) { return false; }
             return true;
         }
 
         public int hashCode() {
             int value = 7;
-            value = 31 * value + (this.value != null ? this.value.hashCode() : 0);
             return value;
         }
 
         public static final class Builder {
-            public String value;
-
             public Platform build() {
                 return new Platform(
-                    value
                 );
             }
         }
     }
 
-    public static final class KVRead extends ResponseBody {
-        public final java.util.Optional<java.util.List<@com.novi.serde.Unsigned Byte>> value;
+    public static final class KVRead extends RequestBody {
+        public final String value;
 
-        public KVRead(java.util.Optional<java.util.List<@com.novi.serde.Unsigned Byte>> value) {
+        public KVRead(String value) {
             java.util.Objects.requireNonNull(value, "value must not be null");
             this.value = value;
         }
@@ -193,14 +172,14 @@ public abstract class ResponseBody {
         public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
             serializer.increase_container_depth();
             serializer.serialize_variant_index(3);
-            TraitHelpers.serialize_option_vector_u8(value, serializer);
+            serializer.serialize_str(value);
             serializer.decrease_container_depth();
         }
 
         static KVRead load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
             deserializer.increase_container_depth();
             Builder builder = new Builder();
-            builder.value = TraitHelpers.deserialize_option_vector_u8(deserializer);
+            builder.value = deserializer.deserialize_str();
             deserializer.decrease_container_depth();
             return builder.build();
         }
@@ -221,7 +200,7 @@ public abstract class ResponseBody {
         }
 
         public static final class Builder {
-            public java.util.Optional<java.util.List<@com.novi.serde.Unsigned Byte>> value;
+            public String value;
 
             public KVRead build() {
                 return new KVRead(
@@ -231,25 +210,30 @@ public abstract class ResponseBody {
         }
     }
 
-    public static final class KVWrite extends ResponseBody {
-        public final Boolean value;
+    public static final class KVWrite extends RequestBody {
+        public final String field0;
+        public final java.util.List<@com.novi.serde.Unsigned Byte> field1;
 
-        public KVWrite(Boolean value) {
-            java.util.Objects.requireNonNull(value, "value must not be null");
-            this.value = value;
+        public KVWrite(String field0, java.util.List<@com.novi.serde.Unsigned Byte> field1) {
+            java.util.Objects.requireNonNull(field0, "field0 must not be null");
+            java.util.Objects.requireNonNull(field1, "field1 must not be null");
+            this.field0 = field0;
+            this.field1 = field1;
         }
 
         public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
             serializer.increase_container_depth();
             serializer.serialize_variant_index(4);
-            serializer.serialize_bool(value);
+            serializer.serialize_str(field0);
+            TraitHelpers.serialize_vector_u8(field1, serializer);
             serializer.decrease_container_depth();
         }
 
         static KVWrite load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
             deserializer.increase_container_depth();
             Builder builder = new Builder();
-            builder.value = deserializer.deserialize_bool();
+            builder.field0 = deserializer.deserialize_str();
+            builder.field1 = TraitHelpers.deserialize_vector_u8(deserializer);
             deserializer.decrease_container_depth();
             return builder.build();
         }
@@ -259,22 +243,64 @@ public abstract class ResponseBody {
             if (obj == null) return false;
             if (getClass() != obj.getClass()) return false;
             KVWrite other = (KVWrite) obj;
-            if (!java.util.Objects.equals(this.value, other.value)) { return false; }
+            if (!java.util.Objects.equals(this.field0, other.field0)) { return false; }
+            if (!java.util.Objects.equals(this.field1, other.field1)) { return false; }
             return true;
         }
 
         public int hashCode() {
             int value = 7;
-            value = 31 * value + (this.value != null ? this.value.hashCode() : 0);
+            value = 31 * value + (this.field0 != null ? this.field0.hashCode() : 0);
+            value = 31 * value + (this.field1 != null ? this.field1.hashCode() : 0);
             return value;
         }
 
         public static final class Builder {
-            public Boolean value;
+            public String field0;
+            public java.util.List<@com.novi.serde.Unsigned Byte> field1;
 
             public KVWrite build() {
                 return new KVWrite(
-                    value
+                    field0,
+                    field1
+                );
+            }
+        }
+    }
+
+    public static final class Render extends RequestBody {
+        public Render() {
+        }
+
+        public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
+            serializer.increase_container_depth();
+            serializer.serialize_variant_index(5);
+            serializer.decrease_container_depth();
+        }
+
+        static Render load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
+            deserializer.increase_container_depth();
+            Builder builder = new Builder();
+            deserializer.decrease_container_depth();
+            return builder.build();
+        }
+
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null) return false;
+            if (getClass() != obj.getClass()) return false;
+            Render other = (Render) obj;
+            return true;
+        }
+
+        public int hashCode() {
+            int value = 7;
+            return value;
+        }
+
+        public static final class Builder {
+            public Render build() {
+                return new Render(
                 );
             }
         }

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/Requests.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/Requests.java
@@ -1,4 +1,4 @@
-package com.redbadger.crux_core.shared_types;
+package com.redbadger.catfacts.shared_types;
 
 public final class Requests {
 

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/Response.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/Response.java
@@ -1,4 +1,4 @@
-package com.redbadger.crux_core.shared_types;
+package com.redbadger.catfacts.shared_types;
 
 
 public final class Response {

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/ResponseBody.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/ResponseBody.java
@@ -1,20 +1,19 @@
-package com.redbadger.crux_core.shared_types;
+package com.redbadger.catfacts.shared_types;
 
 
-public abstract class RequestBody {
+public abstract class ResponseBody {
 
     abstract public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError;
 
-    public static RequestBody deserialize(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
+    public static ResponseBody deserialize(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
         int index = deserializer.deserialize_variant_index();
         switch (index) {
-            case 0: return Time.load(deserializer);
-            case 1: return Http.load(deserializer);
+            case 0: return Http.load(deserializer);
+            case 1: return Time.load(deserializer);
             case 2: return Platform.load(deserializer);
             case 3: return KVRead.load(deserializer);
             case 4: return KVWrite.load(deserializer);
-            case 5: return Render.load(deserializer);
-            default: throw new com.novi.serde.DeserializationError("Unknown variant index for RequestBody: " + index);
+            default: throw new com.novi.serde.DeserializationError("Unknown variant index for ResponseBody: " + index);
         }
     }
 
@@ -24,75 +23,37 @@ public abstract class RequestBody {
         return serializer.get_bytes();
     }
 
-    public static RequestBody bcsDeserialize(byte[] input) throws com.novi.serde.DeserializationError {
+    public static ResponseBody bcsDeserialize(byte[] input) throws com.novi.serde.DeserializationError {
         if (input == null) {
              throw new com.novi.serde.DeserializationError("Cannot deserialize null array");
         }
         com.novi.serde.Deserializer deserializer = new com.novi.bcs.BcsDeserializer(input);
-        RequestBody value = deserialize(deserializer);
+        ResponseBody value = deserialize(deserializer);
         if (deserializer.get_buffer_offset() < input.length) {
              throw new com.novi.serde.DeserializationError("Some input bytes were not read");
         }
         return value;
     }
 
-    public static final class Time extends RequestBody {
-        public Time() {
-        }
+    public static final class Http extends ResponseBody {
+        public final java.util.List<@com.novi.serde.Unsigned Byte> value;
 
-        public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
-            serializer.increase_container_depth();
-            serializer.serialize_variant_index(0);
-            serializer.decrease_container_depth();
-        }
-
-        static Time load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
-            deserializer.increase_container_depth();
-            Builder builder = new Builder();
-            deserializer.decrease_container_depth();
-            return builder.build();
-        }
-
-        public boolean equals(Object obj) {
-            if (this == obj) return true;
-            if (obj == null) return false;
-            if (getClass() != obj.getClass()) return false;
-            Time other = (Time) obj;
-            return true;
-        }
-
-        public int hashCode() {
-            int value = 7;
-            return value;
-        }
-
-        public static final class Builder {
-            public Time build() {
-                return new Time(
-                );
-            }
-        }
-    }
-
-    public static final class Http extends RequestBody {
-        public final String value;
-
-        public Http(String value) {
+        public Http(java.util.List<@com.novi.serde.Unsigned Byte> value) {
             java.util.Objects.requireNonNull(value, "value must not be null");
             this.value = value;
         }
 
         public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
             serializer.increase_container_depth();
-            serializer.serialize_variant_index(1);
-            serializer.serialize_str(value);
+            serializer.serialize_variant_index(0);
+            TraitHelpers.serialize_vector_u8(value, serializer);
             serializer.decrease_container_depth();
         }
 
         static Http load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
             deserializer.increase_container_depth();
             Builder builder = new Builder();
-            builder.value = deserializer.deserialize_str();
+            builder.value = TraitHelpers.deserialize_vector_u8(deserializer);
             deserializer.decrease_container_depth();
             return builder.build();
         }
@@ -113,7 +74,7 @@ public abstract class RequestBody {
         }
 
         public static final class Builder {
-            public String value;
+            public java.util.List<@com.novi.serde.Unsigned Byte> value;
 
             public Http build() {
                 return new Http(
@@ -123,19 +84,74 @@ public abstract class RequestBody {
         }
     }
 
-    public static final class Platform extends RequestBody {
-        public Platform() {
+    public static final class Time extends ResponseBody {
+        public final String value;
+
+        public Time(String value) {
+            java.util.Objects.requireNonNull(value, "value must not be null");
+            this.value = value;
+        }
+
+        public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
+            serializer.increase_container_depth();
+            serializer.serialize_variant_index(1);
+            serializer.serialize_str(value);
+            serializer.decrease_container_depth();
+        }
+
+        static Time load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
+            deserializer.increase_container_depth();
+            Builder builder = new Builder();
+            builder.value = deserializer.deserialize_str();
+            deserializer.decrease_container_depth();
+            return builder.build();
+        }
+
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (obj == null) return false;
+            if (getClass() != obj.getClass()) return false;
+            Time other = (Time) obj;
+            if (!java.util.Objects.equals(this.value, other.value)) { return false; }
+            return true;
+        }
+
+        public int hashCode() {
+            int value = 7;
+            value = 31 * value + (this.value != null ? this.value.hashCode() : 0);
+            return value;
+        }
+
+        public static final class Builder {
+            public String value;
+
+            public Time build() {
+                return new Time(
+                    value
+                );
+            }
+        }
+    }
+
+    public static final class Platform extends ResponseBody {
+        public final String value;
+
+        public Platform(String value) {
+            java.util.Objects.requireNonNull(value, "value must not be null");
+            this.value = value;
         }
 
         public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
             serializer.increase_container_depth();
             serializer.serialize_variant_index(2);
+            serializer.serialize_str(value);
             serializer.decrease_container_depth();
         }
 
         static Platform load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
             deserializer.increase_container_depth();
             Builder builder = new Builder();
+            builder.value = deserializer.deserialize_str();
             deserializer.decrease_container_depth();
             return builder.build();
         }
@@ -145,26 +161,31 @@ public abstract class RequestBody {
             if (obj == null) return false;
             if (getClass() != obj.getClass()) return false;
             Platform other = (Platform) obj;
+            if (!java.util.Objects.equals(this.value, other.value)) { return false; }
             return true;
         }
 
         public int hashCode() {
             int value = 7;
+            value = 31 * value + (this.value != null ? this.value.hashCode() : 0);
             return value;
         }
 
         public static final class Builder {
+            public String value;
+
             public Platform build() {
                 return new Platform(
+                    value
                 );
             }
         }
     }
 
-    public static final class KVRead extends RequestBody {
-        public final String value;
+    public static final class KVRead extends ResponseBody {
+        public final java.util.Optional<java.util.List<@com.novi.serde.Unsigned Byte>> value;
 
-        public KVRead(String value) {
+        public KVRead(java.util.Optional<java.util.List<@com.novi.serde.Unsigned Byte>> value) {
             java.util.Objects.requireNonNull(value, "value must not be null");
             this.value = value;
         }
@@ -172,14 +193,14 @@ public abstract class RequestBody {
         public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
             serializer.increase_container_depth();
             serializer.serialize_variant_index(3);
-            serializer.serialize_str(value);
+            TraitHelpers.serialize_option_vector_u8(value, serializer);
             serializer.decrease_container_depth();
         }
 
         static KVRead load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
             deserializer.increase_container_depth();
             Builder builder = new Builder();
-            builder.value = deserializer.deserialize_str();
+            builder.value = TraitHelpers.deserialize_option_vector_u8(deserializer);
             deserializer.decrease_container_depth();
             return builder.build();
         }
@@ -200,7 +221,7 @@ public abstract class RequestBody {
         }
 
         public static final class Builder {
-            public String value;
+            public java.util.Optional<java.util.List<@com.novi.serde.Unsigned Byte>> value;
 
             public KVRead build() {
                 return new KVRead(
@@ -210,30 +231,25 @@ public abstract class RequestBody {
         }
     }
 
-    public static final class KVWrite extends RequestBody {
-        public final String field0;
-        public final java.util.List<@com.novi.serde.Unsigned Byte> field1;
+    public static final class KVWrite extends ResponseBody {
+        public final Boolean value;
 
-        public KVWrite(String field0, java.util.List<@com.novi.serde.Unsigned Byte> field1) {
-            java.util.Objects.requireNonNull(field0, "field0 must not be null");
-            java.util.Objects.requireNonNull(field1, "field1 must not be null");
-            this.field0 = field0;
-            this.field1 = field1;
+        public KVWrite(Boolean value) {
+            java.util.Objects.requireNonNull(value, "value must not be null");
+            this.value = value;
         }
 
         public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
             serializer.increase_container_depth();
             serializer.serialize_variant_index(4);
-            serializer.serialize_str(field0);
-            TraitHelpers.serialize_vector_u8(field1, serializer);
+            serializer.serialize_bool(value);
             serializer.decrease_container_depth();
         }
 
         static KVWrite load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
             deserializer.increase_container_depth();
             Builder builder = new Builder();
-            builder.field0 = deserializer.deserialize_str();
-            builder.field1 = TraitHelpers.deserialize_vector_u8(deserializer);
+            builder.value = deserializer.deserialize_bool();
             deserializer.decrease_container_depth();
             return builder.build();
         }
@@ -243,64 +259,22 @@ public abstract class RequestBody {
             if (obj == null) return false;
             if (getClass() != obj.getClass()) return false;
             KVWrite other = (KVWrite) obj;
-            if (!java.util.Objects.equals(this.field0, other.field0)) { return false; }
-            if (!java.util.Objects.equals(this.field1, other.field1)) { return false; }
+            if (!java.util.Objects.equals(this.value, other.value)) { return false; }
             return true;
         }
 
         public int hashCode() {
             int value = 7;
-            value = 31 * value + (this.field0 != null ? this.field0.hashCode() : 0);
-            value = 31 * value + (this.field1 != null ? this.field1.hashCode() : 0);
+            value = 31 * value + (this.value != null ? this.value.hashCode() : 0);
             return value;
         }
 
         public static final class Builder {
-            public String field0;
-            public java.util.List<@com.novi.serde.Unsigned Byte> field1;
+            public Boolean value;
 
             public KVWrite build() {
                 return new KVWrite(
-                    field0,
-                    field1
-                );
-            }
-        }
-    }
-
-    public static final class Render extends RequestBody {
-        public Render() {
-        }
-
-        public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
-            serializer.increase_container_depth();
-            serializer.serialize_variant_index(5);
-            serializer.decrease_container_depth();
-        }
-
-        static Render load(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
-            deserializer.increase_container_depth();
-            Builder builder = new Builder();
-            deserializer.decrease_container_depth();
-            return builder.build();
-        }
-
-        public boolean equals(Object obj) {
-            if (this == obj) return true;
-            if (obj == null) return false;
-            if (getClass() != obj.getClass()) return false;
-            Render other = (Render) obj;
-            return true;
-        }
-
-        public int hashCode() {
-            int value = 7;
-            return value;
-        }
-
-        public static final class Builder {
-            public Render build() {
-                return new Render(
+                    value
                 );
             }
         }

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/TraitHelpers.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/TraitHelpers.java
@@ -1,4 +1,4 @@
-package com.redbadger.crux_core.shared_types;
+package com.redbadger.catfacts.shared_types;
 
 final class TraitHelpers {
     static void serialize_option_CatImage(java.util.Optional<CatImage> value, com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/ViewModel.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/ViewModel.java
@@ -1,4 +1,4 @@
-package com.redbadger.crux_core.shared_types;
+package com.redbadger.catfacts.shared_types;
 
 
 public final class ViewModel {

--- a/examples/cat_facts/shared/uniffi.toml
+++ b/examples/cat_facts/shared/uniffi.toml
@@ -1,5 +1,5 @@
 [bindings.kotlin]
-package_name = "com.redbadger.crux_core.shared"
+package_name = "com.redbadger.catfacts.shared"
 cdylib_name = "shared"
 
 [bindings.swift]

--- a/examples/cat_facts/shared_types/build.rs
+++ b/examples/cat_facts/shared_types/build.rs
@@ -14,7 +14,7 @@ fn main() {
         .expect("swift type gen failed");
 
     gen.java(
-        "com.redbadger.crux_core.shared_types",
+        "com.redbadger.catfacts.shared_types",
         output_root.join("java"),
     )
     .expect("java type gen failed");


### PR DESCRIPTION
Currently, the type generation assumes that the target code will live under the com.redbadger.crux_core.shared_types package.  However, users of crux can specify their own package, so this isn't always the case.

This commit changes the type generation to set the package in the Requests.java file, and copy it to the correct package directory.  It also changes the package in the cat facts example, to demonstrate this working correctly.