### PR TITLE
Improve termination detection in the counter CLI

### DIFF
--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
  "clap 4.1.3",
  "crossbeam-channel",
  "eyre",
+ "futures",
  "serde",
  "shared",
  "surf",

--- a/examples/counter/cli/Cargo.toml
+++ b/examples/counter/cli/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 [dependencies]
 async-std = { version = "1.12.0", features = ["std", "attributes"] }
 async-task-group = "0.2.1"
+futures = "0.3"
 bcs = "0.1.4"
 clap = { version = "4.1.3", features = ["derive"] }
 crossbeam-channel = "0.5.6"

--- a/examples/counter/cli/src/main.rs
+++ b/examples/counter/cli/src/main.rs
@@ -1,14 +1,20 @@
 use async_std::io::ReadExt;
+use crossbeam_channel::Sender;
+use futures::{stream, TryStreamExt};
+
 use bcs::{from_bytes, to_bytes};
 use clap::Parser;
-use crossbeam_channel::Sender;
 use eyre::{bail, eyre, Result};
 use shared::{
     http::protocol::{HttpRequest, HttpResponse},
     sse::{SseRequest, SseResponse},
     Effect, Event, Request, ViewModel,
 };
-use std::{str::FromStr, time::Duration};
+use std::{
+    str::FromStr,
+    sync::{Arc, Weak},
+    time::Duration,
+};
 use surf::{http::Method, Client, Config, Url};
 
 enum CoreMessage {
@@ -47,71 +53,86 @@ struct Args {
     cmd: Command,
 }
 
-#[async_std::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     let (tx, rx) = crossbeam_channel::unbounded::<CoreMessage>();
 
-    let cmd = Args::parse().cmd;
+    let strong_tx = Arc::new(tx);
+    let tx = Arc::downgrade(&strong_tx);
 
-    let watching = matches!(cmd, Command::Watch);
-    if watching {
-        println!("^C to exit");
+    // Kick off with the given command
+
+    main_loop(Args::parse().cmd.into(), tx.clone())?;
+    drop(strong_tx); // tx may still live in a side-effect futures
+
+    // Continue until there's no more work to do
+    while let Ok(msg) = rx.recv() {
+        main_loop(msg, tx.clone())?;
     }
-
-    tx.send(cmd.into()).unwrap();
-
-    let handle = async_task_group::group(|group| async move {
-        'outer: while let Ok(msg) = rx.recv() {
-            let reqs = match msg {
-                CoreMessage::Event(m) => shared::process_event(&to_bytes(&m).unwrap()),
-                CoreMessage::Response(uuid, output) => shared::handle_response(
-                    &uuid,
-                    &match output {
-                        Outcome::Http(x) => to_bytes(&x).unwrap(),
-                        Outcome::Sse(x) => to_bytes(&x).unwrap(),
-                    },
-                ),
-            };
-            let reqs: Vec<Request<Effect>> = from_bytes(&reqs).unwrap();
-
-            for Request { uuid, effect } in reqs {
-                match effect {
-                    Effect::Render(_) => {
-                        let view = from_bytes::<ViewModel>(&shared::view())?;
-                        if !view.text.contains("pending") {
-                            println!("{}", view.text);
-                            if !watching {
-                                break 'outer;
-                            }
-                        }
-                    }
-                    Effect::Http(HttpRequest { method, url }) => {
-                        group.spawn({
-                            let method = Method::from_str(&method).expect("unknown http method");
-                            let url = Url::parse(&url).unwrap();
-
-                            http(uuid, method, url, tx.clone())
-                        });
-                    }
-                    Effect::ServerSentEvents(SseRequest { url }) => {
-                        group.spawn({
-                            let url = Url::parse(&url).unwrap();
-
-                            sse(uuid, url, tx.clone())
-                        });
-                    }
-                }
-            }
-        }
-        Ok(group)
-    });
-
-    handle.await.unwrap();
 
     Ok(())
 }
 
