### PR TITLE
Add `x86_64-apple-ios` to targets list

### DIFF
--- a/examples/cat_facts/README.md
+++ b/examples/cat_facts/README.md
@@ -10,6 +10,7 @@
    aarch64-apple-ios-sim
    aarch64-linux-android
    wasm32-unknown-unknown
+   x86_64-apple-ios
    ```
 
 1. Install the `uniffi-bindgen` binary ...

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,6 +6,7 @@ targets = [
   "aarch64-apple-ios",
   "aarch64-apple-ios-sim",
   "aarch64-linux-android",
-  "wasm32-unknown-unknown"
+  "wasm32-unknown-unknown",
+  "x86_64-apple-ios"
 ]
 profile = "minimal"


### PR DESCRIPTION
This seems to be needed for the iOS simulator on intel macs.