### PR TITLE
Update docs to cover the Core API changes

### DIFF
--- a/crux_core/src/bridge/mod.rs
+++ b/crux_core/src/bridge/mod.rs
@@ -22,6 +22,8 @@ where
     pub effect: Eff,
 }
 
+/// Bridge is a core wrapper presenting the same interface as the [`Core`] but in a
+/// serialized form
 pub struct Bridge<Eff, A>
 where
     Eff: Effect,
@@ -36,6 +38,7 @@ where
     Eff: Effect + Send + 'static,
     A: App,
 {
+    /// Create a new Bridge using the provided `core`.
     pub fn new(core: Core<Eff, A>) -> Self {
         Self {
             core,
@@ -92,6 +95,7 @@ where
         bcs::to_bytes(&requests).expect("Request serialization failed.")
     }
 
+    /// Get the current state of the app's view model (serialized).
     pub fn view(&self) -> Vec<u8> {
         bcs::to_bytes(&self.core.view()).expect("View should serialize")
     }

--- a/crux_core/src/capability/mod.rs
+++ b/crux_core/src/capability/mod.rs
@@ -291,6 +291,7 @@ where
     spawner: executor::Spawner,
 }
 
+/// Initial version of capability Context which has not yet been specialized to a chosen capability
 pub struct ProtoContext<Eff, Event> {
     shell_channel: Sender<Eff>,
     app_channel: Sender<Event>,
@@ -331,7 +332,7 @@ where
     /// the effect type.
     ///
     /// This will likely only be called from the implementation of [`WithContext`]
-    /// for the app's `Capabilities` type.
+    /// for the app's `Capabilities` type. You should not need to call this function directly.
     pub fn specialize<Op, F>(&self, func: F) -> CapabilityContext<Op, Ev>
     where
         F: Fn(Request<Op>) -> Eff + Sync + Send + Copy + 'static,

--- a/crux_core/src/core/effect.rs
+++ b/crux_core/src/core/effect.rs
@@ -2,10 +2,16 @@ use serde::Serialize;
 
 use crate::bridge::ResolveBytes;
 
+/// Implemented automatically with the Effect macro from `crux_macros`.
+/// This is used by the [`Bridge`] to serialize effects going across the
+/// FFI boundary.
 pub trait Effect: Send + 'static {
     /// Ffi is an enum with variants corresponding to the Effect variants
     /// but instead of carrying a `Request<Op>` they carry the `Op` directly
     type Ffi: Serialize;
 
+    /// Converts the `Effect` into its FFI counter part and returns it alongside
+    /// A deserializing version of the resolve callback of the request that the
+    /// original `Effect` was carrying.
     fn serialize(self) -> (Self::Ffi, ResolveBytes);
 }

--- a/crux_core/src/core/effect.rs
+++ b/crux_core/src/core/effect.rs
@@ -3,15 +3,15 @@ use serde::Serialize;
 use crate::bridge::ResolveBytes;
 
 /// Implemented automatically with the Effect macro from `crux_macros`.
-/// This is used by the [`Bridge`] to serialize effects going across the
+/// This is used by the [`Bridge`](crate::bridge::Bridge) to serialize effects going across the
 /// FFI boundary.
 pub trait Effect: Send + 'static {
     /// Ffi is an enum with variants corresponding to the Effect variants
     /// but instead of carrying a `Request<Op>` they carry the `Op` directly
     type Ffi: Serialize;
 
-    /// Converts the `Effect` into its FFI counter part and returns it alongside
-    /// A deserializing version of the resolve callback of the request that the
+    /// Converts the `Effect` into its FFI counterpart and returns it alongside
+    /// a deserializing version of the resolve callback for the request that the
     /// original `Effect` was carrying.
     fn serialize(self) -> (Self::Ffi, ResolveBytes);
 }

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -14,6 +14,13 @@ use crate::capability::{self, channel::Receiver, Operation, ProtoContext, Queuin
 use crate::{App, WithContext};
 
 /// The Crux core. Create an instance of this type with your effect type, and your app type as type parameters
+///
+/// The core interface allows passing in events of type `<A as App>::Event` using [`Core::process_event`].
+/// It will return back an effect of type `Ef`, containing an effect request, with the input needed for processing
+/// the effect. the `Effect` type can be used by shells to dispatch to the right capability implementation.
+///
+/// The result of the capability's work can then be sent back to the core using [`Core::resolve`], passing
+/// in the request and the corresponding capability output type.
 pub struct Core<Ef, A>
 where
     A: App,
@@ -34,13 +41,9 @@ where
     /// Create an instance of the Crux core to start a Crux application, e.g.
     ///
     /// ```rust,ignore
-    /// lazy_static! {
-    ///     static ref CORE: Core<HelloEffect, Hello> = Core::new::<HelloCapabilities>();
-    /// }
+    /// let core: Core<HelloEffect, Hello> = Core::new::<HelloCapabilities>();
     /// ```
     ///
-    /// The core interface passes across messages serialized as bytes. These can be
-    /// deserialized in the Shell using the types generated using the [crate::typegen] module.
     pub fn new<Capabilities>() -> Self
     where
         Capabilities: WithContext<A, Ef>,
@@ -60,6 +63,8 @@ where
         }
     }
 
