### PR TITLE
Make event argument of Capability trait Send

### DIFF
--- a/crux_core/src/capability/mod.rs
+++ b/crux_core/src/capability/mod.rs
@@ -224,7 +224,7 @@ pub trait Capability<Ev> {
     where
         F: Fn(NewEvent) -> Ev + Send + Sync + Copy + 'static,
         Ev: 'static,
-        NewEvent: 'static;
+        NewEvent: 'static + Send;
 }
 
 /// Allows Crux to construct app's set of required capabilities, providing context


### PR DESCRIPTION
For capabilities which return a "signal" – an event with no payload, the Event type needs to be `Send`. This adds the trait bound to the `Capability` trait` trait.
