### PR TITLE
Spike: cli to generate types using rustdoc json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +172,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
+
+[[package]]
 name = "blocking"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,10 +198,105 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cargo_toml"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f83bc2e401ed041b7057345ebc488c005efa0341d5541ce7004d30458d0090b"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42dfd32784433290c51d92c438bb72ea5063797fc3cc9a21a8c4346bebbb2098"
+dependencies = [
+ "bitflags 2.0.2",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap-verbosity-flag"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e2b6c3dcdb73299f48ae05b294da14e2f560b3ed2c09e742269eb1b22af231"
+dependencies = [
+ "clap",
+ "log",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -230,6 +342,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crux_cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "atty",
+ "cargo_metadata",
+ "cargo_toml",
+ "clap",
+ "clap-verbosity-flag",
+ "log",
+ "termcolor",
 ]
 
 [[package]]
@@ -382,6 +508,27 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "event-listener"
@@ -577,6 +724,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +737,27 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "http-types"
@@ -647,6 +821,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "infer"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +856,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8687c819457e979cc940d09cb16e42a1bf70aa6b60a549de6d3a62a0ee90c69e"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -717,6 +924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +950,12 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parking"
@@ -833,7 +1052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
@@ -856,6 +1075,30 @@ checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -963,6 +1206,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1230,9 @@ name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -989,7 +1249,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5225c69f4a85eef7f9d9d1143c4893fadcb8c1e9fd0e1c88dc2db2519275b584"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "include_dir",
  "phf",
  "serde",
@@ -1039,6 +1299,15 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1114,6 +1383,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1435,40 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -1340,6 +1652,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1746,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "winnow"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deac0939bd6e4f24ab5919fbf751c97a8cfc8543bb083a305ed5c0c10bb241d1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "crux_cli",
   "crux_core",
   "crux_http",
   "crux_kv",

--- a/crux_cli/Cargo.toml
+++ b/crux_cli/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "crux_cli"
+version = "0.1.0"
+authors.workspace = true
+repository.workspace = true
+edition.workspace = true
+license.workspace = true
+keywords.workspace = true
+rust-version.workspace = true
+
+[[bin]]
+name = "crux"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+atty = "0.2.14"
+cargo_metadata = "0.15.3"
+cargo_toml = "0.15.2"
+clap = { version = "4.1.11", features = ["derive"] }
+clap-verbosity-flag = "2.0.0"
+log = "0.4.17"
+termcolor = "1.2.0"

--- a/crux_cli/src/config.rs
+++ b/crux_cli/src/config.rs
@@ -1,0 +1,142 @@
+use termcolor::{ColorChoice, StandardStream};
+
+#[allow(dead_code)]
+pub struct GlobalConfig {
+    level: Option<log::Level>,
+    is_stderr_tty: bool,
+    stdout: StandardStream,
+    stderr: StandardStream,
+}
+
+impl Default for GlobalConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GlobalConfig {
+    pub fn new() -> Self {
+        let is_stdout_tty = atty::is(atty::Stream::Stdout);
+        let is_stderr_tty = atty::is(atty::Stream::Stderr);
+
+        let color_choice = match std::env::var("CARGO_TERM_COLOR").as_deref() {
+            Ok("always") => Some(ColorChoice::Always),
+            Ok("alwaysansi") => Some(ColorChoice::AlwaysAnsi),
+            Ok("auto") => Some(ColorChoice::Auto),
+            Ok("never") => Some(ColorChoice::Never),
+            Ok(_) | Err(..) => None,
+        };
+
+        Self {
+            level: None,
+            is_stderr_tty,
+            stdout: StandardStream::stdout(color_choice.unwrap_or({
+                if is_stdout_tty {
+                    ColorChoice::Auto
+                } else {
+                    ColorChoice::Never
+                }
+            })),
+            stderr: StandardStream::stderr(color_choice.unwrap_or({
+                if is_stderr_tty {
+                    ColorChoice::Auto
+                } else {
+                    ColorChoice::Never
+                }
+            })),
+        }
+    }
+
+    pub fn set_level(mut self, level: Option<log::Level>) -> Self {
+        self.level = level;
+        self
+    }
+
+    pub fn is_verbose(&self) -> bool {
+        log::Level::Debug <= self.level.unwrap_or(log::Level::Error)
+    }
+
+    pub fn verbose(
+        &mut self,
+        callback: impl Fn(&mut Self) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        if self.is_verbose() {
+            callback(self)?;
+        }
+        Ok(())
+    }
+
+    pub fn is_extra_verbose(&self) -> bool {
+        log::Level::Trace <= self.level.unwrap_or(log::Level::Error)
+    }
+
+    pub fn extra_verbose(
+        &mut self,
+        callback: impl Fn(&mut Self) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        if self.is_extra_verbose() {
+            callback(self)?;
+        }
+        Ok(())
+    }
+
+    pub fn is_stderr_tty(&self) -> bool {
+        self.is_stderr_tty
+    }
+
+    pub fn stdout(&mut self) -> &mut StandardStream {
+        &mut self.stdout
+    }
+
+    pub fn stderr(&mut self) -> &mut StandardStream {
+        &mut self.stderr
+    }
+
+    /// Print a message with a colored title in the style of Cargo shell messages.
+    pub fn shell_print(
+        &mut self,
+        status: impl std::fmt::Display,
+        message: impl std::fmt::Display,
+        color: termcolor::Color,
+        justified: bool,
+    ) -> anyhow::Result<()> {
+        use std::io::Write;
+        use termcolor::WriteColor;
+
+        self.stderr().set_color(
+            termcolor::ColorSpec::new()
+                .set_fg(Some(color))
+                .set_bold(true),
+        )?;
+        if justified {
+            write!(self.stderr(), "{status:>12}")?;
+        } else {
+            write!(self.stderr(), "{status}")?;
+            self.stderr()
+                .set_color(termcolor::ColorSpec::new().set_bold(true))?;
+            write!(self.stderr(), ":")?;
+        }
+        self.stderr().reset()?;
+
+        writeln!(self.stderr(), " {message}")?;
+
+        Ok(())
+    }
+
+    /// Print a styled action message.
+    pub fn shell_status(
+        &mut self,
+        action: impl std::fmt::Display,
+        message: impl std::fmt::Display,
+    ) -> anyhow::Result<()> {
+        self.shell_print(action, message, termcolor::Color::Green, true)
+    }
+
+    pub fn shell_note(&mut self, message: impl std::fmt::Display) -> anyhow::Result<()> {
+        self.shell_print("note", message, termcolor::Color::Cyan, false)
+    }
+
+    pub fn shell_warn(&mut self, message: impl std::fmt::Display) -> anyhow::Result<()> {
+        self.shell_print("warning", message, termcolor::Color::Yellow, false)
+    }
+}

--- a/crux_cli/src/lib.rs
+++ b/crux_cli/src/lib.rs
@@ -1,0 +1,30 @@
+mod config;
+mod manifest;
+mod rustdoc_cmd;
+mod util;
+
+use anyhow::Result;
+pub use config::GlobalConfig;
+use manifest::Manifest;
+use rustdoc_cmd::RustdocCommand;
+use std::path::{Path, PathBuf};
+
+pub fn produce_doc(manifest_path: impl AsRef<Path>, config: &mut GlobalConfig) -> Result<PathBuf> {
+    let manifest = Manifest::parse(manifest_path.as_ref().to_path_buf())?;
+
+    let name = crate::manifest::get_package_name(&manifest)?;
+    let version = crate::manifest::get_package_version(&manifest)?;
+
+    let rustdoc_cmd = RustdocCommand::new()
+        .deps(false)
+        .silence(!config.is_verbose());
+
+    let rustdoc_path = rustdoc_cmd.dump(
+        config,
+        manifest_path.as_ref(),
+        Some(&format!("{name}@{version}")),
+        false,
+    )?;
+
+    Ok(rustdoc_path)
+}

--- a/crux_cli/src/main.rs
+++ b/crux_cli/src/main.rs
@@ -1,0 +1,32 @@
+use clap::Parser;
+use clap_verbosity_flag::Verbosity;
+use crux_cli::{produce_doc, GlobalConfig};
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Path to the Cargo.toml (for the shared library)
+    #[arg(short, long)]
+    manifest_path: String,
+
+    #[command(flatten)]
+    verbose: Verbosity,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+
+    let mut config = GlobalConfig::new().set_level(args.verbose.log_level());
+    let binding = produce_doc(args.manifest_path, &mut config)?;
+
+    let path = binding.to_str().unwrap();
+    config.shell_status("generate json", format!("path: {path}"))?;
+
+    Ok(())
+}
+
+#[test]
+fn verify_cli() {
+    use clap::CommandFactory;
+    Args::command().debug_assert()
+}

