### PR TITLE
Swap underlying store for Automerge to support sync

### DIFF
--- a/examples/notes/Cargo.lock
+++ b/examples/notes/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +86,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "automerge"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001093dfcea0a077d36b6039d98e77a6b8cea9e625552ec206305cbbd3a69816"
+dependencies = [
+ "flate2",
+ "fxhash",
+ "hex",
+ "itertools",
+ "leb128",
+ "serde",
+ "sha2",
+ "smol_str",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "bcs"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,10 +131,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -215,6 +256,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +318,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -307,6 +376,32 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -411,6 +506,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +585,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +631,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +659,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -585,6 +720,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "nom"
@@ -888,13 +1032,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shared"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "automerge",
  "bincode",
  "crux_core",
  "crux_macros",
+ "futures",
  "lazy_static",
  "serde",
  "uniffi",
@@ -929,6 +1086,15 @@ name = "smawk"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
+name = "smol_str"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7475118a28b7e3a2e157ce0131ba8c5526ea96e90ee601d9f6bb2e286a35ab44"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "static_assertions"
@@ -1038,6 +1204,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1226,44 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicase"
@@ -1201,6 +1420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
  "getrandom",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/examples/notes/ios/Notes/ContentView.swift
+++ b/examples/notes/ios/Notes/ContentView.swift
@@ -64,6 +64,10 @@ class Core: ObservableObject {
             switch req.effect {
             case .render(_):
                 view = try! ViewModel.bcsDeserialize(input: Notes.view())
+            case let .pubSub(.publish(bytes)):
+                print(["Publish", bytes.count, "bytes"])
+            case .pubSub(.subscribe):
+                print("Subscribe")
             }
         }
     }

--- a/examples/notes/shared/Cargo.toml
+++ b/examples/notes/shared/Cargo.toml
@@ -22,6 +22,8 @@ crux_macros = { version = "0.1", path = "../../../crux_macros" }
 bincode = "1.3.3"
 lazy_static = "1.4"
 uniffi = "0.23.0"
+automerge = "0.3.0"
+futures = "0.3"
 
 [target.uniffi-bindgen.dependencies]
 uniffi = { version = "0.23.0", features = ["cli"] }

