### PR TITLE
Add integration test exercising the capability async runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "crux_macros",
  "derive_more",
  "futures",
+ "rand 0.8.5",
  "serde",
  "serde-generate",
  "serde-reflection",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "async-channel",
  "bcs",
  "crossbeam-channel",
  "crux_macros",

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -34,6 +34,7 @@ crux_macros = { version = "0.1", path = "../crux_macros" }
 serde = { version = "1.0.152", features = ["derive"] }
 static_assertions = "1.1"
 async-channel = "1.8"
+rand = "0.8"
 
 [features]
 typegen = ["dep:serde-generate", "dep:serde-reflection"]

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -33,6 +33,7 @@ assert_matches = "1.5"
 crux_macros = { version = "0.1", path = "../crux_macros" }
 serde = { version = "1.0.152", features = ["derive"] }
 static_assertions = "1.1"
+async-channel = "1.8"
 
 [features]
 typegen = ["dep:serde-generate", "dep:serde-reflection"]

--- a/crux_core/tests/capability_runtime.rs
+++ b/crux_core/tests/capability_runtime.rs
@@ -1,0 +1,200 @@
+mod capability {
+    use async_channel::Sender;
+    use crux_core::{
+        capability::{CapabilityContext, Operation},
+        Capability,
+    };
+    use futures::StreamExt;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Fetch {
+        pub id: usize,
+    }
+
+    impl Operation for Fetch {
+        type Output = Vec<usize>; // links to other items
+    }
+
+    pub struct Crawler<Ev> {
+        context: CapabilityContext<Fetch, Ev>,
+        tasks_tx: Sender<(usize, Sender<usize>)>,
+    }
+
+    const NUM_WORKERS: usize = 3;
+
+    // A hypothetical asynchronous crawler, which fetches remote items
+    // and discovers links for further items in them. Imagine a web crawler.
+    // To avoid fetching too many items concurrently it has a worker pool
+    //
+    // We use this in the test to make sure the capability runtime supports
+    // this type of use-case correctly.
+    impl<Ev> Crawler<Ev>
+    where
+        Ev: 'static,
+    {
+        pub fn new(context: CapabilityContext<Fetch, Ev>) -> Self {
+            let (tasks_tx, tasks_rx) = async_channel::unbounded::<(usize, Sender<usize>)>();
+
+            for n in 0..NUM_WORKERS {
+                context.spawn({
+                    let context = context.clone();
+                    let tasks_rx = tasks_rx.clone();
+                    let tasks_tx = tasks_tx.clone();
+
+                    async move {
+                        while let Ok((id, results_tx)) = tasks_rx.recv().await {
+                            results_tx.send(id).await.unwrap();
+
+                            println!("Worker {n} fetching #{id}");
+                            let more_ids = context.request_from_shell(Fetch { id }).await;
+                            for id in more_ids {
+                                tasks_tx.send((id, results_tx.clone())).await.unwrap();
+                            }
+                        }
+                    }
+                });
+            }
+
+            Crawler { context, tasks_tx }
+        }
+
+        pub fn fetch_tree<F>(&self, id: usize, ev: F)
+        where
+            F: Fn(Vec<usize>) -> Ev + Send + 'static,
+        {
+            let (results_tx, results_rx) = async_channel::unbounded::<usize>();
+            let tasks_tx = self.tasks_tx.clone();
+
+            self.context.spawn({
+                let context = self.context.clone();
+
+                async move {
+                    tasks_tx.send((id, results_tx)).await.unwrap();
+
+                    let results: Vec<_> = results_rx.collect().await;
+
+                    context.update_app(ev(results));
+                }
+            });
+        }
+    }
+
+    impl<Ev> Capability<Ev> for Crawler<Ev> {
+        type Operation = Fetch;
+        type MappedSelf<MappedEv> = Crawler<MappedEv>;
+
+        fn map_event<F, NewEvent>(&self, f: F) -> Self::MappedSelf<NewEvent>
+        where
+            F: Fn(NewEvent) -> Ev + Send + Sync + Copy + 'static,
+            Ev: 'static,
+            NewEvent: 'static,
+        {
+            Self::MappedSelf::new(self.context.map_event(f))
+        }
+    }
+}
+
+mod app {
+    use crux_core::{render::Render, App};
+    use crux_macros::Effect;
+    use serde::{Deserialize, Serialize};
+
+    use super::capability::Crawler;
+
+    #[derive(Serialize, Deserialize)]
+    pub enum Event {
+        Fetch,
+        Done(Vec<usize>),
+    }
+
+    #[derive(Effect)]
+    #[effect(app = "MyApp")]
+    pub struct Capabilities {
+        crawler: super::capability::Crawler<Event>,
+        render: crux_core::render::Render<Event>,
+    }
+
+    #[derive(Default)]
+    pub struct MyApp;
+
+    impl App for MyApp {
+        type Event = Event;
+        type Model = Vec<usize>;
+        type ViewModel = Vec<usize>;
+        type Capabilities = Capabilities;
+
+        fn update(&self, event: Self::Event, model: &mut Self::Model, caps: &Self::Capabilities) {
+            match event {
+                Event::Fetch => caps.crawler.fetch_tree(0, Event::Done),
+                Event::Done(items) => {
+                    *model = items;
+                    caps.render.render();
+                }
+            }
+        }
+
+        fn view(&self, model: &Self::Model) -> Self::ViewModel {
+            model.clone()
+        }
+    }
+}
+
+mod tests {
+    use std::collections::VecDeque;
+
+    use crux_core::{Core, Request};
+
+    use super::app::{Capabilities, Effect, Event, MyApp};
+    use super::capability::Fetch;
+
+    #[test]
+    fn fetches_a_tree() {
+        let core: Core<Effect, MyApp> = Core::new::<Capabilities>();
+
+        let event_bytes = bcs::to_bytes(&Event::Fetch).unwrap();
+
+        let requests = core.message(&event_bytes);
+
+        let mut requests: VecDeque<Request<Effect>> = bcs::from_bytes::<Vec<_>>(&requests)
+            .unwrap()
+            .into_iter()
+            .collect();
+
+        let mut counter: usize = 1;
+
+        while !requests.is_empty() {
+            let Request { uuid, effect } = requests.pop_front().unwrap();
+
+            match effect {
+                Effect::Crawler(Fetch { id }) => {
+                    let output = if counter < 30 {
+                        vec![counter, counter + 1, counter + 2]
+                    } else {
+                        vec![]
+                    };
+
+                    counter += 3;
+
+                    let output = bcs::to_bytes(&output).unwrap();
+
+                    let reqs: Vec<Request<Effect>> =
+                        bcs::from_bytes(&core.response(&uuid, &output)).unwrap();
+                    for r in reqs {
+                        requests.push_back(r)
+                    }
+                }
+                Effect::Render(_) => {
+                    let view: Vec<usize> = bcs::from_bytes(&core.view()).unwrap();
+                    let expected: Vec<usize> = (0..=30).collect();
+
+                    assert_eq!(view, expected);
+
+                    return;
+                }
+            }
+        }
+
+        unreachable!("Capability never returned a result");
+    }
+}

