### PR TITLE
Run CI on PRs as well

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,9 @@ name: build
 
 on:
   push:
+  pull_request:
+    branches:
+      - master
 
 env:
   CARGO_INCREMENTAL: 0
@@ -13,6 +16,7 @@ env:
 jobs:
   build-crux:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
     steps:
       - uses: actions/checkout@v2
@@ -51,6 +55,7 @@ jobs:
 
   find-examples:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     outputs:
       examples: ${{ steps.find.outputs.examples }}
     steps:
@@ -62,6 +67,7 @@ jobs:
 
   build-examples:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     needs: find-examples
     strategy:
       matrix:


### PR DESCRIPTION
Add a trigger for the build workflow to also run on PRs (including forks). 

This should be safe to do, based on <https://securitylab.github.com/research/github-actions-preventing-pwn-requests/>