--- a/crux_cli/src/manifest.rs
+++ b/crux_cli/src/manifest.rs
@@ -1,0 +1,73 @@
+use std::path::PathBuf;
+
+use anyhow::Context;
+
+#[derive(Debug, Clone)]
+pub(crate) struct Manifest {
+    pub(crate) path: PathBuf,
+    pub(crate) parsed: cargo_toml::Manifest,
+}
+
+impl Manifest {
+    pub(crate) fn parse(path: PathBuf) -> anyhow::Result<Self> {
+        // Parsing via `cargo_toml::Manifest::from_path()` is preferable to parsing from a string,
+        // because inspection of surrounding files is sometimes necessary to determine
+        // the existence of lib targets and ensure proper handling of workspace inheritance.
+        let parsed = cargo_toml::Manifest::from_path(&path)
+            .with_context(|| format!("failed when reading {}", path.display()))?;
+
+        Ok(Self { path, parsed })
+    }
+}
+
+pub(crate) fn get_package_name(manifest: &Manifest) -> anyhow::Result<&str> {
+    let package = manifest.parsed.package.as_ref().with_context(|| {
+        format!(
+            "failed to parse {}: no `package` table",
+            manifest.path.display()
+        )
+    })?;
+    Ok(&package.name)
+}
+
+pub(crate) fn get_package_version(manifest: &Manifest) -> anyhow::Result<&str> {
+    let package = manifest.parsed.package.as_ref().with_context(|| {
+        format!(
+            "failed to parse {}: no `package` table",
+            manifest.path.display()
+        )
+    })?;
+    let version = package.version.get().with_context(|| {
+        format!(
+            "failed to retrieve package version from {}",
+            manifest.path.display()
+        )
+    })?;
+    Ok(version)
+}
+
+pub(crate) fn get_lib_target_name(manifest: &Manifest) -> anyhow::Result<String> {
+    // If there's a [lib] section, return the name it specifies, if any.
+    if let Some(product) = &manifest.parsed.lib {
+        if let Some(lib_name) = &product.name {
+            return Ok(lib_name.clone());
+        }
+    }
+
+    // Otherwise, assume the crate is a lib crate with the default lib target name:
+    // the same name as the package but with dashes replaced with underscores.
+    Ok(get_package_name(manifest)?.replace('-', "_"))
+}
+
+pub(crate) fn get_first_bin_target_name(manifest: &Manifest) -> anyhow::Result<String> {
+    // If there's a [[bin]] section, return the first item's name.
+    if let Some(product) = manifest.parsed.bin.first() {
+        if let Some(bin_name) = &product.name {
+            return Ok(bin_name.clone());
+        }
+    }
+
+    // Otherwise, assume the crate is a bin crate with the default bin target name:
+    // the same name as the package but with dashes replaced with underscores.
+    Ok(get_package_name(manifest)?.replace('-', "_"))
+}

