### PR TITLE
enable windows users to build the android project

### DIFF
--- a/examples/counter/Android/shared/build.gradle
+++ b/examples/counter/Android/shared/build.gradle
@@ -74,24 +74,40 @@ afterEvaluate {
 task bindGen(type: Exec) {
     def outDir = "${projectDir}/src/main/java"
     workingDir "../../"
-    commandLine(
-            "sh", "-c",
-            """\
+    if (System.getProperty('os.name').toLowerCase().contains('windows')) {
+        commandLine(
+                "cmd", "/c",
+                "target\\debug\\uniffi-bindgen generate shared\\src\\shared.udl " +
+                        "--language kotlin " +
+                        "--out-dir " + outDir.replace('/', '\\')
+        )
+    } else {
+        commandLine(
+                "sh", "-c",
+                """\
             target/debug/uniffi-bindgen generate shared/src/shared.udl \
             --language kotlin \
             --out-dir $outDir
             """
-    )
+        )
+    }
 }
 
 task typesGen(type: Exec) {
     def outDir = "${projectDir}/src/main/java"
     def srcDir = "shared_types/generated/java/com"
     workingDir "../../"
-    commandLine(
-            "sh", "-c",
-            """\
+    if (System.getProperty('os.name').toLowerCase().contains('windows')) {
+        commandLine(
+                "cmd", "/c",
+                "xcopy /e /y " + srcDir.replace('/', '\\') + " " + outDir.replace('/', '\\')
+        )
+    } else {
+        commandLine(
+                "sh", "-c",
+                """\
             cp -r $srcDir $outDir
             """
-    )
+        )
+    }
 }

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -58,6 +58,10 @@ pnpm install
 pnpm dev
 ```
 
+### Notes:
+
+On Windows if you get "ℹ️  Installing wasm-pack" it does not work. You can solve it by installing it manually from: https://rustwasm.github.io/wasm-pack/installer/
+
 ## iOS
 
 You will need XCode, which you can get in the Mac AppStore


### PR DESCRIPTION
Hi I played around a bit with crux and I was able to build the android example with these changes.
Maybe related to #82 altough I am not even sure what effect the toolchain file actually has?

The cli example also works. The others I have not tried yet. 
I thought I will provide this and maybe a nice discussion could emerge