### PR TITLE
Fix path support in crux_derive::Effect.

### DIFF
--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -100,8 +100,8 @@ pub(crate) fn effect_impl(input: &DeriveInput) -> TokenStream {
 fn split_event_type(ty: &Type) -> (Ident, Type) {
     match ty {
         Type::Path(p) if p.qself.is_none() => {
-            // Get the first segment of the path (there should be only one)
-            let path_segment = p.path.segments.first().unwrap();
+            // Get the last segment of the path where the generic parameter should be
+            let path_segment = p.path.segments.last().unwrap();
             let t1 = &path_segment.ident;
             let type_params = &path_segment.arguments;
 
@@ -166,7 +166,7 @@ mod tests {
             #[derive(Effect)]
             #[effect(name = "MyEffect", app = "MyApp")]
             pub struct MyCapabilities {
-                pub http: Http<MyEvent>,
+                pub http: crux_http::Http<MyEvent>,
                 pub key_value: KeyValue<MyEvent>,
                 pub platform: Platform<MyEvent>,
                 pub render: Render<MyEvent>,


### PR DESCRIPTION
`split_event_type` was always looking for generic arguments in the first section of paths.  This isn't correct and meant if you provided a capability like `crux_http::Http<Event>` it'd look for generic arguments in `crux_http`, fail to find them and then complain that "all fields should be generic over the same event type"