--- a/crux_cli/src/rustdoc_cmd.rs
+++ b/crux_cli/src/rustdoc_cmd.rs
@@ -1,0 +1,245 @@
+use crate::GlobalConfig;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RustdocCommand {
+    deps: bool,
+    silence: bool,
+}
+
+impl RustdocCommand {
+    pub(crate) fn new() -> Self {
+        Self {
+            deps: false,
+            silence: false,
+        }
+    }
+
+    /// Include dependencies
+    ///
+    /// Reasons to have this disabled:
+    /// - Faster API extraction
+    /// - Less likely to hit bugs in rustdoc, like
+    ///   - rust-lang/rust#89097
+    ///   - rust-lang/rust#83718
+    ///
+    /// Reasons to have this enabled:
+    /// - Check for accidental inclusion of dependencies in your API
+    /// - Detect breaking changes from dependencies in your API
+    pub(crate) fn deps(mut self, yes: bool) -> Self {
+        self.deps = yes;
+        self
+    }
+
+    /// Don't write progress to stderr
+    pub(crate) fn silence(mut self, yes: bool) -> Self {
+        self.silence = yes;
+        self
+    }
+
+    /// Produce a rustdoc JSON file for the specified configuration.
+    pub(crate) fn dump(
+        &self,
+        config: &mut GlobalConfig,
+        manifest_path: &std::path::Path,
+        pkg_spec: Option<&str>,
+        all_features: bool,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        let metadata = cargo_metadata::MetadataCommand::new()
+            .manifest_path(manifest_path)
+            .no_deps()
+            .exec()?;
+        let manifest_target_directory = metadata
+            .target_directory
+            .as_path()
+            .as_std_path()
+            // HACK: Avoid potential errors when mixing toolchains
+            .join(crate::util::SCOPE)
+            .join("target");
+        let target_dir = manifest_target_directory.as_path();
+
+        let stderr = if self.silence {
+            std::process::Stdio::piped()
+        } else {
+            // Print cargo doc progress
+            std::process::Stdio::inherit()
+        };
+
+        let mut cmd = std::process::Command::new("cargo");
+        cmd.env("RUSTC_BOOTSTRAP", "1")
+            .env(
+                "RUSTDOCFLAGS",
+                "-Z unstable-options --document-private-items --document-hidden-items --output-format=json --cap-lints allow",
+            )
+            .stdout(std::process::Stdio::null()) // Don't pollute output
+            .stderr(stderr)
+            .arg("doc")
+            .arg("--manifest-path")
+            .arg(manifest_path)
+            .arg("--target-dir")
+            .arg(target_dir);
+        if let Some(pkg_spec) = pkg_spec {
+            cmd.arg("--package").arg(pkg_spec);
+        }
+        if !self.deps {
+            cmd.arg("--no-deps");
+        }
+        if all_features {
+            cmd.arg("--all-features");
+        }
+        if config.is_stderr_tty() {
+            cmd.arg("--color=always");
+        }
+        let output = cmd.output()?;
+        if !output.status.success() {
+            if self.silence {
+                anyhow::bail!(
+                    "Failed when running cargo-doc on {}:\n{}",
+                    manifest_path.display(),
+                    String::from_utf8_lossy(&output.stderr)
+                )
+            } else {
+                anyhow::bail!(
+                    "Failed when running cargo-doc on {}. See stderr.",
+                    manifest_path.display(),
+                )
+            }
+        }
+
+        if let Some(pkg_spec) = pkg_spec {
+            // N.B.: This package spec is not necessarily part of the manifest at `manifest_path`!
+            //       For example, when getting rustdoc JSON for a crate version from the registry,
+            //       the manifest is "synthetic" with only a dependency on that crate and version
+            //       and therefore is not a manifest *for* that crate itself.
+            let crate_name = pkg_spec
+                .split_once('@')
+                .map(|s| s.0)
+                .unwrap_or(pkg_spec)
+                .to_owned();
+
+            // N.B.: Crates named like `foo-bar` have rustdoc JSON named like `foo_bar.json`.
+            let crate_name_with_underscores = crate_name.replace('-', "_");
+            let json_path = target_dir.join(format!("doc/{crate_name_with_underscores}.json"));
+            if json_path.exists() {
+                Ok(json_path)
+            } else {
+                anyhow::bail!(
+                    "Could not find expected rustdoc output for `{}`: {}",
+                    crate_name,
+                    json_path.display()
+                );
+            }
+        } else {
+            let manifest = crate::manifest::Manifest::parse(manifest_path.to_path_buf())?;
+
+            let lib_target_name = crate::manifest::get_lib_target_name(&manifest)?;
+            let json_path = target_dir.join(format!("doc/{lib_target_name}.json"));
+            if json_path.exists() {
+                return Ok(json_path);
+            }
+
+            let first_bin_target_name = crate::manifest::get_first_bin_target_name(&manifest)?;
+            let json_path = target_dir.join(format!("doc/{first_bin_target_name}.json"));
+            if !json_path.exists() {
+                let crate_name = if let Some(pkg_spec) = pkg_spec {
+                    pkg_spec.split_once('@').map(|s| s.0).unwrap_or(pkg_spec)
+                } else {
+                    crate::manifest::get_package_name(&manifest)?
+                };
+
+                anyhow::bail!(
+                    "Could not find expected rustdoc output for `{}`: {}",
+                    crate_name,
+                    json_path.display()
+                );
+            }
+
+            Ok(json_path)
+        }
+    }
+}
+
+impl Default for RustdocCommand {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::GlobalConfig;
+    use std::path::Path;
+
+    use super::RustdocCommand;
+
+    #[test]
+    fn rustdoc_for_lib_crate_without_lib_section() {
+        RustdocCommand::default()
+            .dump(
+                &mut GlobalConfig::new(),
+                Path::new("./test_rustdoc/implicit_lib/Cargo.toml"),
+                None,
+                true,
+            )
+            .expect("no errors");
+    }
+
+    #[test]
+    fn rustdoc_for_lib_crate_with_lib_section() {
+        RustdocCommand::default()
+            .dump(
+                &mut GlobalConfig::new(),
+                Path::new("./test_rustdoc/renamed_lib/Cargo.toml"),
+                None,
+                true,
+            )
+            .expect("no errors");
+    }
+
+    #[test]
+    fn rustdoc_for_bin_crate_without_bin_section() {
+        RustdocCommand::default()
+            .dump(
+                &mut GlobalConfig::new(),
+                Path::new("./test_rustdoc/implicit_bin/Cargo.toml"),
+                None,
+                true,
+            )
+            .expect("no errors");
+    }
+
+    #[test]
+    fn rustdoc_for_bin_crate_with_bin_section() {
+        RustdocCommand::default()
+            .dump(
+                &mut GlobalConfig::new(),
+                Path::new("./test_rustdoc/renamed_bin/Cargo.toml"),
+                None,
+                true,
+            )
+            .expect("no errors");
+    }
+
+    #[test]
+    fn rustdoc_for_crate_in_workspace_with_workspace_manifest() {
+        RustdocCommand::default()
+            .dump(
+                &mut GlobalConfig::new(),
+                Path::new("./test_rustdoc/crate_in_workspace/Cargo.toml"),
+                Some("crate_in_workspace_crate1"),
+                true,
+            )
+            .expect("no errors");
+    }
+
+    #[test]
+    fn rustdoc_for_crate_in_workspace_with_crate_manifest() {
+        RustdocCommand::default()
+            .dump(
+                &mut GlobalConfig::new(),
+                Path::new("./test_rustdoc/crate_in_workspace/crate1/Cargo.toml"),
+                None,
+                true,
+            )
+            .expect("no errors");
+    }
+}