--- a/examples/notes/shared/src/app/note.rs
+++ b/examples/notes/shared/src/app/note.rs
@@ -1,0 +1,100 @@
+use automerge::{transaction::Transactable, Automerge, Change, ObjId, ObjType, ReadDoc, ROOT};
+
+pub struct Note {
+    document: Automerge,
+}
+
+impl Default for Note {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Note {
+    pub fn new() -> Self {
+        let mut document = Automerge::new();
+
+        document
+            .transact(|tx| tx.put_object(automerge::ROOT, "body", ObjType::Text))
+            .expect("to create a document");
+
+        Self {
+            document: document.fork(),
+        }
+    }
+
+    pub fn with_text(text: &str) -> Self {
+        let mut note = Self::new();
+        let body = note.body();
+
+        note.document
+            .transact(|tx| tx.splice_text(&body, 0, 0, text))
+            .expect("to update body of a new note");
+
+        assert_eq!(note.text(), text.to_string());
+
+        note
+    }
+
+    pub fn load(bytes: &[u8]) -> Self {
+        let document = Automerge::load(bytes).expect("to load document");
+
+        Self { document }
+    }
+
+    pub fn text(&self) -> String {
+        self.document
+            .text(self.body())
+            .expect("document to have body")
+    }
+
+    pub fn splice_text(&mut self, pos: usize, del: usize, text: &str) -> Change {
+        let body = self.body();
+
+        self.document
+            .transact(|tx| tx.splice_text(body, pos, del, text))
+            .expect("to splice the body text");
+
+        self.document
+            .get_last_local_change()
+            .expect("to find a change")
+            .clone()
+    }
+
+    pub fn apply_changes(&mut self, changes: impl IntoIterator<Item = Change>) {
+        self.document
+            .apply_changes(changes)
+            .expect("to apply changes")
+    }
+
+    fn body(&self) -> ObjId {
+        self.document
+            .get(ROOT, "body")
+            .expect("to get")
+            .expect("to find body")
+            .1
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn inserts_text() {
+        let mut note = Note::new();
+
+        note.splice_text(0, 0, "hello");
+
+        assert_eq!(note.text(), "hello");
+    }
+
+    #[test]
+    fn splices_text() {
+        let mut note = Note::with_text("hello");
+
+        note.splice_text(2, 1, "L");
+
+        assert_eq!(note.text(), "heLlo");
+    }
+}

--- a/examples/notes/shared/src/capabilities.rs
+++ b/examples/notes/shared/src/capabilities.rs
@@ -1,0 +1,76 @@
+pub mod pub_sub {
+    use crux_core::capability::{Capability, CapabilityContext, Operation};
+    use futures::StreamExt;
+    use serde::{Deserialize, Serialize};
+
+    // TODO add topics
+
+    #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+    pub enum PubSubOperation {
+        Publish(Vec<u8>),
+        Subscribe,
+    }
+
+    #[derive(Deserialize)]
+    pub struct Message(Vec<u8>);
+
+    impl Operation for PubSubOperation {
+        type Output = Message;
+    }
+
+    pub struct PubSub<Event> {
+        context: CapabilityContext<PubSubOperation, Event>,
+    }
+
+    impl<Ev> PubSub<Ev>
+    where
+        Ev: 'static,
+    {
+        pub fn new(context: CapabilityContext<PubSubOperation, Ev>) -> Self {
+            Self { context }
+        }
+
+        pub fn subscribe<F>(&self, make_event: F)
+        where
+            F: Fn(Vec<u8>) -> Ev + Clone + Send + 'static,
+        {
+            self.context.spawn({
+                let context = self.context.clone();
+
+                async move {
+                    let mut stream = context.stream_from_shell(PubSubOperation::Subscribe);
+
+                    while let Some(message) = stream.next().await {
+                        let make_event = make_event.clone();
+
+                        context.update_app(make_event(message.0));
+                    }
+                }
+            })
+        }
+
+        pub fn publish(&self, data: Vec<u8>) {
+            self.context.spawn({
+                let context = self.context.clone();
+
+                async move {
+                    context.notify_shell(PubSubOperation::Publish(data)).await;
+                }
+            })
+        }
+    }
+
+    impl<Ef> Capability<Ef> for PubSub<Ef> {
+        type Operation = PubSubOperation;
+        type MappedSelf<MappedEv> = PubSub<MappedEv>;
+
+        fn map_event<F, NewEvent>(&self, f: F) -> Self::MappedSelf<NewEvent>
+        where
+            F: Fn(NewEvent) -> Ef + Send + Sync + Copy + 'static,
+            Ef: 'static,
+            NewEvent: 'static,
+        {
+            PubSub::new(self.context.map_event(f))
+        }
+    }
+}

--- a/examples/notes/shared/src/lib.rs
+++ b/examples/notes/shared/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod capabilities;
 
 use lazy_static::lazy_static;
 

--- a/examples/notes/shared_types/build.rs
+++ b/examples/notes/shared_types/build.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use crux_core::{typegen::TypeGen, Request};
-use shared::{Effect, Event, TextCursor, ViewModel};
+use shared::{capabilities::pub_sub::PubSubOperation, Effect, Event, TextCursor, ViewModel};
 use std::path::PathBuf;
 
 fn main() {
@@ -27,6 +27,8 @@ fn main() {
 fn register_types(gen: &mut TypeGen) -> Result<()> {
     gen.register_type::<Request<Effect>>()?;
     gen.register_type::<Effect>()?;
+
+    gen.register_type::<PubSubOperation>()?;
 
     gen.register_type::<Event>()?;
     gen.register_type::<TextCursor>()?;


### PR DESCRIPTION
Instead of storing the plain text of the note, it is now stored in an [Automerge](https://automerge.org/) document,
using [automerge-rs](https://github.com/automerge/automerge-rs). 

I've also added a really basic pubsub capability to be able to do an integration test for the sync. I'll go on to add
a lot more of those tests and make sure the syncing works properly.

This revealed one really nifty thing about Crux - testing the sync is just a unit test with two instances of the app
running and the test acting as the shell and exchanging messages between them. Blew my tiny mind!
