### PR TITLE
Experiment — Error handling for HTTP capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,7 @@ dependencies = [
  "derive_more",
  "serde",
  "serde_json",
+ "thiserror",
  "url",
 ]
 

--- a/crux_core/src/future.rs
+++ b/crux_core/src/future.rs
@@ -48,11 +48,11 @@ where
     Ev: 'static,
 {
     /// Send an effect request to the shell, expecting an output. The
-    /// provided `operation` describes the effect input in a serialisable fashion,
+    /// provided `operation` describes the effect input in a serializable fashion,
     /// and must implement the [`Operation`](crate::capability::Operation) trait to declare the expected
     /// output type.
     ///
-    /// `request_from_shell` is returns a future of the output, which can be
+    /// `request_from_shell` returns a future of the output, which can be
     /// `await`ed. You should only call this method inside an async task
     /// created with [`CapabilityContext::spawn`](crate::capability::CapabilityContext::spawn).
     pub fn request_from_shell(&self, operation: Op) -> EffectFuture<Op::Output> {

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -16,6 +16,7 @@ crux_core = { version = "0.2", path = "../crux_core" }
 derive_more = "0.99.17"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0.91"
+thiserror = "1.0.38"
 url = "2.3.1"
 
 [dev-dependencies]

--- a/crux_http/src/lib.rs
+++ b/crux_http/src/lib.rs
@@ -50,8 +50,10 @@ pub struct HttpResponse {
     pub body: Option<Vec<u8>>, // TODO support headers
 }
 
+pub type HttpResult = Result<HttpResponse, HttpError>;
+
 impl Operation for HttpRequest {
-    type Output = Result<HttpResponse, HttpError>;
+    type Output = HttpResult;
 }
 
 #[derive(Error, Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -81,7 +83,7 @@ where
     pub fn get<F>(&self, url: Url, callback: F)
     where
         Ev: 'static,
-        F: Fn(Result<HttpResponse, HttpError>) -> Ev + Send + 'static,
+        F: Fn(HttpResult) -> Ev + Send + 'static,
     {
         self.send(HttpMethod::Get, url, callback)
     }
@@ -92,7 +94,7 @@ where
     pub fn post<F>(&self, url: Url, callback: F)
     where
         Ev: 'static,
-        F: Fn(Result<HttpResponse, HttpError>) -> Ev + Send + 'static,
+        F: Fn(HttpResult) -> Ev + Send + 'static,
     {
         self.send(HttpMethod::Post, url, callback)
     }
@@ -104,7 +106,7 @@ where
     pub fn send<F>(&self, method: HttpMethod, url: Url, callback: F)
     where
         Ev: 'static,
-        F: Fn(Result<HttpResponse, HttpError>) -> Ev + Send + 'static,
+        F: Fn(HttpResult) -> Ev + Send + 'static,
     {
         let ctx = self.context.clone();
         self.context.spawn(async move {

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -1,6 +1,6 @@
 mod shared {
     use crux_core::render::Render;
-    use crux_http::{Http, HttpError, HttpResponse};
+    use crux_http::{Http, HttpResponse, HttpResult};
     use crux_macros::Effect;
     use serde::{Deserialize, Serialize};
     use url::Url;
@@ -12,7 +12,7 @@ mod shared {
     pub enum Event {
         Get,
         Post,
-        Set(Result<HttpResponse, HttpError>),
+        Set(HttpResult),
     }
 
     #[derive(Default, Serialize, Deserialize)]
@@ -74,11 +74,11 @@ mod shell {
     use super::shared::{App, Effect, Event, ViewModel};
     use anyhow::Result;
     use crux_core::{Core, Request};
-    use crux_http::{HttpError, HttpRequest, HttpResponse};
+    use crux_http::{HttpRequest, HttpResponse, HttpResult};
     use std::collections::VecDeque;
 
     pub enum Outcome {
-        Http(Result<HttpResponse, HttpError>),
+        Http(HttpResult),
     }
 
     enum CoreMessage {

--- a/crux_http/tests/with_tester.rs
+++ b/crux_http/tests/with_tester.rs
@@ -1,6 +1,6 @@
 mod shared {
 
-    use crux_http::{Http, HttpError, HttpResponse};
+    use crux_http::{Http, HttpResponse, HttpResult};
     use crux_macros::Effect;
     use serde::{Deserialize, Serialize};
     use url::Url;
@@ -11,7 +11,7 @@ mod shared {
     #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
     pub enum Event {
         Get,
-        Set(Result<HttpResponse, HttpError>),
+        Set(HttpResult),
     }
 
     #[derive(Default, Serialize, Deserialize)]
@@ -63,7 +63,7 @@ mod shared {
 mod tests {
     use crate::shared::{App, Effect, Event, Model};
     use crux_core::testing::AppTester;
-    use crux_http::{HttpError, HttpRequest, HttpResponse};
+    use crux_http::{HttpRequest, HttpResponse, HttpResult};
 
     #[test]
     fn with_tester() {
@@ -80,7 +80,7 @@ mod tests {
             })
         );
 
-        let http_response = Ok::<_, HttpError>(HttpResponse {
+        let http_response = HttpResult::Ok(HttpResponse {
             status: 200,
             body: Some(serde_json::to_vec("hello").unwrap()),
         });

--- a/examples/cat_facts/Cargo.lock
+++ b/examples/cat_facts/Cargo.lock
@@ -633,6 +633,7 @@ dependencies = [
  "derive_more",
  "serde",
  "serde_json",
+ "thiserror",
  "url",
 ]
 

--- a/examples/cat_facts/cli/src/main.rs
+++ b/examples/cat_facts/cli/src/main.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<()> {
                             uuid,
                             Outcome::Http(HttpResponse {
                                 status: 200,
-                                body: bytes,
+                                body: Some(bytes),
                             }),
                         ));
                     }

--- a/examples/cat_facts/cli/src/main.rs
+++ b/examples/cat_facts/cli/src/main.rs
@@ -6,7 +6,7 @@ use async_std::{
 use chrono::{DateTime, Utc};
 use clap::Parser;
 use shared::{
-    http::{HttpError, HttpRequest, HttpResponse},
+    http::{HttpError, HttpRequest, HttpResponse, HttpResult},
     key_value::{KeyValueOperation, KeyValueOutput},
     platform::PlatformResponse,
     time::TimeResponse,
@@ -34,7 +34,7 @@ enum Command {
 pub enum Outcome {
     Platform(PlatformResponse),
     Time(TimeResponse),
-    Http(Result<HttpResponse, HttpError>),
+    Http(HttpResult),
     KeyValue(KeyValueOutput),
 }
 
@@ -155,7 +155,7 @@ async fn read_state(_key: &str) -> Result<Vec<u8>> {
     Ok(buf)
 }
 
-async fn http(method: Method, url: &Url) -> Result<HttpResponse, HttpError> {
+async fn http(method: Method, url: &Url) -> HttpResult {
     let error = |error| HttpError {
         method: method.to_string(),
         url: url.to_string(),

--- a/examples/cat_facts/shared/Cargo.toml
+++ b/examples/cat_facts/shared/Cargo.toml
@@ -1,11 +1,7 @@
 [package]
 name = "shared"
 version = "0.1.0"
-authors.workspace = true
-repository.workspace = true
-edition.workspace = true
-license.workspace = true
-keywords.workspace = true
+edition = "2021"
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 pub use crux_core::App;
 use crux_core::{render::Render, Capability};
-use crux_http::{Http, HttpError, HttpResponse};
+use crux_http::{Http, HttpResponse, HttpResult};
 use crux_kv::{KeyValue, KeyValueOutput};
 use crux_macros::Effect;
 use crux_platform::Platform;
@@ -67,8 +67,8 @@ pub enum Event {
     Fetch,
     Restore,                  // restore state
     SetState(KeyValueOutput), // receive the data to restore state with
-    SetFact(Result<HttpResponse, HttpError>),
-    SetImage(Result<HttpResponse, HttpError>),
+    SetFact(HttpResult),
+    SetImage(HttpResult),
     CurrentTime(TimeResponse),
 }
 
@@ -255,7 +255,7 @@ mod tests {
 
         let body = Some(serde_json::to_vec(&a_fact).unwrap());
 
-        let update = update.effects[0].resolve(&Ok::<_, HttpError>(HttpResponse {
+        let update = update.effects[0].resolve(&HttpResult::Ok(HttpResponse {
             status: 200,
             body: body.clone(),
         }));

--- a/examples/cat_facts/shared_types/build.rs
+++ b/examples/cat_facts/shared_types/build.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use crux_core::{typegen::TypeGen, Request};
-use crux_http::{HttpRequest, HttpResponse};
+use crux_http::{HttpError, HttpRequest, HttpResponse};
 use crux_kv::{KeyValueOperation, KeyValueOutput};
 use crux_platform::PlatformResponse;
 use crux_time::TimeResponse;
@@ -33,12 +33,16 @@ fn register_types(gen: &mut TypeGen) -> Result<()> {
     gen.register_type::<Request<Effect>>()?;
 
     gen.register_type::<Effect>()?;
-    gen.register_type::<HttpRequest>()?;
-    gen.register_type::<KeyValueOperation>()?;
-
     gen.register_type::<Event>()?;
+
+    gen.register_type::<HttpRequest>()?;
     gen.register_type::<HttpResponse>()?;
+    gen.register_type::<HttpError>()?;
+    gen.register_type::<Result<HttpResponse, HttpError>>()?;
+
+    gen.register_type::<KeyValueOperation>()?;
     gen.register_type::<KeyValueOutput>()?;
+
     gen.register_type::<TimeResponse>()?;
 
     gen.register_type::<PlatformEvent>()?;

--- a/examples/cat_facts/shared_types/build.rs
+++ b/examples/cat_facts/shared_types/build.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use crux_core::{typegen::TypeGen, Request};
-use crux_http::{HttpError, HttpRequest, HttpResponse};
+use crux_http::{HttpError, HttpRequest, HttpResponse, HttpResult};
 use crux_kv::{KeyValueOperation, KeyValueOutput};
 use crux_platform::PlatformResponse;
 use crux_time::TimeResponse;
@@ -38,7 +38,7 @@ fn register_types(gen: &mut TypeGen) -> Result<()> {
     gen.register_type::<HttpRequest>()?;
     gen.register_type::<HttpResponse>()?;
     gen.register_type::<HttpError>()?;
-    gen.register_type::<Result<HttpResponse, HttpError>>()?;
+    gen.register_type::<HttpResult>()?;
 
     gen.register_type::<KeyValueOperation>()?;
     gen.register_type::<KeyValueOutput>()?;

--- a/examples/cat_facts/web-nextjs/pages/index.tsx
+++ b/examples/cat_facts/web-nextjs/pages/index.tsx
@@ -12,8 +12,6 @@ import * as types from "shared_types/types/shared_types";
 import * as bcs from "shared_types/bcs/mod";
 import { Optional } from "shared_types/serde/mod";
 
-type Action = Message | Response;
-
 interface Message {
   kind: "message";
   message: types.Event;
@@ -25,7 +23,7 @@ interface Response {
   outcome:
     | types.PlatformResponse
     | types.TimeResponse
-    | types.HttpResponse
+    | types.Result
     | types.KeyValueOutput;
 }
 
@@ -123,7 +121,9 @@ const Home: NextPage = () => {
           respond({
             kind: "response",
             uuid: request.uuid,
-            outcome: new types.HttpResponse(resp.status, response_bytes),
+            outcome: new types.ResultVariantOk(
+              new types.HttpResponse(resp.status, response_bytes)
+            ),
           });
           break;
         default:

--- a/examples/cat_facts/web-yew/src/main.rs
+++ b/examples/cat_facts/web-yew/src/main.rs
@@ -6,7 +6,7 @@ use woothee::parser::Parser;
 use yew::prelude::*;
 
 use shared::{
-    http::{HttpError, HttpRequest, HttpResponse},
+    http::{HttpError, HttpRequest, HttpResponse, HttpResult},
     key_value::{KeyValueOperation, KeyValueOutput},
     platform::PlatformResponse,
     time::TimeResponse,
@@ -44,7 +44,7 @@ enum CoreMessage {
 pub enum Outcome {
     Platform(PlatformResponse),
     Time(TimeResponse),
-    Http(Result<HttpResponse, HttpError>),
+    Http(HttpResult),
     KeyValue(KeyValueOutput),
 }
 
@@ -174,7 +174,7 @@ fn main() {
     yew::Renderer::<HelloWorld>::new().render();
 }
 
-async fn http(method: http::Method, url: &str) -> Result<HttpResponse, HttpError> {
+async fn http(method: http::Method, url: &str) -> HttpResult {
     let error = |error| HttpError {
         method: method.to_string(),
         url: url.to_string(),

--- a/examples/cat_facts/web-yew/src/main.rs
+++ b/examples/cat_facts/web-yew/src/main.rs
@@ -110,7 +110,7 @@ impl Component for HelloWorld {
                             uuid,
                             Outcome::Http(HttpResponse {
                                 status: 200,
-                                body: bytes,
+                                body: Some(bytes),
                             }),
                         ));
                     });

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -546,10 +546,10 @@ dependencies = [
 name = "cli"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-std",
  "bcs",
  "clap 4.0.32",
- "eyre",
  "serde",
  "shared",
  "surf",
@@ -683,6 +683,7 @@ dependencies = [
  "derive_more",
  "serde",
  "serde_json",
+ "thiserror",
  "url",
 ]
 
@@ -948,16 +949,6 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "eyre"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
-dependencies = [
- "indenter",
- "once_cell",
-]
 
 [[package]]
 name = "fastrand"
@@ -1602,12 +1593,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"

--- a/examples/counter/cli/Cargo.toml
+++ b/examples/counter/cli/Cargo.toml
@@ -9,7 +9,7 @@ keywords.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-eyre = "0.6.8"
+anyhow.workspace = true
 async-std = { version = "1.12.0", features = ["std", "attributes"] }
 bcs = "0.1.4"
 clap = { version = "4.0.32", features = ["derive"] }

--- a/examples/counter/cli/src/main.rs
+++ b/examples/counter/cli/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use shared::{
-    http::{HttpError, HttpRequest, HttpResponse},
+    http::{HttpError, HttpRequest, HttpResponse, HttpResult},
     Effect, Event, Request, ViewModel,
 };
 use std::{collections::VecDeque, str::FromStr, time::Duration};
@@ -30,7 +30,7 @@ impl From<Command> for CoreMessage {
 }
 
 pub enum Outcome {
-    Http(Result<HttpResponse, HttpError>),
+    Http(HttpResult),
 }
 
 #[derive(Parser)]
@@ -82,7 +82,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn http(method: Method, url: &Url) -> Result<HttpResponse, HttpError> {
+async fn http(method: Method, url: &Url) -> HttpResult {
     let error = |error| HttpError {
         method: method.to_string(),
         url: url.to_string(),

--- a/examples/counter/shared/Cargo.toml
+++ b/examples/counter/shared/Cargo.toml
@@ -1,11 +1,7 @@
 [package]
 name = "shared"
 version = "0.1.0"
-authors.workspace = true
-repository.workspace = true
-edition.workspace = true
-license.workspace = true
-keywords.workspace = true
+edition = "2021"
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]

--- a/examples/counter/shared/src/app/mod.rs
+++ b/examples/counter/shared/src/app/mod.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, NaiveDateTime, Utc};
 use crux_core::render::Render;
-use crux_http::{Http, HttpError, HttpResponse};
+use crux_http::{Http, HttpError, HttpResponse, HttpResult};
 use crux_macros::Effect;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -98,7 +98,7 @@ impl From<&Model> for ViewModel {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum Event {
     Get,
-    Set(Result<HttpResponse, HttpError>),
+    Set(HttpResult),
     Increment,
     Decrement,
 }
@@ -110,7 +110,7 @@ pub struct Capabilities {
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq)]
-pub struct Counter {
+struct Counter {
     value: i32,
     updated_at: i64,
 }
@@ -118,9 +118,9 @@ pub struct Counter {
 #[cfg(test)]
 mod tests {
     use super::{App, Event, Model};
-    use crate::{Counter, Effect};
+    use crate::{app::Counter, Effect};
     use crux_core::{render::RenderOperation, testing::AppTester};
-    use crux_http::{HttpError, HttpRequest, HttpResponse};
+    use crux_http::{HttpRequest, HttpResponse, HttpResult};
 
     #[test]
     fn get_counter() {
@@ -143,7 +143,7 @@ mod tests {
             })
             .unwrap(),
         );
-        let update = update.effects[0].resolve(&Ok::<_, HttpError>(HttpResponse {
+        let update = update.effects[0].resolve(&HttpResult::Ok(HttpResponse {
             status: 200,
             body: body.clone(),
         }));
@@ -210,7 +210,7 @@ mod tests {
         });
         assert_eq!(actual, expected);
 
-        let update = update.effects[1].resolve(&Ok::<_, HttpError>(HttpResponse {
+        let update = update.effects[1].resolve(&HttpResult::Ok(HttpResponse {
             status: 200,
             body: Some(
                 serde_json::to_vec(&Counter {
@@ -260,7 +260,7 @@ mod tests {
         });
         assert_eq!(actual, expected);
 
-        let update = update.effects[1].resolve(&Ok::<_, HttpError>(HttpResponse {
+        let update = update.effects[1].resolve(&HttpResult::Ok(HttpResponse {
             status: 200,
             body: Some(
                 serde_json::to_vec(&Counter {

--- a/examples/counter/shared_types/build.rs
+++ b/examples/counter/shared_types/build.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use crux_core::{typegen::TypeGen, Request};
-use crux_http::{HttpError, HttpRequest, HttpResponse};
+use crux_http::{HttpError, HttpRequest, HttpResponse, HttpResult};
 use shared::{Effect, Event, ViewModel};
 use std::path::PathBuf;
 
@@ -32,7 +32,7 @@ fn register_types(gen: &mut TypeGen) -> Result<()> {
     gen.register_type::<HttpRequest>()?;
     gen.register_type::<HttpResponse>()?;
     gen.register_type::<HttpError>()?;
-    gen.register_type::<Result<HttpResponse, HttpError>>()?;
+    gen.register_type::<HttpResult>()?;
 
     gen.register_type::<ViewModel>()?;
     Ok(())

--- a/examples/counter/shared_types/build.rs
+++ b/examples/counter/shared_types/build.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use crux_core::{typegen::TypeGen, Request};
-use crux_http::{HttpRequest, HttpResponse};
+use crux_http::{HttpError, HttpRequest, HttpResponse};
 use shared::{Effect, Event, ViewModel};
 use std::path::PathBuf;
 
@@ -27,10 +27,12 @@ fn register_types(gen: &mut TypeGen) -> Result<()> {
     gen.register_type::<Request<Effect>>()?;
 
     gen.register_type::<Effect>()?;
-    gen.register_type::<HttpRequest>()?;
-
     gen.register_type::<Event>()?;
+
+    gen.register_type::<HttpRequest>()?;
     gen.register_type::<HttpResponse>()?;
+    gen.register_type::<HttpError>()?;
+    gen.register_type::<Result<HttpResponse, HttpError>>()?;
 
     gen.register_type::<ViewModel>()?;
     Ok(())

--- a/examples/counter/web-nextjs/pages/index.tsx
+++ b/examples/counter/web-nextjs/pages/index.tsx
@@ -18,7 +18,7 @@ interface Message {
 interface Response {
   kind: "response";
   uuid: number[];
-  outcome: types.HttpResponse;
+  outcome: types.Result;
 }
 
 type State = {
@@ -90,7 +90,9 @@ const Home: NextPage = () => {
           respond({
             kind: "response",
             uuid,
-            outcome: new types.HttpResponse(res.status, response_bytes),
+            outcome: new types.ResultVariantOk(
+              new types.HttpResponse(res.status, response_bytes)
+            ),
           });
           break;
         default:

--- a/examples/counter/web-yew/src/main.rs
+++ b/examples/counter/web-yew/src/main.rs
@@ -1,9 +1,8 @@
-use anyhow::Result;
 use gloo_net::http;
 use yew::prelude::*;
 
 use shared::{
-    http::{HttpError, HttpRequest, HttpResponse},
+    http::{HttpError, HttpRequest, HttpResponse, HttpResult},
     Effect, Event, Request, ViewModel,
 };
 
@@ -16,7 +15,7 @@ enum CoreMessage {
 }
 
 pub enum Outcome {
-    Http(Result<HttpResponse, HttpError>),
+    Http(HttpResult),
 }
 
 impl Component for RootComponent {
@@ -105,7 +104,7 @@ fn main() {
     yew::Renderer::<RootComponent>::new().render();
 }
 
-async fn http(method: http::Method, url: &str) -> Result<HttpResponse, HttpError> {
+async fn http(method: http::Method, url: &str) -> HttpResult {
     let error = |error| HttpError {
         method: method.to_string(),
         url: url.to_string(),


### PR DESCRIPTION
Experimenting with what it could look like to thread Result types through the core (e.g. for Http Capability)

Notes:
- Had to temporarily remove the deserialisation in the capability (e.g. `getJson()`), but might be able to add it back later
- Thought that aliasing `Result<HttpResponse, HttpError>` to `HttpResult` might flow through into the type generation to avoid name clashes, but it appears not to. We might need to find another solution to this (e.g. multiple output files, also see https://github.com/zefchain/serde-reflection/issues/22#issuecomment-1368202043)
- the `wasmpack` plugin for `nextjs` doesn't support the cargo workspace hoisting of package fields, so had to remove this for the `shared` libs (although it seems the dependency hoisting is OK).