### PR TITLE
Publish book in the root of github pages

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -33,7 +33,7 @@ jobs:
         run: mdbook build
 
       - name: Move outputs
-        run: mkdir ./public && mv ./target/doc ./public/ && mv ./docs/book ./public/
+        run: mkdir ./public && mv ./target/doc ./public/master_api_docs && mv ./docs/book/* ./public/
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Publish the book in the root of the GitHub pages and the API docs in a subfolder,
so that the landing page is not a 404
