### PR TITLE
Surface resolve errors to Rust shells

### DIFF
--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -72,7 +72,8 @@ where
     where
         Op: Operation,
     {
-        let _ = request.resolve(result);
+        let resolve_result = request.resolve(result);
+        debug_assert!(resolve_result.is_ok());
 
         self.process()
     }


### PR DESCRIPTION
Core::resolve now returns a `Result<Vec<Effect>, ResolveError>`, so the errors don't just get swallowed.

I'm slightly on the fence about this – realistically, this is not an error that would happen occasionally at runtime, it's a design-time problem. There's also not much that can be done to handle it. It gets raised because the Shell is attempting to resolve a request that has already been resolved or never required resolving, and if it does happen, it is probably completely ok to ignore and carry on running (but needs investigating, because something is wrong with the effect handling).

This means the Shell code will be littered with somewhat unnecessary error handling. It might be better for Crux to just panic, like it does when used over the FFI bridge, and not bother the Shell code with `Result`s.

I'd love to hear your thoughts on this @obmarg, @StuartHarris.
