### PR TITLE
Adds callout blocks to docs

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -2,7 +2,7 @@ name: pages
 on:
   push:
     branches:
-      - master
+      - docs-callouts
 
 env:
   CARGO_INCREMENTAL: 0
@@ -21,9 +21,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.66.0
 
       - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1
+        uses: jontze/action-mdbook@v2
         with:
-          mdbook-version: "latest"
+          use-admonish: true
 
       - name: Build Documentation
         run: cargo doc --all --no-deps

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -2,7 +2,7 @@ name: pages
 on:
   push:
     branches:
-      - docs-callouts
+      - master
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Setup mdBook
         uses: jontze/action-mdbook@v2
         with:
+          token: ${{secrets.GITHUB_TOKEN}}
           use-admonish: true
 
       - name: Build Documentation

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,3 +4,14 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Crux: Cross-platform app development in Rust"
+
+[preprocessor.emoji]
+
+[preprocessor.admonish]
+command = "mdbook-admonish"
+assets_version = "2.0.0" # do not edit: managed by `mdbook-admonish install`
+
+[output]
+
+[output.html]
+additional-css = ["././mdbook-admonish.css"]

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -5,8 +5,6 @@ multilingual = false
 src = "src"
 title = "Crux: Cross-platform app development in Rust"
 
-[preprocessor.emoji]
-
 [preprocessor.admonish]
 command = "mdbook-admonish"
 assets_version = "2.0.0" # do not edit: managed by `mdbook-admonish install`