--- a/crux_cli/src/util.rs
+++ b/crux_cli/src/util.rs
@@ -1,0 +1,1 @@
+pub(crate) const SCOPE: &str = "crux_cli";

--- a/crux_cli/test_rustdoc/.gitignore
+++ b/crux_cli/test_rustdoc/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/crux_cli/test_rustdoc/crate_in_workspace/Cargo.toml
+++ b/crux_cli/test_rustdoc/crate_in_workspace/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = ["crate1"]
+
+[workspace.package]
+version = "0.1.0"

--- a/crux_cli/test_rustdoc/crate_in_workspace/crate1/Cargo.toml
+++ b/crux_cli/test_rustdoc/crate_in_workspace/crate1/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+publish = false
+name = "crate_in_workspace_crate1"
+version = { workspace = true }
+
+[dependencies]

--- a/crux_cli/test_rustdoc/implicit_bin/Cargo.toml
+++ b/crux_cli/test_rustdoc/implicit_bin/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "implicit_bin"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]

--- a/crux_cli/test_rustdoc/implicit_bin/src/main.rs
+++ b/crux_cli/test_rustdoc/implicit_bin/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crux_cli/test_rustdoc/implicit_lib/Cargo.toml
+++ b/crux_cli/test_rustdoc/implicit_lib/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "implicit_lib"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]

