### PR TITLE
Add test helpers to make sync tests more straightforward

### DIFF
--- a/examples/notes/shared/src/app/note.rs
+++ b/examples/notes/shared/src/app/note.rs
@@ -36,6 +36,10 @@ impl Note {
         note
     }
 
+    pub fn save(&mut self) -> Vec<u8> {
+        self.document.save()
+    }
+
     pub fn load(bytes: &[u8]) -> Self {
         let document = Automerge::load(bytes).expect("to load document");
 


### PR DESCRIPTION
As much as I dislike refactoring in tests, this felt helpful to make the tests more readable. Not sure if there's anything in this that is worth bringing into the AppTester, maybe? Probably needs more tests of this nature to spot common patterns.