--- a/docs/mdbook-admonish.css
+++ b/docs/mdbook-admonish.css
@@ -1,0 +1,352 @@
+@charset "UTF-8";
+:root {
+  --md-admonition-icon--note:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83 3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25z'/></svg>");
+  --md-admonition-icon--abstract:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M17 9H7V7h10m0 6H7v-2h10m-3 6H7v-2h7M12 3a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1m7 0h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z'/></svg>");
+  --md-admonition-icon--info:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z'/></svg>");
+  --md-admonition-icon--tip:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M17.66 11.2c-.23-.3-.51-.56-.77-.82-.67-.6-1.43-1.03-2.07-1.66C13.33 7.26 13 4.85 13.95 3c-.95.23-1.78.75-2.49 1.32-2.59 2.08-3.61 5.75-2.39 8.9.04.1.08.2.08.33 0 .22-.15.42-.35.5-.23.1-.47.04-.66-.12a.58.58 0 0 1-.14-.17c-1.13-1.43-1.31-3.48-.55-5.12C5.78 10 4.87 12.3 5 14.47c.06.5.12 1 .29 1.5.14.6.41 1.2.71 1.73 1.08 1.73 2.95 2.97 4.96 3.22 2.14.27 4.43-.12 6.07-1.6 1.83-1.66 2.47-4.32 1.53-6.6l-.13-.26c-.21-.46-.77-1.26-.77-1.26m-3.16 6.3c-.28.24-.74.5-1.1.6-1.12.4-2.24-.16-2.9-.82 1.19-.28 1.9-1.16 2.11-2.05.17-.8-.15-1.46-.28-2.23-.12-.74-.1-1.37.17-2.06.19.38.39.76.63 1.06.77 1 1.98 1.44 2.24 2.8.04.14.06.28.06.43.03.82-.33 1.72-.93 2.27z'/></svg>");
+  --md-admonition-icon--success:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='m9 20.42-6.21-6.21 2.83-2.83L9 14.77l9.88-9.89 2.83 2.83L9 20.42z'/></svg>");
+  --md-admonition-icon--question:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='m15.07 11.25-.9.92C13.45 12.89 13 13.5 13 15h-2v-.5c0-1.11.45-2.11 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41a2 2 0 0 0-2-2 2 2 0 0 0-2 2H8a4 4 0 0 1 4-4 4 4 0 0 1 4 4 3.2 3.2 0 0 1-.93 2.25M13 19h-2v-2h2M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10c0-5.53-4.5-10-10-10z'/></svg>");
+  --md-admonition-icon--warning:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 14h-2V9h2m0 9h-2v-2h2M1 21h22L12 2 1 21z'/></svg>");
+  --md-admonition-icon--failure:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20 6.91 17.09 4 12 9.09 6.91 4 4 6.91 9.09 12 4 17.09 6.91 20 12 14.91 17.09 20 20 17.09 14.91 12 20 6.91z'/></svg>");
+  --md-admonition-icon--danger:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M11 15H6l7-14v8h5l-7 14v-8z'/></svg>");
+  --md-admonition-icon--bug:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 12h-4v-2h4m0 6h-4v-2h4m6-6h-2.81a5.985 5.985 0 0 0-1.82-1.96L17 4.41 15.59 3l-2.17 2.17a6.002 6.002 0 0 0-2.83 0L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8z'/></svg>");
+  --md-admonition-icon--example:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M7 13v-2h14v2H7m0 6v-2h14v2H7M7 7V5h14v2H7M3 8V5H2V4h2v4H3m-1 9v-1h3v4H2v-1h2v-.5H3v-1h1V17H2m2.25-7a.75.75 0 0 1 .75.75c0 .2-.08.39-.21.52L3.12 13H5v1H2v-.92L4 11H2v-1h2.25z'/></svg>");
+  --md-admonition-icon--quote:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 17h3l2-4V7h-6v6h3M6 17h3l2-4V7H5v6h3l-2 4z'/></svg>");
+  --md-details-icon:
+    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42Z'/></svg>");
+}
+
+:is(.admonition) {
+  display: flow-root;
+  margin: 1.5625em 0;
+  padding: 0 1.2rem;
+  color: var(--fg);
+  page-break-inside: avoid;
+  background-color: var(--bg);
+  border: 0 solid black;
+  border-inline-start-width: 0.4rem;
+  border-radius: 0.2rem;
+  box-shadow: 0 0.2rem 1rem rgba(0, 0, 0, 0.05), 0 0 0.1rem rgba(0, 0, 0, 0.1);
+}
+@media print {
+  :is(.admonition) {
+    box-shadow: none;
+  }
+}
+:is(.admonition) > * {
+  box-sizing: border-box;
+}
+:is(.admonition) :is(.admonition) {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+:is(.admonition) > .tabbed-set:only-child {
+  margin-top: 0;
+}
+html :is(.admonition) > :last-child {
+  margin-bottom: 1.2rem;
+}
+
+a.admonition-anchor-link {
+  display: none;
+  position: absolute;
+  left: -1.2rem;
+  padding-right: 1rem;
+}
+a.admonition-anchor-link:link, a.admonition-anchor-link:visited {
+  color: var(--fg);
+}
+a.admonition-anchor-link:link:hover, a.admonition-anchor-link:visited:hover {
+  text-decoration: none;
+}
+a.admonition-anchor-link::before {
+  content: "§";
+}
+
+:is(.admonition-title, summary) {
+  position: relative;
+  margin-block: 0;
+  margin-inline: -1.6rem -1.2rem;
+  padding-block: 0.8rem;
+  padding-inline: 4.4rem 1.2rem;
+  font-weight: 700;
+  background-color: rgba(68, 138, 255, 0.1);
+  display: flex;
+}
+:is(.admonition-title, summary) p {
+  margin: 0;
+}
+html :is(.admonition-title, summary):last-child {
+  margin-bottom: 0;
+}
+:is(.admonition-title, summary)::before {
+  position: absolute;
+  top: 0.625em;
+  inset-inline-start: 1.6rem;
+  width: 2rem;
+  height: 2rem;
+  background-color: #448aff;
+  mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></svg>');
+  -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></svg>');
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  content: "";
+}
+:is(.admonition-title, summary):hover a.admonition-anchor-link {
+  display: initial;
+}
+
+details.admonition > summary.admonition-title::after {
+  position: absolute;
+  top: 0.625em;
+  inset-inline-end: 1.6rem;
+  height: 2rem;
+  width: 2rem;
+  background-color: currentcolor;
+  mask-image: var(--md-details-icon);
+  -webkit-mask-image: var(--md-details-icon);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  content: "";
+  transform: rotate(0deg);
+  transition: transform 0.25s;
+}
+details[open].admonition > summary.admonition-title::after {
+  transform: rotate(90deg);
+}
+
+:is(.admonition):is(.note) {
+  border-color: #448aff;
+}
+
+:is(.note) > :is(.admonition-title, summary) {
+  background-color: rgba(68, 138, 255, 0.1);
+}
+:is(.note) > :is(.admonition-title, summary)::before {
+  background-color: #448aff;
+  mask-image: var(--md-admonition-icon--note);
+  -webkit-mask-image: var(--md-admonition-icon--note);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.abstract, .summary, .tldr) {
+  border-color: #00b0ff;
+}
+
+:is(.abstract, .summary, .tldr) > :is(.admonition-title, summary) {
+  background-color: rgba(0, 176, 255, 0.1);
+}
+:is(.abstract, .summary, .tldr) > :is(.admonition-title, summary)::before {
+  background-color: #00b0ff;
+  mask-image: var(--md-admonition-icon--abstract);
+  -webkit-mask-image: var(--md-admonition-icon--abstract);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.info, .todo) {
+  border-color: #00b8d4;
+}
+
+:is(.info, .todo) > :is(.admonition-title, summary) {
+  background-color: rgba(0, 184, 212, 0.1);
+}
+:is(.info, .todo) > :is(.admonition-title, summary)::before {
+  background-color: #00b8d4;
+  mask-image: var(--md-admonition-icon--info);
+  -webkit-mask-image: var(--md-admonition-icon--info);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.tip, .hint, .important) {
+  border-color: #00bfa5;
+}
+
+:is(.tip, .hint, .important) > :is(.admonition-title, summary) {
+  background-color: rgba(0, 191, 165, 0.1);
+}
+:is(.tip, .hint, .important) > :is(.admonition-title, summary)::before {
+  background-color: #00bfa5;
+  mask-image: var(--md-admonition-icon--tip);
+  -webkit-mask-image: var(--md-admonition-icon--tip);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.success, .check, .done) {
+  border-color: #00c853;
+}
+
+:is(.success, .check, .done) > :is(.admonition-title, summary) {
+  background-color: rgba(0, 200, 83, 0.1);
+}
+:is(.success, .check, .done) > :is(.admonition-title, summary)::before {
+  background-color: #00c853;
+  mask-image: var(--md-admonition-icon--success);
+  -webkit-mask-image: var(--md-admonition-icon--success);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.question, .help, .faq) {
+  border-color: #64dd17;
+}
+
+:is(.question, .help, .faq) > :is(.admonition-title, summary) {
+  background-color: rgba(100, 221, 23, 0.1);
+}
+:is(.question, .help, .faq) > :is(.admonition-title, summary)::before {
+  background-color: #64dd17;
+  mask-image: var(--md-admonition-icon--question);
+  -webkit-mask-image: var(--md-admonition-icon--question);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.warning, .caution, .attention) {
+  border-color: #ff9100;
+}
+
+:is(.warning, .caution, .attention) > :is(.admonition-title, summary) {
+  background-color: rgba(255, 145, 0, 0.1);
+}
+:is(.warning, .caution, .attention) > :is(.admonition-title, summary)::before {
+  background-color: #ff9100;
+  mask-image: var(--md-admonition-icon--warning);
+  -webkit-mask-image: var(--md-admonition-icon--warning);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.failure, .fail, .missing) {
+  border-color: #ff5252;
+}
+
+:is(.failure, .fail, .missing) > :is(.admonition-title, summary) {
+  background-color: rgba(255, 82, 82, 0.1);
+}
+:is(.failure, .fail, .missing) > :is(.admonition-title, summary)::before {
+  background-color: #ff5252;
+  mask-image: var(--md-admonition-icon--failure);
+  -webkit-mask-image: var(--md-admonition-icon--failure);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.danger, .error) {
+  border-color: #ff1744;
+}
+
+:is(.danger, .error) > :is(.admonition-title, summary) {
+  background-color: rgba(255, 23, 68, 0.1);
+}
+:is(.danger, .error) > :is(.admonition-title, summary)::before {
+  background-color: #ff1744;
+  mask-image: var(--md-admonition-icon--danger);
+  -webkit-mask-image: var(--md-admonition-icon--danger);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.bug) {
+  border-color: #f50057;
+}
+
+:is(.bug) > :is(.admonition-title, summary) {
+  background-color: rgba(245, 0, 87, 0.1);
+}
+:is(.bug) > :is(.admonition-title, summary)::before {
+  background-color: #f50057;
+  mask-image: var(--md-admonition-icon--bug);
+  -webkit-mask-image: var(--md-admonition-icon--bug);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.example) {
+  border-color: #7c4dff;
+}
+
+:is(.example) > :is(.admonition-title, summary) {
+  background-color: rgba(124, 77, 255, 0.1);
+}
+:is(.example) > :is(.admonition-title, summary)::before {
+  background-color: #7c4dff;
+  mask-image: var(--md-admonition-icon--example);
+  -webkit-mask-image: var(--md-admonition-icon--example);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+:is(.admonition):is(.quote, .cite) {
+  border-color: #9e9e9e;
+}
+
+:is(.quote, .cite) > :is(.admonition-title, summary) {
+  background-color: rgba(158, 158, 158, 0.1);
+}
+:is(.quote, .cite) > :is(.admonition-title, summary)::before {
+  background-color: #9e9e9e;
+  mask-image: var(--md-admonition-icon--quote);
+  -webkit-mask-image: var(--md-admonition-icon--quote);
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-repeat: no-repeat;
+}
+
+.navy :is(.admonition) {
+  background-color: var(--sidebar-bg);
+}
+
+.ayu :is(.admonition), .coal :is(.admonition) {
+  background-color: var(--theme-hover);
+}
+
+.rust :is(.admonition) {
+  background-color: var(--sidebar-bg);
+  color: var(--sidebar-fg);
+}
+.rust .admonition-anchor-link:link, .rust .admonition-anchor-link:visited {
+  color: var(--sidebar-fg);
+}

--- a/docs/src/getting_started/android.md
+++ b/docs/src/getting_started/android.md
@@ -2,7 +2,13 @@
 
 These are the steps to set up Android Studio to build and run a simple Android app that calls into a shared core.
 
-> 🚨 _SHARP EDGE WARNING_: We want to make setting up Android Studio to work with Crux really easy. As time progresses we will try to simplify and automate as much as possible, but at the moment there is some manual configuration to do. This only needs doing once, so we hope it's not too much trouble. If you know of any better ways than those we describe below, please either raise an issue (or a PR) at <https://github.com/redbadger/crux>.
+```admonish
+This walk-through assumes you have already added the `shared` and `shared_types` libraries to your repo, as described in [Shared core and types](./core.md).
+```
+
+```admonish warning title="Sharp edge"
+We want to make setting up Android Studio to work with Crux really easy. As time progresses we will try to simplify and automate as much as possible, but at the moment there is some manual configuration to do. This only needs doing once, so we hope it's not too much trouble. If you know of any better ways than those we describe below, please either raise an issue (or a PR) at <https://github.com/redbadger/crux>.
+```
 
 ## Create an Android App
 
@@ -58,7 +64,9 @@ For more information on how to add an Android library see <https://developer.and
 
 We can now add this library as a _dependency_ of our app.
 
-> Don't just copy and paste the groovy snippets on this page — instead, ensure that each section has (at least) the contents shown.
+```admonish tip
+Don't just copy and paste the groovy snippets on this page — instead, ensure that each section has (at least) the contents shown.
+```
 
 Merge the following into the **app**'s `build.gradle` (`/Android/app/build.gradle`).
 
@@ -125,7 +133,9 @@ We'll use the following tools to incorporate our Rust shared library into the An
 
 Let's get started.
 
-> Don't just copy and paste the groovy snippets on this page — instead, ensure that each section has (at least) the contents shown.
+```admonish tip
+Don't just copy and paste the groovy snippets on this page — instead, ensure that each section has (at least) the contents shown.
+```
 
 Merge the following into the **project**'s `build.gradle` (`/Android/build.gradle`).
 
@@ -140,8 +150,6 @@ plugins {
     id "org.mozilla.rust-android-gradle.rust-android" version "0.9.3"
 }
 ```
-
-> Don't just copy and paste the groovy snippets on this page — instead, ensure that each section has (at least) the contents shown.
 
 Merge the following into the **library**'s `build.gradle` (`/Android/shared/build.gradle`).
 
@@ -212,7 +220,9 @@ task typesGen(type: Exec) {
 
 ```
 
-> When you have edited the gradle files, don't forget to click "sync now".
+```admonish tip
+When you have edited the gradle files, don't forget to click "sync now".
+```
 
 If you now build your project you should see the shared library object file, and the shared types, in the right places.
 
@@ -241,7 +251,11 @@ Android/shared/src/main/java/com/example/counter
 
 ### Hello World counter example
 
-There are several [examples](https://github.com/redbadger/crux/tree/master/examples) of UI for Android in the Crux repository. The simplest is the [Hello World counter example](https://github.com/redbadger/crux/tree/master/examples/hello_world), but this deliberately does not have an Android example.
+```admonish example
+There are several [examples](https://github.com/redbadger/crux/tree/master/examples) of Android apps in the Crux repository.
+
+However, the simplest example is the [Hello World counter example](https://github.com/redbadger/crux/tree/master/examples/hello_world) — it only has `shared` and `shared_types` libraries, which will work with the following example code.
+```
 
 Edit `/Android/app/src/main/java/com/example/android/MainActivity.kt` to look like this:
 
@@ -367,6 +381,8 @@ fun DefaultPreview() {
 }
 ```
 
+```admonish success
 You should then be able to run the app in the simulator, and it should look like this:
 
-<img alt="hello world app" src="./hello_world_android.webp"  width="300">
+<p align="center"><img alt="hello world app" src="./hello_world_android.webp"  width="300"></p>
+```

--- a/docs/src/getting_started/core.md
+++ b/docs/src/getting_started/core.md
@@ -2,7 +2,9 @@
 
 These are the steps to set up the two crates forming the shared core – the core itself, and the shared types crate which does type generation for the foreign languages.
 
-> 🚨 _SHARP EDGE WARNING_: Most of these steps are going to be automated in future tooling, and published as crates. For now the set up is effectively a copy & paste from one of the [example projects](https://github.com/redbadger/crux/tree/master/examples)
+```admonish warning title="Sharp edge"
+Most of these steps are going to be automated in future tooling, and published as crates. For now the set up is effectively a copy & paste from one of the [example projects](https://github.com/redbadger/crux/tree/master/examples).
+```
 
 ## Install the tools
 
@@ -123,4 +125,6 @@ This crate serves as the container for type generation for the foreign languages
    cargo build -vv
    ```
 
+```admonish success
 You should now be ready to set up [iOS](ios.md), [Android](android.md), [web](web_react.md), or [WebAssembly](web_yew.md) specific builds.
+```

--- a/docs/src/getting_started/ios.md
+++ b/docs/src/getting_started/ios.md
@@ -2,7 +2,13 @@
 
 These are the steps to set up Xcode to build and run a simple iOS app that calls into a shared core.
 
-> 🚨 _SHARP EDGE WARNING_: We want to make setting up Xcode to work with Crux really easy. As time progresses we will try to simplify and automate as much as possible, but at the moment there is some manual configuration to do. This only needs doing once, so we hope it's not too much trouble. If you know of any better ways than those we describe below (e.g. how to do Xcode project configuration from the command line), please either raise an issue (or a PR) at <https://github.com/redbadger/crux>.
+```admonish
+This walk-through assumes you have already added the `shared` and `shared_types` libraries to your repo, as described in [Shared core and types](./core.md).
+```
+
+```admonish warning title="Sharp edge"
+We want to make setting up Xcode to work with Crux really easy. As time progresses we will try to simplify and automate as much as possible, but at the moment there is some manual configuration to do. This only needs doing once, so we hope it's not too much trouble. If you know of any better ways than those we describe below (e.g. how to do Xcode project configuration from the command line), please either raise an issue (or a PR) at <https://github.com/redbadger/crux>.
+```
 
 ## Create an iOS App
 
@@ -149,7 +155,11 @@ In `File -> Add Files to iOS`, add `/shared_types/generated/swift/shared_types.s
 
 ### Hello World counter example
 
-There are several [examples](https://github.com/redbadger/crux/tree/master/examples) of UI for iOS in the Crux repository. The simplest is the [Hello World counter example](https://github.com/redbadger/crux/tree/master/examples/hello_world), but this deliberately does not have an iOS example.
+```admonish example
+There are several [examples](https://github.com/redbadger/crux/tree/master/examples) of iOS apps in the Crux repository.
+
+However, the simplest example is the [Hello World counter example](https://github.com/redbadger/crux/tree/master/examples/hello_world) — it only has `shared` and `shared_types` libraries, which will work with the following example code.
+```
 
 Edit `ContentView.swift` to look like this:
 
@@ -256,6 +266,8 @@ struct iOSApp: App {
 }
 ```
 
+```admonish success
 You should then be able to run the app in the simulator, and it should look like this:
 
-<img alt="hello world app" src="./hello_world_ios.webp"  width="300">
+<p align="center"><img alt="hello world app" src="./hello_world_ios.webp"  width="300"></p>
+```

--- a/docs/src/getting_started/web_react.md
+++ b/docs/src/getting_started/web_react.md
@@ -2,7 +2,13 @@
 
 These are the steps to set up and run a simple TypeScript Web app that calls into a shared core.
 
-> There are many frameworks available for writing Web applications with JavaScript/TypeScript. We've chosen [React](https://reactjs.org/) with [Next.js](https://nextjs.org/) for this walk-through because it is simple and popular. However, a similar setup would work for other frameworks.
+```admonish
+This walk-through assumes you have already added the `shared` and `shared_types` libraries to your repo, as described in [Shared core and types](./core.md).
+```
+
+```admonish info
+There are many frameworks available for writing Web applications with JavaScript/TypeScript. We've chosen [React](https://reactjs.org/) with [Next.js](https://nextjs.org/) for this walk-through because it is simple and popular. However, a similar setup would work for other frameworks.
+```
 
 ## Create a Next.js App
 
@@ -130,7 +136,11 @@ pnpm add ../shared_types/generated/typescript
 
 ### Hello World counter example
 
-There are several [examples](https://github.com/redbadger/crux/tree/master/examples) of Web UI for Next.js in the Crux repository. The simplest is the [Hello World counter example](https://github.com/redbadger/crux/tree/master/examples/hello_world), but this deliberately does not have a Next.js example.
+```admonish example
+There are several [examples](https://github.com/redbadger/crux/tree/master/examples) of Next.js apps in the Crux repository.
+
+However, the simplest example is the [Hello World counter example](https://github.com/redbadger/crux/tree/master/examples/hello_world) — it only has `shared` and `shared_types` libraries, which will work with the following example code.
+```
 
 Edit `web-nextjs/src/pages/index.tsx` to look like this:
 
@@ -298,6 +308,8 @@ We can build our app, and serve it for the browser, in one simple step.
 pnpm dev
 ```
 
+```admonish success
 Your app should look like this:
 
-<img alt="hello world app" src="./hello_world_nextjs.webp"  width="300">
+<p align="center"><img alt="hello world app" src="./hello_world_nextjs.webp"  width="300"></p>
+```

--- a/docs/src/getting_started/web_yew.md
+++ b/docs/src/getting_started/web_yew.md
@@ -2,7 +2,13 @@
 
 These are the steps to set up and run a simple Rust Web app that calls into a shared core.
 
-> There are many frameworks available for writing Web applications in Rust. We've chosen [Yew](https://yew.rs/) for this walk-through because it is arguably the most mature. However, a similar setup would work for any framework that compiles to WebAssembly.
+```admonish
+This walk-through assumes you have already added the `shared` and `shared_types` libraries to your repo, as described in [Shared core and types](./core.md).
+```
+
+```admonish info
+There are many frameworks available for writing Web applications in Rust. We've chosen [Yew](https://yew.rs/) for this walk-through because it is arguably the most mature. However, a similar setup would work for any framework that compiles to WebAssembly.
+```
 
 ## Create a Yew App
 
@@ -54,7 +60,11 @@ We'll also need a file called `index.html`, to serve our app.
 
 ### Hello World counter example
 
-There are several [examples](https://github.com/redbadger/crux/tree/master/examples) of UI for Yew in the Crux repository. The simplest is the [Hello World counter example](https://github.com/redbadger/crux/tree/master/examples/hello_world), but this deliberately does not have a Yew example.
+```admonish example
+There are several [examples](https://github.com/redbadger/crux/tree/master/examples) of Yew apps in the Crux repository.
+
+However, the simplest example is the [Hello World counter example](https://github.com/redbadger/crux/tree/master/examples/hello_world) — it only has `shared` and `shared_types` libraries, which will work with the following example code.
+```
 
 Edit `src/main.rs` to look like this:
 
@@ -141,6 +151,8 @@ We can build our app, serve it and open it in our browser, in one simple step.
 trunk serve --open
 ```
 
+```admonish success
 Your app should look like this:
 
-<img alt="hello world app" src="./hello_world_yew.webp"  width="300">
+<p align="center"><img alt="hello world app" src="./hello_world_yew.webp"  width="300"></p>
+```

--- a/docs/src/guide/capability_apis.md
+++ b/docs/src/guide/capability_apis.md
@@ -77,7 +77,9 @@ The implementation of the method has a little bit of boilerplate to enable us to
 
 You can see we use two APIs to orchestrate the interaction. First `request_from_shell` sends the delay operation we made earlier to the Shell. This call returns a future, which we can `.await`. Once done, we use the other API `update_app` to dispatch the event we were given. At the `.await`, the task will be suspended, Crux will pass the operation to the Shell wrapped in the `Effect` type we talked about in the last chapter and the Shell will use it's native APIs to wait for the given duration, and eventually respond. This will wake our task up again and we can continue working.
 
-> 🚨 _SHARP EDGE WARNING_: There is one more thing we need to do, which will likely be reduced to a derive macro in future versions of Crux. We need to implement the `Capability` trait.
+```admonish warning title="Sharp edge"
+There is one more thing we need to do, which will likely be reduced to a derive macro in future versions of Crux. We need to implement the `Capability` trait.
+```
 
 ```rust,noplayground
 impl<Ef> Capability<Ef> for Delay<Ef> {

--- a/docs/src/guide/composing.md
+++ b/docs/src/guide/composing.md
@@ -1,3 +1,5 @@
 # Composable Applications
 
-TO DO.
+```admonish info
+Coming soon.
+```

--- a/docs/src/guide/message_interface.md
+++ b/docs/src/guide/message_interface.md
@@ -1,3 +1,5 @@
 # Message interface between core and shell
 
-TO DO.
+```admonish info
+Coming soon.
+```

--- a/docs/src/internals/continuations.md
+++ b/docs/src/internals/continuations.md
@@ -1,3 +1,5 @@
 # Continuations
 
-TO DO.
+```admonish info
+Coming soon.
+```

--- a/docs/src/internals/core_api.md
+++ b/docs/src/internals/core_api.md
@@ -1,3 +1,5 @@
 # Core API
 
-TO DO.
+```admonish info
+Coming soon.
+```

--- a/docs/src/internals/serialization.md
+++ b/docs/src/internals/serialization.md
@@ -1,3 +1,5 @@
 # Serialization
 
-TO DO.
+```admonish info
+Coming soon.
+```

--- a/docs/src/internals/typegen.md
+++ b/docs/src/internals/typegen.md
@@ -1,3 +1,5 @@
 # Type generation
 
-TO DO.
+```admonish info
+Coming soon.
+```

--- a/docs/src/internals/uniffi.md
+++ b/docs/src/internals/uniffi.md
@@ -1,3 +1,5 @@
 # FFI interface
 
-TO DO.
+```admonish info
+Coming soon.
+```

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -8,8 +8,7 @@ It splits the application into two distinct parts, a Core built in Rust, which d
 
 The interface between the two is a native FFI (Foreign Function Interface) with cross-language type checking and message passing semantics, where simple data structures are passed across the boundary.
 
-## Get to know Crux
-
+```admonish title="Get to know Crux"
 To get playing with Crux quickly, follow the [Getting Started](./getting_started/core.md) steps. If you prefer to read more about how apps are built in Crux first, read the [Development Guide](./guide/hello_world.md). And if you'd like to know what possessed us to try this in the first place, read about our [Motivation](./motivation.md).
 
 There are two places to find API documentation: the latest published version on docs.rs, and we also have the very latest master docs if you too like to live dangerously.
@@ -18,6 +17,7 @@ There are two places to find API documentation: the latest published version on 
 - **crux_http** - HTTP client capability: [latest release](https://docs.rs/crux_http/latest/crux_http/) | [latest master](https://redbadger.github.io/crux/master_api_docs/crux_http/)
 
 Crux is open source on [Github](https://github.com/redbadger/crux). A good way to learn Crux is to explore the code, play with the [examples](https://github.com/redbadger/crux/tree/master/examples), and raise issues or pull requests. We'd love you to get involved.
+```
 
 ## Design overview
 


### PR DESCRIPTION
This PR uses the [mdbook-admonish](https://github.com/tommilligan/mdbook-admonish) preprocessor to render material 3 admonitions.
For example 
<img width="789" alt="image" src="https://user-images.githubusercontent.com/203552/216131877-c51a0c15-ccf1-419b-9d7c-8acfb3348c7b.png">

To test, pull the branch and `cd docs && mdbook serve --open`