### PR TITLE
feat(crux_http): added HTTPRequest::body to protocol.rs

### DIFF
--- a/crux_http/src/client.rs
+++ b/crux_http/src/client.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::http::{Method, Url};
 use crate::middleware::{Middleware, Next};
-use crate::protocol::EffectSender;
+use crate::protocol::{EffectSender, ProtocolRequestBuilder};
 use crate::{Config, Request, RequestBuilder, ResponseAsync, Result};
 
 /// An HTTP client, capable of sending `Request`s
@@ -112,7 +112,7 @@ impl Client {
 
         let next = Next::new(&mw_stack, &|req, client| {
             Box::pin(async move {
-                let req = crate::protocol::HttpRequest::from(req);
+                let req = req.into_protocol_request().await.unwrap();
                 Ok(client.effect_sender.send(req).await.into())
             })
         });
@@ -335,7 +335,8 @@ mod client_tests {
             vec![HttpRequest {
                 method: "GET".into(),
                 url: "https://example.com/".into(),
-                headers: vec![]
+                headers: vec![],
+                body: vec![],
             }]
         )
     }

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -156,7 +156,8 @@ mod tests {
                 Effect::Http(HttpRequest {
                     method: "GET".to_string(),
                     url: "http://example.com/".to_string(),
-                    headers: vec![]
+                    headers: vec![],
+                    body: vec![],
                 }),
                 Effect::Render(RenderOperation)
             ]
@@ -174,7 +175,8 @@ mod tests {
                 Effect::Http(HttpRequest {
                     method: "GET".to_string(),
                     url: "http://example.com/".to_string(),
-                    headers: vec![]
+                    headers: vec![],
+                    body: vec![],
                 }),
                 Effect::Render(RenderOperation)
             ]


### PR DESCRIPTION
Based on [this Zulip discussion](https://crux-community.zulipchat.com/#narrow/stream/373912-general/topic/http-capability) I added a request body to the protocol HTTPRequest.

Could not simply update the `impl From<crate::Request> for HttpRequest` as I needed an `async` context therefore I created a designated `trait ProtocolRequestBuilder`.

Please review ...