### PR TITLE
Rename rustdoc::missing_doc_code_examples lint

### DIFF
--- a/crux_http/src/middleware/redirect.rs
+++ b/crux_http/src/middleware/redirect.rs
@@ -77,7 +77,7 @@ impl Redirect {
 
 #[async_trait::async_trait]
 impl Middleware for Redirect {
-    #[allow(missing_doc_code_examples)]
+    #[allow(rustdoc::missing_doc_code_examples)]
     async fn handle(
         &self,
         mut req: Request,

--- a/crux_http/src/response/decode.rs
+++ b/crux_http/src/response/decode.rs
@@ -20,7 +20,7 @@ pub struct DecodeError {
 // because it can be many megabytes large. The actual content is not that interesting anyways
 // and can be accessed manually if it is required.
 impl fmt::Debug for DecodeError {
-    #[allow(missing_doc_code_examples)]
+    #[allow(rustdoc::missing_doc_code_examples)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DecodeError")
             .field("encoding", &self.encoding)
@@ -31,7 +31,7 @@ impl fmt::Debug for DecodeError {
 }
 
 impl fmt::Display for DecodeError {
-    #[allow(missing_doc_code_examples)]
+    #[allow(rustdoc::missing_doc_code_examples)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "could not decode body as {}", &self.encoding)
     }

--- a/crux_http/src/response/response.rs
+++ b/crux_http/src/response/response.rs
@@ -292,7 +292,7 @@ impl<Body> AsMut<http::Headers> for Response<Body> {
 }
 
 impl<Body> fmt::Debug for Response<Body> {
-    #[allow(missing_doc_code_examples)]
+    #[allow(rustdoc::missing_doc_code_examples)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Response")
             .field("version", &self.version)

--- a/crux_http/src/response/response_async.rs
+++ b/crux_http/src/response/response_async.rs
@@ -358,7 +358,7 @@ impl AsMut<http::Response> for ResponseAsync {
 }
 
 impl AsyncRead for ResponseAsync {
-    #[allow(missing_doc_code_examples)]
+    #[allow(rustdoc::missing_doc_code_examples)]
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -369,7 +369,7 @@ impl AsyncRead for ResponseAsync {
 }
 
 impl fmt::Debug for ResponseAsync {
-    #[allow(missing_doc_code_examples)]
+    #[allow(rustdoc::missing_doc_code_examples)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Response")
             .field("response", &self.res)


### PR DESCRIPTION
Just noticed these warnings in `crux_http` when running tests 😄 

warning: lint `missing_doc_code_examples` has been renamed to `rustdoc::missing_doc_code_examples`

There are still warnings that the lint is unstable, but now only half as many.

Was: warning: 12 warnings emitted
Now: warning: 6 warnings emitted