+    /// Run the app's `update` function with a given `event`, returing a vector of
+    /// effect requests.
     pub fn process_event(&self, event: <A as App>::Event) -> Vec<Ef> {
         let mut model = self.model.write().expect("Model RwLock was poisoned.");
 
@@ -68,6 +73,11 @@ where
         self.process()
     }
 
+    /// Resolve an effect `request` for operation `Op` with the corresponding result.
+    ///
+    /// Not that the `request` is borrowed mutably. When a request expected to only be
+    /// resolved once is passed in, it will be consumed and changed to a request which can
+    /// no longer be resolved.
     pub fn resolve<Op>(&self, request: &mut Request<Op>, result: Op::Output) -> Vec<Ef>
     where
         Op: Operation,
@@ -92,7 +102,7 @@ where
         self.requests.drain().collect()
     }
 
-    /// Get the current state of the app's view model (serialized).
+    /// Get the current state of the app's view model.
     pub fn view(&self) -> <A as App>::ViewModel {
         let model = self.model.read().expect("Model RwLock was poisoned.");
 

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -63,7 +63,7 @@ where
         }
     }
 
-    /// Run the app's `update` function with a given `event`, returing a vector of
+    /// Run the app's `update` function with a given `event`, returning a vector of
     /// effect requests.
     pub fn process_event(&self, event: <A as App>::Event) -> Vec<Ef> {
         let mut model = self.model.write().expect("Model RwLock was poisoned.");

--- a/crux_core/src/core/request.rs
+++ b/crux_core/src/core/request.rs
@@ -5,6 +5,13 @@ use crate::{
     core::resolve::{Resolve, ResolveError},
 };
 
+/// Request represents an effect request from the core to the shell.
+///
+/// The `operation` is the input needed to proces the effect, and will be one
+/// of the capabilities' [`Operation`] types.
+///
+/// The request can be resolved by passing it to `Core::resolve` along with the
+/// corresponding result of type `Operation::Output`.
 pub struct Request<Op>
 where
     Op: Operation,

--- a/crux_core/src/core/request.rs
+++ b/crux_core/src/core/request.rs
@@ -7,7 +7,7 @@ use crate::{
 
 /// Request represents an effect request from the core to the shell.
 ///
-/// The `operation` is the input needed to proces the effect, and will be one
+/// The `operation` is the input needed to process the effect, and will be one
 /// of the capabilities' [`Operation`] types.
 ///
 /// The request can be resolved by passing it to `Core::resolve` along with the

--- a/crux_core/src/core/resolve.rs
+++ b/crux_core/src/core/resolve.rs
@@ -3,7 +3,9 @@ use thiserror::Error;
 type ResolveOnce<Out> = Box<dyn FnOnce(Out) + Send>;
 type ResolveMany<Out> = Box<dyn Fn(Out) -> Result<(), ()> + Send>;
 
-pub enum Resolve<Out> {
+/// Resolve is a callback used to resolve an effect request and continue
+/// one of the capability Tasks running on the executor.
+pub(crate) enum Resolve<Out> {
     Never,
     Once(ResolveOnce<Out>),
     Many(ResolveMany<Out>),

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -166,8 +166,8 @@ pub use self::{
     core::{Core, Effect, Request},
 };
 
-/// Implement [App] on your type to make it into a Crux app. Use your type implementing [App]
-/// as the type argument to [Core] or [Bridge].
+/// Implement [`App`] on your type to make it into a Crux app. Use your type implementing [`App`]
+/// as the type argument to [`Core`] or [`Bridge`](bridge::Bridge).
 pub trait App: Default {
     /// Event, typically an `enum`, defines the actions that can be taken to update the application state.
     type Event: Send + 'static;

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -12,7 +12,7 @@
 //! ## Getting Started
 //!
 //! Crux applications are split into two parts: a Core written in Rust and a Shell written in the platform
-//! native language (e.g. Swift or Kotlin).
+//! native language (e.g. Swift or Kotlin). It is also possible to use Crux from Rust shells.
 //! The Core architecture is based on [Elm architecture](https://guide.elm-lang.org/architecture/).
 //!
 //! Quick glossary of terms to help you follow the example:
@@ -43,6 +43,7 @@
 //!
 //! use serde::{Serialize, Deserialize};
 //! use crux_core::{App, render::Render};
+//! use crux_macros::Effect;
 //!
 //! // Model describing the application state
 //! #[derive(Default)]
@@ -65,6 +66,8 @@
 //!     pub render: Render<Event>
 //! }
 //!
+//! struct Hello;
+//!
 //! impl App for Hello {
 //!     // Use the above Event
 //!     type Event = Event;
@@ -85,7 +88,7 @@
 //!         caps.render.render()
 //!     }
 //!
-//!     fn view(&self, model: &Model) -> self::ViewModel {
+//!     fn view(&self, model: &Model) -> Self::ViewModel {
 //!         format!("Count is: {}", model.count)
 //!     }
 //! }
@@ -94,7 +97,7 @@
 //! ## Integrating with a Shell
 //!
 //! To use the application in a user interface shell, you need to expose the core interface for FFI.
-//! This "plumbing" will likely be simplified with macros in the next version of Crux.
+//! This "plumbing" will likely be simplified with macros in the future versions of Crux.
 //!
 //! ```rust,ignore
 //! // src/lib.rs
@@ -103,15 +106,16 @@
 //! use lazy_static::lazy_static;
 //! use wasm_bindgen::prelude::wasm_bindgen;
 //!
-//! pub use crux_core::Request;
-//! use crux_core::Core;
+//! pub use crux_core::bridge::{Bridge, Request};
+//! pub use crux_core::Core;
+//! pub use crux_http as http;
 //!
 //! pub use app::*;
 //!
 //! uniffi_macros::include_scaffolding!("hello");
 //!
 //! lazy_static! {
-//!     static ref CORE: Core<Effect, App> = Core::new::<Capabilities>();
+//!     static ref CORE: Bridge<Effect, App> = Bridge::new(Core::new::<Capabilities>());
 //! }
 //!
 //! #[wasm_bindgen]
@@ -163,7 +167,7 @@ pub use self::{
 };
 
 /// Implement [App] on your type to make it into a Crux app. Use your type implementing [App]
-/// as the type argument to [Core].
+/// as the type argument to [Core] or [Bridge].
 pub trait App: Default {
     /// Event, typically an `enum`, defines the actions that can be taken to update the application state.
     type Event: Send + 'static;

--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -49,6 +49,10 @@ where
         self.context.updates()
     }
 
+    /// Resolve an effect `request` from previous update with an operation output.
+    ///
+    /// This potentially runs the app's `update` function if the effect is completed, and
+    /// produce another `Update`.
     pub fn resolve<Op: Operation>(
         &self,
         request: &mut Request<Op>,
@@ -109,7 +113,8 @@ impl<Ef, Ev> AppContext<Ef, Ev> {
     }
 }
 
-/// Update test helper holds the result of running an app update using [`AppTester::update`].
+/// Update test helper holds the result of running an app update using [`AppTester::update`]
+/// or resolving a request with [`AppTester::resolve`].
 #[derive(Debug)]
 pub struct Update<Ef, Ev> {
     /// Effects requested from the update run

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -18,13 +18,15 @@
 1. [Elm Architecture](./guide/elm_architecture.md)
 1. [Capabilities](./guide/capabilities.md)
    1. [Capability APIs](./guide/capability_apis.md)
+1. [Core API](./guide/core_api.md)
 1. [Message interface between core and shell](./guide/message_interface.md)
 1. [Composable Applications](./guide/composing.md)
 
 # Internals
 
+1. [Capability runtime](./internals/runtime.md)
+1. [Effect handling](./internals/effect.md)
 1. [FFI interface](./internals/uniffi.md)
-   1. [Core API](./internals/core_api.md)
-   1. [Type generation](./internals/typegen.md)
 1. [Serialization](./internals/serialization.md)
-1. [Continuations](./internals/continuations.md)
+1. [Type generation](./internals/typegen.md)
+

--- a/docs/src/getting_started/core.md
+++ b/docs/src/getting_started/core.md
@@ -102,7 +102,7 @@ Soon we will have macros and/or code-gen to help with this, but for now, we need
 Now we are in a position to create a basic app in `/shared/src/app.rs`. This is from the [simple Counter example](https://github.com/redbadger/crux/blob/master/examples/hello_world/shared/src/counter.rs) (which also has tests, although we're not showing them here):
 
 ```rust,noplayground
-{{#include ../../../examples/hello_world/shared/src/counter.rs:1:45}}
+{{#include ../../../examples/hello_world/shared/src/counter.rs:1:52}}
 ```
 
 Make sure everything builds OK

--- a/docs/src/guide/core_api.md
+++ b/docs/src/guide/core_api.md
@@ -1,4 +1,4 @@
-# Continuations
+# Core API
 
 ```admonish info
 Coming soon.

--- a/docs/src/internals/effect.md
+++ b/docs/src/internals/effect.md
@@ -1,0 +1,5 @@
+# Effects & Requests
+
+```admonish info
+Coming soon.
+```

--- a/docs/src/internals/runtime.md
+++ b/docs/src/internals/runtime.md
@@ -1,0 +1,5 @@
+# Capability Runtime
+
+```admonish info
+Coming soon.
+```


### PR DESCRIPTION
Updates the API docs and the book to reflect the recent changes to the Core API and splitting out the Bridge code.

While working on this, I've noticed there are a few types and methods which are `pub` and probably shouldn't be, and also a case of less than ideal error handling. I'll probably open another PR to tidy those bits up. 
