### PR TITLE
Add support for HTTP request headers

### DIFF
--- a/crux_http/src/client.rs
+++ b/crux_http/src/client.rs
@@ -334,7 +334,8 @@ mod client_tests {
             shell.take_requests_received(),
             vec![HttpRequest {
                 method: "GET".into(),
-                url: "https://example.com/".into()
+                url: "https://example.com/".into(),
+                headers: vec![]
             }]
         )
     }

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -8,10 +8,16 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct HttpHeader {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct HttpRequest {
     pub method: String,
     pub url: String,
-    // TODO support headers
+    pub headers: Vec<HttpHeader>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -44,6 +50,15 @@ impl From<crate::Request> for HttpRequest {
         HttpRequest {
             method: req.method().to_string(),
             url: req.url().to_string(),
+            headers: req
+                .iter()
+                .flat_map(|(name, values)| {
+                    values.iter().map(|value| HttpHeader {
+                        name: name.to_string(),
+                        value: value.to_string(),
+                    })
+                })
+                .collect(),
         }
     }
 }

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -155,7 +155,8 @@ mod tests {
             vec![
                 Effect::Http(HttpRequest {
                     method: "GET".to_string(),
-                    url: "http://example.com/".to_string()
+                    url: "http://example.com/".to_string(),
+                    headers: vec![]
                 }),
                 Effect::Render(RenderOperation)
             ]
@@ -172,7 +173,8 @@ mod tests {
             vec![
                 Effect::Http(HttpRequest {
                     method: "GET".to_string(),
-                    url: "http://example.com/".to_string()
+                    url: "http://example.com/".to_string(),
+                    headers: vec![]
                 }),
                 Effect::Render(RenderOperation)
             ]

--- a/crux_http/tests/with_tester.rs
+++ b/crux_http/tests/with_tester.rs
@@ -35,6 +35,7 @@ mod shared {
                 Event::Get => {
                     caps.http
                         .get("http://example.com")
+                        .header("Authorization", "secret-token")
                         .expect_string()
                         .send(Event::Set);
                 }
@@ -62,7 +63,7 @@ mod tests {
 
     use crate::shared::{App, Effect, Event, Model};
     use crux_core::testing::AppTester;
-    use crux_http::protocol::{HttpRequest, HttpResponse};
+    use crux_http::protocol::{HttpHeader, HttpRequest, HttpResponse};
 
     #[test]
     fn with_tester() {
@@ -75,7 +76,11 @@ mod tests {
             update.effects[0],
             Effect::Http(HttpRequest {
                 method: "GET".to_string(),
-                url: "http://example.com/".to_string()
+                url: "http://example.com/".to_string(),
+                headers: vec![HttpHeader {
+                    name: "authorization".to_string(),
+                    value: "secret-token".to_string()
+                }]
             })
         );
 

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/HttpHeader.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/HttpHeader.java
@@ -1,0 +1,77 @@
+package com.redbadger.catfacts.shared_types;
+
+
+public final class HttpHeader {
+    public final String name;
+    public final String value;
+
+    public HttpHeader(String name, String value) {
+        java.util.Objects.requireNonNull(name, "name must not be null");
+        java.util.Objects.requireNonNull(value, "value must not be null");
+        this.name = name;
+        this.value = value;
+    }
+
+    public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
+        serializer.increase_container_depth();
+        serializer.serialize_str(name);
+        serializer.serialize_str(value);
+        serializer.decrease_container_depth();
+    }
+
+    public byte[] bcsSerialize() throws com.novi.serde.SerializationError {
+        com.novi.serde.Serializer serializer = new com.novi.bcs.BcsSerializer();
+        serialize(serializer);
+        return serializer.get_bytes();
+    }
+
+    public static HttpHeader deserialize(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
+        deserializer.increase_container_depth();
+        Builder builder = new Builder();
+        builder.name = deserializer.deserialize_str();
+        builder.value = deserializer.deserialize_str();
+        deserializer.decrease_container_depth();
+        return builder.build();
+    }
+
+    public static HttpHeader bcsDeserialize(byte[] input) throws com.novi.serde.DeserializationError {
+        if (input == null) {
+             throw new com.novi.serde.DeserializationError("Cannot deserialize null array");
+        }
+        com.novi.serde.Deserializer deserializer = new com.novi.bcs.BcsDeserializer(input);
+        HttpHeader value = deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.length) {
+             throw new com.novi.serde.DeserializationError("Some input bytes were not read");
+        }
+        return value;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        HttpHeader other = (HttpHeader) obj;
+        if (!java.util.Objects.equals(this.name, other.name)) { return false; }
+        if (!java.util.Objects.equals(this.value, other.value)) { return false; }
+        return true;
+    }
+
+    public int hashCode() {
+        int value = 7;
+        value = 31 * value + (this.name != null ? this.name.hashCode() : 0);
+        value = 31 * value + (this.value != null ? this.value.hashCode() : 0);
+        return value;
+    }
+
+    public static final class Builder {
+        public String name;
+        public String value;
+
+        public HttpHeader build() {
+            return new HttpHeader(
+                name,
+                value
+            );
+        }
+    }
+}

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/HttpRequest.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/HttpRequest.java
@@ -4,18 +4,22 @@ package com.redbadger.catfacts.shared_types;
 public final class HttpRequest {
     public final String method;
     public final String url;
+    public final java.util.List<HttpHeader> headers;
 
-    public HttpRequest(String method, String url) {
+    public HttpRequest(String method, String url, java.util.List<HttpHeader> headers) {
         java.util.Objects.requireNonNull(method, "method must not be null");
         java.util.Objects.requireNonNull(url, "url must not be null");
+        java.util.Objects.requireNonNull(headers, "headers must not be null");
         this.method = method;
         this.url = url;
+        this.headers = headers;
     }
 
     public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
         serializer.increase_container_depth();
         serializer.serialize_str(method);
         serializer.serialize_str(url);
+        TraitHelpers.serialize_vector_HttpHeader(headers, serializer);
         serializer.decrease_container_depth();
     }
 
@@ -30,6 +34,7 @@ public final class HttpRequest {
         Builder builder = new Builder();
         builder.method = deserializer.deserialize_str();
         builder.url = deserializer.deserialize_str();
+        builder.headers = TraitHelpers.deserialize_vector_HttpHeader(deserializer);
         deserializer.decrease_container_depth();
         return builder.build();
     }
@@ -53,6 +58,7 @@ public final class HttpRequest {
         HttpRequest other = (HttpRequest) obj;
         if (!java.util.Objects.equals(this.method, other.method)) { return false; }
         if (!java.util.Objects.equals(this.url, other.url)) { return false; }
+        if (!java.util.Objects.equals(this.headers, other.headers)) { return false; }
         return true;
     }
 
@@ -60,17 +66,20 @@ public final class HttpRequest {
         int value = 7;
         value = 31 * value + (this.method != null ? this.method.hashCode() : 0);
         value = 31 * value + (this.url != null ? this.url.hashCode() : 0);
+        value = 31 * value + (this.headers != null ? this.headers.hashCode() : 0);
         return value;
     }
 
     public static final class Builder {
         public String method;
         public String url;
+        public java.util.List<HttpHeader> headers;
 
         public HttpRequest build() {
             return new HttpRequest(
                 method,
-                url
+                url,
+                headers
             );
         }
     }

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/TraitHelpers.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/TraitHelpers.java
@@ -37,6 +37,22 @@ final class TraitHelpers {
         }
     }
 
+    static void serialize_vector_HttpHeader(java.util.List<HttpHeader> value, com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
+        serializer.serialize_len(value.size());
+        for (HttpHeader item : value) {
+            item.serialize(serializer);
+        }
+    }
+
+    static java.util.List<HttpHeader> deserialize_vector_HttpHeader(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
+        long length = deserializer.deserialize_len();
+        java.util.List<HttpHeader> obj = new java.util.ArrayList<HttpHeader>((int) length);
+        for (long i = 0; i < length; i++) {
+            obj.add(HttpHeader.deserialize(deserializer));
+        }
+        return obj;
+    }
+
     static void serialize_vector_u8(java.util.List<@com.novi.serde.Unsigned Byte> value, com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
         serializer.serialize_len(value.size());
         for (@com.novi.serde.Unsigned Byte item : value) {

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -229,14 +229,16 @@ mod tests {
             update.effects[0],
             Effect::Http(HttpRequest {
                 method: "GET".into(),
-                url: FACT_API_URL.into()
+                url: FACT_API_URL.into(),
+                headers: vec![]
             })
         );
         assert_eq!(
             update.effects[1],
             Effect::Http(HttpRequest {
                 method: "GET".into(),
-                url: IMAGE_API_URL.into()
+                url: IMAGE_API_URL.into(),
+                headers: vec![]
             })
         );
     }
@@ -252,7 +254,8 @@ mod tests {
             update.effects[0],
             Effect::Http(HttpRequest {
                 method: "GET".into(),
-                url: FACT_API_URL.into()
+                url: FACT_API_URL.into(),
+                headers: vec![]
             })
         );
         let a_fact = CatFact {

--- a/examples/counter/Android/app/src/main/java/com/example/counter/MainActivity.kt
+++ b/examples/counter/Android/app/src/main/java/com/example/counter/MainActivity.kt
@@ -105,7 +105,7 @@ class Model : ViewModel() {
                 this.view = MyViewModel.bcsDeserialize(view().toUByteArray().toByteArray())
             }
             is Effect.Http -> {
-                val response = http(httpClient, HttpMethod(effect.value.method), effect.value.url)
+                val response = http(httpClient, HttpMethod(effect.value.method), effect.value.url, effect.value.headers)
                 update(
                     CoreMessage.Response(
                         req.uuid.toByteArray().toUByteArray().toList(),

--- a/examples/counter/Android/app/src/main/java/com/example/counter/http.kt
+++ b/examples/counter/Android/app/src/main/java/com/example/counter/http.kt
@@ -1,5 +1,6 @@
 package com.example.counter
 
+import com.example.counter.shared_types.HttpHeader
 import com.example.counter.shared_types.HttpResponse
 import io.ktor.client.*
 import io.ktor.client.call.*
@@ -9,10 +10,16 @@ import io.ktor.http.*
 suspend fun http(
     client: HttpClient,
     method: HttpMethod,
-    url: String
+    url: String,
+    headers: List<HttpHeader>
 ): HttpResponse {
     val response = client.request(url) {
         this.method = method
+        this.headers {
+            for (header in headers) {
+                append(header.name, header.value)
+            }
+        }
     }
     val bytes: ByteArray = response.body()
     return HttpResponse(response.status.value.toShort(), bytes.toList())

--- a/examples/counter/Android/shared/src/main/java/com/example/counter/shared_types/HttpHeader.java
+++ b/examples/counter/Android/shared/src/main/java/com/example/counter/shared_types/HttpHeader.java
@@ -1,0 +1,77 @@
+package com.example.counter.shared_types;
+
+
+public final class HttpHeader {
+    public final String name;
+    public final String value;
+
+    public HttpHeader(String name, String value) {
+        java.util.Objects.requireNonNull(name, "name must not be null");
+        java.util.Objects.requireNonNull(value, "value must not be null");
+        this.name = name;
+        this.value = value;
+    }
+
+    public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
+        serializer.increase_container_depth();
+        serializer.serialize_str(name);
+        serializer.serialize_str(value);
+        serializer.decrease_container_depth();
+    }
+
+    public byte[] bcsSerialize() throws com.novi.serde.SerializationError {
+        com.novi.serde.Serializer serializer = new com.novi.bcs.BcsSerializer();
+        serialize(serializer);
+        return serializer.get_bytes();
+    }
+
+    public static HttpHeader deserialize(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
+        deserializer.increase_container_depth();
+        Builder builder = new Builder();
+        builder.name = deserializer.deserialize_str();
+        builder.value = deserializer.deserialize_str();
+        deserializer.decrease_container_depth();
+        return builder.build();
+    }
+
+    public static HttpHeader bcsDeserialize(byte[] input) throws com.novi.serde.DeserializationError {
+        if (input == null) {
+             throw new com.novi.serde.DeserializationError("Cannot deserialize null array");
+        }
+        com.novi.serde.Deserializer deserializer = new com.novi.bcs.BcsDeserializer(input);
+        HttpHeader value = deserialize(deserializer);
+        if (deserializer.get_buffer_offset() < input.length) {
+             throw new com.novi.serde.DeserializationError("Some input bytes were not read");
+        }
+        return value;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        HttpHeader other = (HttpHeader) obj;
+        if (!java.util.Objects.equals(this.name, other.name)) { return false; }
+        if (!java.util.Objects.equals(this.value, other.value)) { return false; }
+        return true;
+    }
+
+    public int hashCode() {
+        int value = 7;
+        value = 31 * value + (this.name != null ? this.name.hashCode() : 0);
+        value = 31 * value + (this.value != null ? this.value.hashCode() : 0);
+        return value;
+    }
+
+    public static final class Builder {
+        public String name;
+        public String value;
+
+        public HttpHeader build() {
+            return new HttpHeader(
+                name,
+                value
+            );
+        }
+    }
+}

--- a/examples/counter/Android/shared/src/main/java/com/example/counter/shared_types/HttpRequest.java
+++ b/examples/counter/Android/shared/src/main/java/com/example/counter/shared_types/HttpRequest.java
@@ -4,18 +4,22 @@ package com.example.counter.shared_types;
 public final class HttpRequest {
     public final String method;
     public final String url;
+    public final java.util.List<HttpHeader> headers;
 
-    public HttpRequest(String method, String url) {
+    public HttpRequest(String method, String url, java.util.List<HttpHeader> headers) {
         java.util.Objects.requireNonNull(method, "method must not be null");
         java.util.Objects.requireNonNull(url, "url must not be null");
+        java.util.Objects.requireNonNull(headers, "headers must not be null");
         this.method = method;
         this.url = url;
+        this.headers = headers;
     }
 
     public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
         serializer.increase_container_depth();
         serializer.serialize_str(method);
         serializer.serialize_str(url);
+        TraitHelpers.serialize_vector_HttpHeader(headers, serializer);
         serializer.decrease_container_depth();
     }
 
@@ -30,6 +34,7 @@ public final class HttpRequest {
         Builder builder = new Builder();
         builder.method = deserializer.deserialize_str();
         builder.url = deserializer.deserialize_str();
+        builder.headers = TraitHelpers.deserialize_vector_HttpHeader(deserializer);
         deserializer.decrease_container_depth();
         return builder.build();
     }
@@ -53,6 +58,7 @@ public final class HttpRequest {
         HttpRequest other = (HttpRequest) obj;
         if (!java.util.Objects.equals(this.method, other.method)) { return false; }
         if (!java.util.Objects.equals(this.url, other.url)) { return false; }
+        if (!java.util.Objects.equals(this.headers, other.headers)) { return false; }
         return true;
     }
 
@@ -60,17 +66,20 @@ public final class HttpRequest {
         int value = 7;
         value = 31 * value + (this.method != null ? this.method.hashCode() : 0);
         value = 31 * value + (this.url != null ? this.url.hashCode() : 0);
+        value = 31 * value + (this.headers != null ? this.headers.hashCode() : 0);
         return value;
     }
 
     public static final class Builder {
         public String method;
         public String url;
+        public java.util.List<HttpHeader> headers;
 
         public HttpRequest build() {
             return new HttpRequest(
                 method,
-                url
+                url,
+                headers
             );
         }
     }

--- a/examples/counter/Android/shared/src/main/java/com/example/counter/shared_types/TraitHelpers.java
+++ b/examples/counter/Android/shared/src/main/java/com/example/counter/shared_types/TraitHelpers.java
@@ -1,6 +1,22 @@
 package com.example.counter.shared_types;
 
 final class TraitHelpers {
+    static void serialize_vector_HttpHeader(java.util.List<HttpHeader> value, com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
+        serializer.serialize_len(value.size());
+        for (HttpHeader item : value) {
+            item.serialize(serializer);
+        }
+    }
+
+    static java.util.List<HttpHeader> deserialize_vector_HttpHeader(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
+        long length = deserializer.deserialize_len();
+        java.util.List<HttpHeader> obj = new java.util.ArrayList<HttpHeader>((int) length);
+        for (long i = 0; i < length; i++) {
+            obj.add(HttpHeader.deserialize(deserializer));
+        }
+        return obj;
+    }
+
     static void serialize_vector_u8(java.util.List<@com.novi.serde.Unsigned Byte> value, com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
         serializer.serialize_len(value.size());
         for (@com.novi.serde.Unsigned Byte item : value) {

--- a/examples/counter/iOS/CounterApp/ContentView.swift
+++ b/examples/counter/iOS/CounterApp/ContentView.swift
@@ -21,9 +21,14 @@ class Model: ObservableObject {
         update(msg: .event(.startWatch))
     }
 
-    private func http(uuid: Uuid, method: String, url: String) {
+    private func http(uuid: Uuid, method: String, url: String, headers: [HttpHeader]) {
         var req = URLRequest(url: URL(string: url)!)
         req.httpMethod = method
+
+        for header in headers {
+            req.addValue(header.value, forHTTPHeaderField: header.name)
+        }
+
         Task {
             let (data, response) = try! await URLSession.shared.data(for: req)
             if let httpResponse = response as? HTTPURLResponse {
@@ -71,7 +76,7 @@ class Model: ObservableObject {
         for req in reqs {
             switch req.effect {
             case .render: view = try! ViewModel.bcsDeserialize(input: CounterApp.view())
-            case let .http(r): http(uuid: req.uuid, method: r.method, url: r.url)
+            case let .http(r): http(uuid: req.uuid, method: r.method, url: r.url, headers: r.headers)
             case let .serverSentEvents(r): sse(uuid: req.uuid, url: r.url)
             }
         }

--- a/examples/counter/shared/src/app.rs
+++ b/examples/counter/shared/src/app.rs
@@ -145,6 +145,7 @@ mod tests {
         let expected = &Effect::Http(HttpRequest {
             method: "GET".to_string(),
             url: "https://crux-counter.fly.dev/".to_string(),
+            headers: vec![],
         });
         assert_eq!(actual, expected);
 
@@ -205,6 +206,7 @@ mod tests {
         let expected = &Effect::Http(HttpRequest {
             method: "POST".to_string(),
             url: "https://crux-counter.fly.dev/inc".to_string(),
+            headers: vec![],
         });
         assert_eq!(actual, expected);
 
@@ -245,6 +247,7 @@ mod tests {
         let expected = &Effect::Http(HttpRequest {
             method: "POST".to_string(),
             url: "https://crux-counter.fly.dev/dec".to_string(),
+            headers: vec![],
         });
         assert_eq!(actual, expected);
 

--- a/examples/counter/web-nextjs/pages/index.tsx
+++ b/examples/counter/web-nextjs/pages/index.tsx
@@ -84,8 +84,12 @@ const Home: NextPage = () => {
 
           break;
         case types.EffectVariantHttp: {
-          const { method, url } = (effect as types.EffectVariantHttp).value;
-          const req = new Request(url, { method });
+          const { method, url, headers } = (effect as types.EffectVariantHttp)
+            .value;
+          const req = new Request(url, {
+            method,
+            headers: headers.map((header) => [header.name, header.value]),
+          });
           const res = await fetch(req);
           const body = await res.arrayBuffer();
           const response_bytes = Array.from(new Uint8Array(body));


### PR DESCRIPTION
Per title, exposes headers that are set on HTTP requests through to the shell, so that they can be sent out.

I've only updated the counter example; happy to do cat facts too if we want but it'd be a little more work (e.g. the shells currently only support HTTP GETs so would need bringing up to date).