### PR TITLE
Make `channels` & `executor` private.

### DIFF
--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -162,8 +162,8 @@
 //!
 
 pub mod capability;
-pub mod channels;
-pub mod executor;
+mod channels;
+mod executor;
 mod future;
 pub mod render;
 mod steps;


### PR DESCRIPTION
Noticed these sitting undocumented in the 0.2 docs.  At one point I thought these might be public API, but we've ended up hiding them sufficiently.  So rather than documenting them, lets just hide them from users.