--- a/crux_core/tests/capability_runtime.rs
+++ b/crux_core/tests/capability_runtime.rs
@@ -167,7 +167,7 @@ mod tests {
             let Request { uuid, effect } = requests.pop_front().unwrap();
 
             match effect {
-                Effect::Crawler(Fetch { id }) => {
+                Effect::Crawler(Fetch { id: _id }) => {
                     let output = if counter < 30 {
                         vec![counter, counter + 1, counter + 2]
                     } else {

--- a/crux_core/tests/capability_runtime.rs
+++ b/crux_core/tests/capability_runtime.rs
@@ -144,6 +144,7 @@ mod tests {
     use std::collections::VecDeque;
 
     use crux_core::{Core, Request};
+    use rand::prelude::*;
 
     use super::app::{Capabilities, Effect, Event, MyApp};
     use super::capability::Fetch;
@@ -180,9 +181,13 @@ mod tests {
 
                     let reqs: Vec<Request<Effect>> =
                         bcs::from_bytes(&core.response(&uuid, &output)).unwrap();
+
                     for r in reqs {
                         requests.push_back(r)
                     }
+
+                    // Simulate network timing
+                    requests.make_contiguous().shuffle(&mut rand::thread_rng());
                 }
                 Effect::Render(_) => {
                     let view: Vec<usize> = bcs::from_bytes(&core.view()).unwrap();


### PR DESCRIPTION
This is part useful, part exercise in understanding what's possible with the capability runtime.

The test creates a capability which implements a hypothetical tree crawler, which needs to fetch items over the network using the Shell. In order not to open too many connections, it does it on a worker pool.

This checks that more complex scenarios like this are possible, and also allows us to potentially mess with the runtime and understand whether we introduced subtle bugs.