--- a/crux_cli/test_rustdoc/implicit_lib/src/lib.rs
+++ b/crux_cli/test_rustdoc/implicit_lib/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/crux_cli/test_rustdoc/renamed_bin/Cargo.toml
+++ b/crux_cli/test_rustdoc/renamed_bin/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "renamed_bin"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "renamed"
+path = "src/main.rs"
+
+[dependencies]

--- a/crux_cli/test_rustdoc/renamed_bin/src/main.rs
+++ b/crux_cli/test_rustdoc/renamed_bin/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crux_cli/test_rustdoc/renamed_lib/Cargo.toml
+++ b/crux_cli/test_rustdoc/renamed_lib/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "renamed_lib"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "librenamed"
+
+[dependencies]

--- a/crux_cli/test_rustdoc/renamed_lib/src/lib.rs
+++ b/crux_cli/test_rustdoc/renamed_lib/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -461,6 +461,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "cargo-manifest"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ce38d2d1efbe0e7180766a872570bc07cd5430a42e713b01006d4afa89912fe"
+dependencies = [
+ "serde",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -2356,6 +2366,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-json"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a095606d04b20308f6d7d2eb40184a3d8161552022f77473b2d55fc4098c2b7b"
+dependencies = [
+ "cargo-manifest",
+ "cargo_metadata",
+ "serde",
+ "thiserror",
+ "toml 0.7.3",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +2557,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,6 +2657,7 @@ dependencies = [
  "derive_more",
  "futures",
  "lazy_static",
+ "rustdoc-json",
  "serde",
  "serde_json",
  "thiserror",
@@ -3006,7 +3039,42 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
+ "indexmap",
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -3216,7 +3284,7 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.11",
  "uniffi_meta",
  "uniffi_testing",
  "weedle2",
@@ -3273,7 +3341,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "toml",
+ "toml 0.5.11",
  "uniffi_build",
  "uniffi_meta",
 ]
@@ -3623,6 +3691,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "winnow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "yew"

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -119,7 +119,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -461,16 +461,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "cargo-manifest"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ce38d2d1efbe0e7180766a872570bc07cd5430a42e713b01006d4afa89912fe"
-dependencies = [
- "serde",
- "toml 0.5.11",
 ]
 
 [[package]]
@@ -2366,19 +2356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustdoc-json"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a095606d04b20308f6d7d2eb40184a3d8161552022f77473b2d55fc4098c2b7b"
-dependencies = [
- "cargo-manifest",
- "cargo_metadata",
- "serde",
- "thiserror",
- "toml 0.7.3",
-]
-
-[[package]]
 name = "rustix"
 version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,15 +2534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2657,7 +2625,6 @@ dependencies = [
  "derive_more",
  "futures",
  "lazy_static",
- "rustdoc-json",
  "serde",
  "serde_json",
  "thiserror",
@@ -3039,42 +3006,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "indexmap",
  "serde",
-]
-
-[[package]]
-name = "toml"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc18466501acd8ac6a3f615dd29a3438f8ca6bb3b19537138b3106e575621274"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]
@@ -3284,7 +3216,7 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
- "toml 0.5.11",
+ "toml",
  "uniffi_meta",
  "uniffi_testing",
  "weedle2",
@@ -3341,7 +3273,7 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "toml 0.5.11",
+ "toml",
  "uniffi_build",
  "uniffi_meta",
 ]
@@ -3691,15 +3623,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
-
-[[package]]
-name = "winnow"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d020b441f92996c80d94ae9166e8501e59c7bb56121189dc9eab3bd8216966"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "yew"

--- a/examples/counter/shared/Cargo.toml
+++ b/examples/counter/shared/Cargo.toml
@@ -35,4 +35,5 @@ bcs = "0.1.5"
 uniffi = { version = "0.23.0", features = ["cli"] }
 
 [build-dependencies]
+rustdoc-json = "0.8.2"
 uniffi = { version = "0.23.0", features = ["build"] }

--- a/examples/counter/shared/Cargo.toml
+++ b/examples/counter/shared/Cargo.toml
@@ -35,5 +35,4 @@ bcs = "0.1.5"
 uniffi = { version = "0.23.0", features = ["cli"] }
 
 [build-dependencies]
-rustdoc-json = "0.8.2"
 uniffi = { version = "0.23.0", features = ["build"] }

--- a/examples/counter/shared/build.rs
+++ b/examples/counter/shared/build.rs
@@ -1,12 +1,3 @@
 fn main() {
     uniffi::generate_scaffolding("./src/shared.udl").unwrap();
-
-    // let json_path = rustdoc_json::Builder::default()
-    //     .toolchain("nightly")
-    //     .manifest_path("./Cargo.toml")
-    //     .build()
-    //     .unwrap();
-
-    // // Prints `Wrote rustdoc JSON to "/Users/martin/src/project/target/doc/project.json"`
-    // println!("Wrote rustdoc JSON to {:?}", &json_path);
 }

--- a/examples/counter/shared/build.rs
+++ b/examples/counter/shared/build.rs
@@ -1,3 +1,12 @@
 fn main() {
     uniffi::generate_scaffolding("./src/shared.udl").unwrap();
+
+    // let json_path = rustdoc_json::Builder::default()
+    //     .toolchain("nightly")
+    //     .manifest_path("./Cargo.toml")
+    //     .build()
+    //     .unwrap();
+
+    // // Prints `Wrote rustdoc JSON to "/Users/martin/src/project/target/doc/project.json"`
+    // println!("Wrote rustdoc JSON to {:?}", &json_path);
 }

--- a/examples/counter/shared/src/app.rs
+++ b/examples/counter/shared/src/app.rs
@@ -31,6 +31,7 @@ pub enum Event {
     // events local to the core
     #[serde(skip)]
     Set(crux_http::Result<crux_http::Response<Counter>>),
+    #[serde(skip)]
     WatchUpdate(Counter),
 }
 


### PR DESCRIPTION
This is a spike to see how we might use rustdoc JSON output as a basis for discovering the types we need to generate for Swift, Kotlin and TypeScript. We currently use [serde-generate](https://github.com/zefchain/serde-reflection), but it involves creating a `shared_types` library, and manually registering the types we're interested in.

We want to build a `crux` cli, that may end up with multiple subcommands that attempt to improve DX (examples could be `crux gen --swift` and `crux doctor`), so this is an experiment to see what it might look like.

It shamelessly follows (copies from) the [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks) crate, which also uses rustdoc JSON output.

- [x] generate json docs
- [ ] use [trustfall_rustdoc](https://github.com/obi1kenobi/trustfall-rustdoc) to parse the output
- [ ] use [trustfall](https://github.com/obi1kenobi/trustfall) to query the json output looking for the associated types (of the implementation of the `App` trait).
- [ ] generate foreign types in Swift (to start with)
- [ ] add serialization