### PR TITLE
Allow capabilities to stream data from the shell.

### DIFF
--- a/crux_core/src/capability.rs
+++ b/crux_core/src/capability.rs
@@ -316,7 +316,7 @@ where
         // it's important that it is.  It forces all capabilities to
         // spawn onto the executor which keeps the ordering of effects
         // consistent with their function calls.
-        self.inner.steps.send(Step::once(operation));
+        self.inner.steps.send(Step::resolves_never(operation));
     }
 
     /// Send an event to the app. The event will be processed a the next

--- a/crux_core/src/channels.rs
+++ b/crux_core/src/channels.rs
@@ -20,6 +20,10 @@ pub struct Receiver<T> {
 }
 
 impl<T> Receiver<T> {
+    /// Receives a message if any are waiting.
+    ///
+    /// Panics if the receiver has disconnected, so shouldn't be used if
+    /// that's possible.
     pub fn receive(&self) -> Option<T> {
         match self.inner.try_recv() {
             Ok(inner) => Some(inner),
@@ -30,6 +34,19 @@ impl<T> Receiver<T> {
                 // fix that if we get complaints
                 panic!("Receiver was disconnected.")
             }
+        }
+    }
+
+    /// Receives a message if any are waiting.
+    /// Returns the error branch if the sender has disconnected.
+    ///
+    /// This API isn't that nice, but isn't intended for public consumption
+    /// so whatevs.
+    pub fn try_receive(&self) -> Result<Option<T>, ()> {
+        match self.inner.try_recv() {
+            Ok(inner) => Ok(Some(inner)),
+            Err(crossbeam_channel::TryRecvError::Empty) => Ok(None),
+            Err(crossbeam_channel::TryRecvError::Disconnected) => Err(()),
         }
     }
 

--- a/crux_core/src/future.rs
+++ b/crux_core/src/future.rs
@@ -68,7 +68,7 @@ where
 
         let step = Step::resolves_once(operation, move |bytes| {
             let Some(shared_state) = callback_shared_state.upgrade() else {
-                // The EffectFuture was dropped before we were called, so just
+                // The ShellRequest was dropped before we were called, so just
                 // do nothing.
                 return;
             };

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -151,6 +151,7 @@ mod executor;
 mod future;
 pub mod render;
 mod steps;
+mod stream;
 pub mod testing;
 #[cfg(feature = "typegen")]
 pub mod typegen;
@@ -164,7 +165,10 @@ use channels::Receiver;
 use executor::QueuingExecutor;
 use steps::{Step, StepRegistry};
 
-pub use capability::{Capability, WithContext};
+pub use self::{
+    capability::{Capability, WithContext},
+    future::ShellRequest,
+};
 
 /// Implement [App] on your type to make it into a Crux app. Use your type implementing [App]
 /// as the type argument to [Core].

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -168,6 +168,7 @@ use steps::{Step, StepRegistry};
 pub use self::{
     capability::{Capability, WithContext},
     future::ShellRequest,
+    stream::ShellStream,
 };
 
 /// Implement [App] on your type to make it into a Crux app. Use your type implementing [App]


### PR DESCRIPTION
This PR contains a first pass of the shell->core streaming mechanism for capabilities.  The API that's exposed is broadly similar to what we have now, except:

1. The capability calls `stream_from_shell` instead.
2. They get a `futures::Stream` instead of a `Future`

The shell side should be similar: they get a request with a UUID, and should send any responses to that UUID.

When the capability task ends it'll drop the underlying channel which should free up most of the core-side resources involved.  An entry will remain in the `StepRegistry`, which is not ideal but it shouldn't occupy much memory.  If another message comes in for this UUID it'll be cleaned out of the StepRegistry as well.

Stuff we'll probably need to do on top of this:

1. Actually use it somewhere, it's all theoretical right now.
2. Give the shell some way to tell if a task has ended, and maybe even end it themselves (although it's possible we can handle one or both of those with the individual capability protocols).