### PR TITLE
Add some basic github actions

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,6 @@
+[profile.ci]
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+# Do not cancel the test run on the first failure.
+fail-fast = false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,111 @@
+name: build
+
+on:
+  push:
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-D warnings"
+  RUST_BACKTRACE: short
+  NEXTEST_PROFILE: ci
+  CI: 1
+
+jobs:
+  build-crux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
+      - uses: dtolnay/rust-toolchain@1.66.0
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        shell: bash
+        run: cargo fmt --all --check
+
+      - name: Build crux
+        shell: bash
+        run: cargo build --workspace
+
+      - name: Install nextest
+        shell: bash
+        run: |
+          curl -LsSf https://get.nexte.st/0.9/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
+      - name: Build tests
+        shell: bash
+        run: |
+          cargo nextest run --workspace --all-features --no-run
+
+      - name: Run tests
+        shell: bash
+        run: |
+          cargo nextest run --workspace --all-features
+
+      - name: Build & run doctests
+        shell: bash
+        run: |
+          cargo test --doc --workspace
+
+  find-examples:
+    runs-on: ubuntu-latest
+    outputs:
+      examples: ${{ steps.find.outputs.examples }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: find
+        run: |
+          EXAMPLES=$(ls -d examples/*/ | xargs basename | jq --raw-input --slurp --compact-output 'split("\n")[:-1]')
+          echo "examples=$EXAMPLES" >> $GITHUB_OUTPUT
+
+  build-examples:
+    runs-on: ubuntu-latest
+    needs: find-examples
+    strategy:
+      matrix:
+        example: ${{ fromJson(needs.find-examples.outputs.examples) }}
+
+    defaults:
+      run:
+        working-directory: examples/${{ matrix.example }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: Swatinem/rust-cache@v1
+      - uses: dtolnay/rust-toolchain@1.66.0
+        with:
+          components: rustfmt
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 7.18.1
+
+      - name: Check formatting
+        shell: bash
+        run: cargo fmt --all --check
+
+      - name: Build ${{ matrix.example }}
+        shell: bash
+        run: cargo build --workspace
+
+      - name: Install nextest
+        shell: bash
+        run: |
+          curl -LsSf https://get.nexte.st/0.9/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+
+      - name: Build tests
+        shell: bash
+        run: |
+          cargo nextest run --workspace --all-features --no-run
+
+      - name: Run tests
+        shell: bash
+        run: |
+          cargo nextest run --workspace --all-features
+
+      - name: Build & run doctests
+        shell: bash
+        run: |
+          cargo test --doc --workspace

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   rustdoc:
-    if: github.repository == 'red-badger/crux'
+    if: github.repository == 'redbadger/crux'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -1,0 +1,33 @@
+name: rustdoc
+on:
+  push:
+   branches:
+     - master
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTFLAGS: "-D warnings"
+  RUSTUP_MAX_RETRIES: 10
+
+jobs:
+  rustdoc:
+    if: github.repository == 'red-badger/crux'
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: Swatinem/rust-cache@v1
+    - uses: dtolnay/rust-toolchain@1.66.0
+
+    - name: Build Documentation
+      run: cargo doc --all --no-deps
+
+    - name: Deploy Docs
+      uses: peaceiris/actions-gh-pages@364c31d33bb99327c77b3a5438a83a357a6729ad # v3.4.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_branch: gh-pages
+        publish_dir: ./target/doc
+        force_orphan: true
+

--- a/examples/cat_facts/.config/nextest.toml
+++ b/examples/cat_facts/.config/nextest.toml
@@ -1,0 +1,6 @@
+[profile.ci]
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+# Do not cancel the test run on the first failure.
+fail-fast = false


### PR DESCRIPTION
- Added a workflow that:
  1. Builds & tests crux itself
  2. Builds the rust code of each of the examples.
- Added a doc action that'll publish master to github docs.

Currently this doesn't build the shell side of any of the examples, that'll need to be done in a future PR.