-async fn http(uuid: Vec<u8>, method: Method, url: Url, tx: Sender<CoreMessage>) -> Result<()> {
+fn main_loop(msg: CoreMessage, tx: Weak<Sender<CoreMessage>>) -> Result<(), eyre::ErrReport> {
+    let reqs = match msg {
+        CoreMessage::Event(m) => shared::process_event(&to_bytes(&m).unwrap()),
+        CoreMessage::Response(uuid, output) => shared::handle_response(
+            &uuid,
+            &match output {
+                Outcome::Http(x) => to_bytes(&x).unwrap(),
+                Outcome::Sse(x) => to_bytes(&x).unwrap(),
+            },
+        ),
+    };
+    let reqs: Vec<Request<Effect>> = from_bytes(&reqs).unwrap();
+
+    for Request { uuid, effect } in reqs {
+        match effect {
+            Effect::Render(_) => {
+                let text = from_bytes::<ViewModel>(&shared::view())?.text;
+
+                if !text.contains("pending") {
+                    println!("{}", text);
+                }
+            }
+            Effect::Http(HttpRequest { method, url }) => {
+                let method = Method::from_str(&method).expect("unknown http method");
+                let url = Url::parse(&url)?;
+
+                async_std::task::spawn({
+                    let tx = tx.upgrade().unwrap();
+                    async move {
+                        let response = http(method, url).await.unwrap();
+                        let outcome = Outcome::Http(response);
+                        let message = CoreMessage::Response(uuid.clone(), outcome);
+
+                        tx.send(message).unwrap();
+                    }
+                });
+            }
+            Effect::ServerSentEvents(SseRequest { url }) => {
+                let url = Url::parse(&url)?;
+
+                async_std::task::spawn({
+                    let tx = tx.upgrade().unwrap();
+                    async move {
+                        let mut stream = sse(url).await.unwrap();
+
+                        while let Ok(Some(item)) = stream.try_next().await {
+                            let outcome = Outcome::Sse(SseResponse::Chunk(item));
+                            let message = CoreMessage::Response(uuid.clone(), outcome);
+
+                            tx.send(message).unwrap();
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn http(method: Method, url: Url) -> Result<HttpResponse> {
     let client: Client = Config::new()
         .set_timeout(Some(Duration::from_secs(5)))
         .try_into()?;
@@ -125,20 +146,14 @@ async fn http(uuid: Vec<u8>, method: Method, url: Url, tx: Sender<CoreMessage>) 
 
     match status {
         200..=299 => match response.body_bytes().await {
-            Ok(body) => {
-                tx.send(CoreMessage::Response(
-                    uuid.to_vec(),
-                    Outcome::Http(HttpResponse { status, body }),
-                ))?;
-            }
+            Ok(body) => Ok(HttpResponse { status, body }),
             Err(e) => bail!("{method} {url}: error {e}"),
         },
         _ => bail!("{method} {url}: status {status}"),
-    };
-    Ok(())
+    }
 }
 
-async fn sse(uuid: Vec<u8>, url: Url, tx: Sender<CoreMessage>) -> Result<()> {
+async fn sse(url: Url) -> Result<impl futures::stream::TryStream<Ok = Vec<u8>>> {
     let mut response = surf::get(&url)
         .await
         .map_err(|e| eyre!("get {url}: error {e}"))?;
@@ -151,14 +166,15 @@ async fn sse(uuid: Vec<u8>, url: Url, tx: Sender<CoreMessage>) -> Result<()> {
         bail!("get {url}: status {status}");
     };
 
-    let mut body = body.into_reader();
-    let mut buf = [0; 1024];
-    loop {
-        let response = match body.read(&mut buf).await {
-            Ok(n) if n == 0 => SseResponse::Done,
-            Ok(n) => SseResponse::Chunk(buf[0..n].to_vec()),
+    let body = body.into_reader();
+
+    Ok(Box::pin(stream::try_unfold(body, |mut body| async {
+        let mut buf = [0; 1024];
+
+        match body.read(&mut buf).await {
+            Ok(n) if n == 0 => Ok(None),
+            Ok(n) => Ok(Some((buf[0..n].to_vec(), body))),
             Err(e) => bail!("failed to read from http response; err = {:?}", e),
-        };
-        tx.send(CoreMessage::Response(uuid.to_vec(), Outcome::Sse(response)))?;
-    }
+        }
+    })))
 }


### PR DESCRIPTION
I've attempted to improve the way the CLI detects whether the work is done or whether there are still some side-effects pending. This works, but I don't particularly love the solution. I'll have a go at a slitghtly different design in a separate PR, but I think this is good to go.

I also took any counter specific bits out of the implementation of the side-effects (http and sse), so they are theoretically reusable. `futures::stream::try_unfold` is pretty awesome.
