### PR TITLE
Add autodiscovery for type generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,7 +298,6 @@ dependencies = [
  "async-channel",
  "bcs",
  "crossbeam-channel",
- "crux_http",
  "crux_macros",
  "derive_more",
  "futures",
@@ -318,6 +317,7 @@ name = "crux_http"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "assert_fs",
  "assert_matches",
  "async-trait",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,49 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
+name = "assert_fs"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f070617a68e5c2ed5d06ee8dd620ee18fb72b99f6c094bed34cf8ab07c875b48"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
+]
 
 [[package]]
 name = "assert_matches"
@@ -176,6 +215,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +293,7 @@ name = "crux_core"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "assert_fs",
  "assert_matches",
  "async-channel",
  "bcs",
@@ -384,6 +434,24 @@ dependencies = [
  "rustc_version",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encode_unicode"
@@ -594,6 +662,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "globset"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
+dependencies = [
+ "aho-corasick 0.7.20",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -658,6 +750,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "include_dir"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +827,15 @@ dependencies = [
  "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -901,6 +1019,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "predicates"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "itertools",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1152,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+dependencies = [
+ "aho-corasick 1.0.1",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1205,15 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "semver"
@@ -1191,6 +1372,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "textwrap"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1418,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1312,6 +1522,16 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1418,6 +1638,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,11 +1669,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -28,6 +28,7 @@ uuid = { version = "1.3.2", features = ["v4", "wasm-bindgen", "js", "serde"] }
 wasm-bindgen = "0.2.84"
 
 [dev-dependencies]
+assert_fs = "1.0.13"
 assert_matches = "1.5"
 async-channel = "1.8"
 crux_macros = { version = "0.2", path = "../crux_macros" }

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -32,7 +32,6 @@ assert_fs = "1.0.13"
 assert_matches = "1.5"
 async-channel = "1.8"
 crux_macros = { version = "0.2", path = "../crux_macros" }
-crux_http = { version = "0.3", path = "../crux_http" }
 serde = { version = "1.0.160", features = ["derive"] }
 static_assertions = "1.1"
 rand = "0.8"

--- a/crux_core/src/bridge/mod.rs
+++ b/crux_core/src/bridge/mod.rs
@@ -52,7 +52,7 @@ where
     /// to your app.
     pub fn process_event<'de>(&self, event: &'de [u8]) -> Vec<u8>
     where
-        <A as App>::Event: Deserialize<'de>,
+        A::Event: Deserialize<'de>,
     {
         self.process(None, event)
     }
@@ -63,14 +63,14 @@ where
     /// The `uuid` MUST match the `uuid` of the effect that triggered it, else the core will panic.
     pub fn handle_response<'de>(&self, uuid: &[u8], output: &'de [u8]) -> Vec<u8>
     where
-        <A as App>::Event: Deserialize<'de>,
+        A::Event: Deserialize<'de>,
     {
         self.process(Some(uuid), output)
     }
 
     fn process<'de>(&self, uuid: Option<&[u8]>, data: &'de [u8]) -> Vec<u8>
     where
-        <A as App>::Event: Deserialize<'de>,
+        A::Event: Deserialize<'de>,
     {
         let effects = match uuid {
             None => {

--- a/crux_core/src/capability/mod.rs
+++ b/crux_core/src/capability/mod.rs
@@ -42,6 +42,7 @@
 //!
 //!     #[derive(Default)]
 //!     pub struct MyApp;
+//!     #[derive(Serialize, Deserialize)]
 //!     pub struct Event;
 //!
 //!     // The `Effect` derive macro generates an `Effect` type that is used by the

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -15,7 +15,7 @@ use crate::{App, WithContext};
 
 /// The Crux core. Create an instance of this type with your effect type, and your app type as type parameters
 ///
-/// The core interface allows passing in events of type `<A as App>::Event` using [`Core::process_event`].
+/// The core interface allows passing in events of type `A::Event` using [`Core::process_event`].
 /// It will return back an effect of type `Ef`, containing an effect request, with the input needed for processing
 /// the effect. the `Effect` type can be used by shells to dispatch to the right capability implementation.
 ///
@@ -65,7 +65,7 @@ where
 
     /// Run the app's `update` function with a given `event`, returning a vector of
     /// effect requests.
-    pub fn process_event(&self, event: <A as App>::Event) -> Vec<Ef> {
+    pub fn process_event(&self, event: A::Event) -> Vec<Ef> {
         let mut model = self.model.write().expect("Model RwLock was poisoned.");
 
         self.app.update(event, &mut model, &self.capabilities);
@@ -103,7 +103,7 @@ where
     }
 
     /// Get the current state of the app's view model.
-    pub fn view(&self) -> <A as App>::ViewModel {
+    pub fn view(&self) -> A::ViewModel {
         let model = self.model.read().expect("Model RwLock was poisoned.");
 
         self.app.view(&model)

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -158,7 +158,7 @@ pub mod typegen;
 mod capabilities;
 mod core;
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 pub use self::{
     capabilities::*,
@@ -170,12 +170,12 @@ pub use self::{
 /// as the type argument to [`Core`] or [`Bridge`](bridge::Bridge).
 pub trait App: Default {
     /// Event, typically an `enum`, defines the actions that can be taken to update the application state.
-    type Event: Send + Deserialize<'static> + 'static;
+    type Event: Send + 'static;
     /// Model, typically a `struct` defines the internal state of the application
     type Model: Default;
     /// ViewModel, typically a `struct` describes the user interface that should be
     /// displayed to the user
-    type ViewModel: Serialize + Deserialize<'static> + 'static;
+    type ViewModel: Serialize;
     /// Capabilities, typically a `struct`, lists the capabilities used by this application
     /// Typically, Capabilities should contain at least an instance of the built-in [`Render`](crate::render::Render) capability.
     type Capabilities;

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -158,7 +158,7 @@ pub mod typegen;
 mod capabilities;
 mod core;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 pub use self::{
     capabilities::*,
@@ -170,12 +170,12 @@ pub use self::{
 /// as the type argument to [`Core`] or [`Bridge`](bridge::Bridge).
 pub trait App: Default {
     /// Event, typically an `enum`, defines the actions that can be taken to update the application state.
-    type Event: Send + 'static;
+    type Event: Send + Deserialize<'static> + 'static;
     /// Model, typically a `struct` defines the internal state of the application
     type Model: Default;
     /// ViewModel, typically a `struct` describes the user interface that should be
     /// displayed to the user
-    type ViewModel: Serialize;
+    type ViewModel: Serialize + Deserialize<'static> + 'static;
     /// Capabilities, typically a `struct`, lists the capabilities used by this application
     /// Typically, Capabilities should contain at least an instance of the built-in [`Render`](crate::render::Render) capability.
     type Capabilities;

--- a/crux_core/src/typegen.rs
+++ b/crux_core/src/typegen.rs
@@ -89,6 +89,7 @@
 //! }
 //! ```
 
+use serde::Deserialize;
 use serde_generate::Encoding;
 use serde_reflection::{Registry, Tracer, TracerConfig};
 use std::{
@@ -169,6 +170,8 @@ impl TypeGen {
     pub fn register_app<A: App>(&mut self) -> Result
     where
         <A as App>::Capabilities: Export,
+        A::Event: Deserialize<'static>,
+        A::ViewModel: Deserialize<'static> + 'static,
     {
         self.register_type::<A::Event>()?;
         self.register_type::<A::ViewModel>()?;

--- a/crux_core/src/typegen.rs
+++ b/crux_core/src/typegen.rs
@@ -182,7 +182,7 @@ impl TypeGen {
                 for sample in &sample_data {
                     match tracer.trace_value::<T>(samples, sample) {
                         Ok(_) => {}
-                        Err(e) => return Err(TypeGenError::ValueTracing(e.to_string())),
+                        Err(e) => return Err(TypeGenError::ValueTracing(e.explanation())),
                     }
                 }
                 Ok(())
@@ -222,9 +222,9 @@ impl TypeGen {
             State::Registering(tracer, _) => match tracer.trace_simple_type::<T>() {
                 Ok(_) => Ok(()),
                 Err(e @ serde_reflection::Error::DeserializationError(_)) => {
-                    Err(TypeGenError::Deserialization(e.to_string()))
+                    Err(TypeGenError::Deserialization(e.explanation()))
                 }
-                Err(e) => Err(TypeGenError::TypeTracing(e.to_string())),
+                Err(e) => Err(TypeGenError::TypeTracing(e.explanation())),
             },
             _ => Err(TypeGenError::LateRegistration),
         }
@@ -267,18 +267,18 @@ impl TypeGen {
                     match tracer.trace_value::<T>(samples, sample) {
                         Ok(_) => {}
                         Err(e @ serde_reflection::Error::DeserializationError(_)) => {
-                            return Err(TypeGenError::ValueTracing(e.to_string()))
+                            return Err(TypeGenError::ValueTracing(e.explanation()))
                         }
-                        Err(e) => return Err(TypeGenError::ValueTracing(e.to_string())),
+                        Err(e) => return Err(TypeGenError::ValueTracing(e.explanation())),
                     }
                 }
 
                 match tracer.trace_type::<T>(samples) {
                     Ok(_) => Ok(()),
                     Err(e @ serde_reflection::Error::DeserializationError(_)) => {
-                        Err(TypeGenError::Deserialization(e.to_string()))
+                        Err(TypeGenError::Deserialization(e.explanation()))
                     }
-                    Err(e) => Err(TypeGenError::TypeTracing(e.to_string())),
+                    Err(e) => Err(TypeGenError::TypeTracing(e.explanation())),
                 }
             }
             _ => Err(TypeGenError::LateRegistration),
@@ -459,7 +459,7 @@ impl TypeGen {
                 self.state = State::Generating(
                     tracer
                         .registry()
-                        .map_err(|e| TypeGenError::Generation(e.to_string()))?,
+                        .map_err(|e| TypeGenError::Generation(e.explanation()))?,
                 );
             }
         }

--- a/crux_core/src/typegen.rs
+++ b/crux_core/src/typegen.rs
@@ -53,8 +53,6 @@
 //!fn generate_types() {
 //!    let mut gen = TypeGen::new();
 //!
-//!    gen.register_type::<Request<EffectFfi>>().unwrap();
-//!
 //!    let sample_events = vec![Event::SendUuid(Uuid::new_v4())];
 //!    gen.register_type_with_samples(sample_events).unwrap();
 //!
@@ -194,25 +192,18 @@ impl TypeGen {
     /// e.g.
     /// ```rust
     /// # use crux_core::typegen::TypeGen;
-    /// # use std::marker::PhantomData;
     /// # use serde::{Serialize, Deserialize};
     /// # use anyhow::Error;
-    /// # #[derive(Serialize, Deserialize)]
-    /// # struct Request<T> { phantom: PhantomData<T> }
-    /// # #[derive(Serialize, Deserialize)]
-    /// # struct Effect {}
-    /// # #[derive(Serialize, Deserialize)]
-    /// # struct Event {}
-    /// # #[derive(Serialize, Deserialize)]
-    /// # struct ViewModel {}
-    /// # fn register() -> Result<(), Error> {
-    /// # let mut gen = TypeGen::new();
-    ///   gen.register_type::<Request<Effect>>()?;
-    ///   gen.register_type::<Effect>()?;
-    ///   gen.register_type::<Event>()?;
-    ///   gen.register_type::<ViewModel>()?;
-    /// # Ok(())
-    /// # }
+    /// #[derive(Serialize, Deserialize)]
+    /// enum MyNestedEnum { None }
+    /// #[derive(Serialize, Deserialize)]
+    /// enum MyEnum { None, Nested(MyNestedEnum) }
+    /// fn register() -> Result<(), Error> {
+    ///   let mut gen = TypeGen::new();
+    ///   gen.register_type::<MyEnum>()?;
+    ///   gen.register_type::<MyNestedEnum>()?;
+    ///   Ok(())
+    /// }
     /// ```
     pub fn register_type<'de, T>(&mut self) -> Result
     where

--- a/crux_core/src/typegen.rs
+++ b/crux_core/src/typegen.rs
@@ -143,9 +143,10 @@ impl TypeGen {
     /// Register all the types used in app `A` to be shared with the Shell.
     ///
     /// Do this before calling TypeGen::swift, TypeGen::java or TypeGen::typescript.
-    /// This method would normally be called in a build.rs file of a sister create responsible for
+    /// This method would normally be called in a build.rs file of a sister crate responsible for
     /// creating "foreign language" type definitions for the FFI boundary.
-    /// See the [section on creating the shared types crate](https://redbadger.github.io/crux/getting_started/core.html#create-the-shared-types-crate)
+    /// See the section on
+    /// [creating the shared types crate](https://redbadger.github.io/crux/getting_started/core.html#create-the-shared-types-crate)
     /// in the Crux book for more information.
     pub fn register_app<A: App>(&mut self) -> Result<()>
     where
@@ -164,7 +165,8 @@ impl TypeGen {
     /// and as part of the process runs a faux deserialization on each of them, with a best
     /// guess of a default value. If that default value does not deserialize, the type registration
     /// will fail.
-    /// You can prevent this problem by registering a valid sample value (or values) which the deserialization will use instead.
+    /// You can prevent this problem by registering a valid sample value (or values),
+    /// which the deserialization will use instead.
     pub fn register_samples<'de, T>(&'de mut self, sample_data: Vec<T>) -> Result<()>
     where
         T: serde::Deserialize<'de> + serde::Serialize + std::fmt::Debug,
@@ -241,7 +243,7 @@ impl TypeGen {
     /// # use uuid::Uuid;
     /// # use serde::{Serialize, Deserialize};
     /// # use anyhow::Error;
-    /// # #[derive(Serialize, Deserialize)]
+    /// # #[derive(Serialize, Deserialize, Debug)]
     /// # struct MyUuid(Uuid);
     /// # fn register() -> Result<(), Error> {
     /// # let mut gen = TypeGen::new();
@@ -256,7 +258,7 @@ impl TypeGen {
     /// that does not use custom deserialization.
     pub fn register_type_with_samples<'de, T>(&'de mut self, sample_data: Vec<T>) -> Result<()>
     where
-        T: serde::Deserialize<'de> + serde::Serialize + std::fmt::Debug,
+        T: serde::Deserialize<'de> + serde::Serialize,
     {
         match &mut self.state {
             State::Registering(tracer, samples) => {

--- a/crux_core/src/typegen.rs
+++ b/crux_core/src/typegen.rs
@@ -10,7 +10,7 @@
 //!
 //! ```rust,ignore
 //! [build-dependencies]
-//! crux_core = { version = "0.3", features = ["typegen"] }
+//! crux_core = { version = "0.4", features = ["typegen"] }
 //! ```
 //!
 //! * Your `shared_types` library, will have an empty `lib.rs`, since we only use it for generating foreign language type declarations.

--- a/crux_core/tests/typegen.rs
+++ b/crux_core/tests/typegen.rs
@@ -1,5 +1,5 @@
 mod shared {
-    use crux_http::Http;
+    use crux_core::render::Render;
     use crux_macros::Effect;
     use serde::{Deserialize, Serialize};
 
@@ -11,6 +11,7 @@ mod shared {
         None,
         SendUuid(uuid::Uuid),
     }
+
     #[derive(Serialize, Deserialize)]
     pub struct ViewModel;
     impl crux_core::App for App {
@@ -20,15 +21,16 @@ mod shared {
         type Capabilities = Capabilities;
         fn update(&self, _event: Event, _model: &mut Self::Model, _caps: &Capabilities) {}
         fn view(&self, _model: &Self::Model) -> Self::ViewModel {
-            todo!();
+            unimplemented!();
         }
     }
 
     #[derive(Effect)]
     pub struct Capabilities {
-        pub http: Http<Event>,
+        pub render: Render<Event>,
     }
 }
+
 mod test {
     use super::shared::{App, EffectFfi, Event};
     use crux_core::{bridge::Request, typegen::TypeGen};
@@ -83,7 +85,6 @@ mod test {
         assert!(registry.contains_key("Event"));
         assert!(registry.contains_key("ViewModel"));
 
-        assert!(registry.contains_key("HttpRequest"));
-        assert!(registry.contains_key("HttpResponse"));
+        assert!(registry.contains_key("RenderOperation"));
     }
 }

--- a/crux_core/tests/typegen.rs
+++ b/crux_core/tests/typegen.rs
@@ -30,17 +30,9 @@ mod shared {
     }
 }
 mod test {
-    use super::shared::{App, Capabilities, EffectFfi, Event, ViewModel};
-    use crux_core::{
-        bridge::Request,
-        capability::Operation,
-        typegen::{Export, TypeGen},
-        Capability,
-    };
-    use crux_http::{
-        protocol::{HttpRequest, HttpResponse},
-        Http,
-    };
+    use super::shared::{App, EffectFfi, Event, ViewModel};
+    use crux_core::{bridge::Request, typegen::TypeGen};
+    use crux_http::protocol::{HttpRequest, HttpResponse};
     use uuid::Uuid;
 
     // FIXME this test is quite slow
@@ -71,17 +63,6 @@ mod test {
 
         gen.typescript("shared_types", output_root.join("typescript"))
             .expect("typescript type gen failed");
-    }
-
-    impl Export for Capabilities {
-        fn register_types(generator: &mut TypeGen) -> anyhow::Result<()> {
-            // for each capability
-            generator.register_type::<<Http<Event> as Capability<Event>>::Operation>()?;
-            generator
-                .register_type::<<<Http<Event> as Capability<Event>>::Operation as Operation>::Output>()?;
-
-            Ok(())
-        }
     }
 
     #[test]

--- a/crux_core/tests/typegen.rs
+++ b/crux_core/tests/typegen.rs
@@ -30,9 +30,8 @@ mod shared {
     }
 }
 mod test {
-    use super::shared::{App, EffectFfi, Event, ViewModel};
+    use super::shared::{App, EffectFfi, Event};
     use crux_core::{bridge::Request, typegen::TypeGen};
-    use crux_http::protocol::{HttpRequest, HttpResponse};
     use uuid::Uuid;
 
     // FIXME this test is quite slow
@@ -42,15 +41,10 @@ mod test {
 
         gen.register_type::<Request<EffectFfi>>().unwrap();
 
-        gen.register_type::<EffectFfi>().unwrap();
-        gen.register_type::<HttpRequest>().unwrap();
-
         let sample_events = vec![Event::SendUuid(Uuid::new_v4())];
         gen.register_type_with_samples(sample_events).unwrap();
 
-        gen.register_type::<HttpResponse>().unwrap();
-
-        gen.register_type::<ViewModel>().unwrap();
+        gen.register_app::<App>().unwrap();
 
         let temp = assert_fs::TempDir::new().unwrap();
         let output_root = temp.join("crux_core_typegen_test");

--- a/crux_core/tests/typegen.rs
+++ b/crux_core/tests/typegen.rs
@@ -32,16 +32,14 @@ mod shared {
 }
 
 mod test {
-    use super::shared::{App, EffectFfi, Event};
-    use crux_core::{bridge::Request, typegen::TypeGen};
+    use super::shared::{App, Event};
+    use crux_core::typegen::TypeGen;
     use uuid::Uuid;
 
     // FIXME this test is quite slow
     #[test]
     fn generate_types() {
         let mut gen = TypeGen::new();
-
-        gen.register_type::<Request<EffectFfi>>().unwrap();
 
         let sample_events = vec![Event::SendUuid(Uuid::new_v4())];
         gen.register_type_with_samples(sample_events).unwrap();

--- a/crux_core/tests/typegen.rs
+++ b/crux_core/tests/typegen.rs
@@ -1,6 +1,6 @@
 mod shared {
     use crux_core::render::Render;
-    use crux_macros::Effect;
+    use crux_macros::{Effect, Export};
     use serde::{Deserialize, Serialize};
 
     #[derive(Default)]
@@ -25,7 +25,7 @@ mod shared {
         }
     }
 
-    #[derive(Effect)]
+    #[derive(Effect, Export)]
     pub struct Capabilities {
         pub render: Render<Event>,
     }

--- a/crux_core/tests/typegen.rs
+++ b/crux_core/tests/typegen.rs
@@ -61,6 +61,8 @@ mod test {
             .expect("typescript type gen failed");
     }
 
+    // TODO: instead of using the Render capability here, it would be better to also test against a custom
+    // capability that has an output type
     #[test]
     fn test_autodiscovery() {
         let mut gen = TypeGen::new();
@@ -85,6 +87,7 @@ mod test {
         assert!(registry.contains_key("Event"));
         assert!(registry.contains_key("ViewModel"));
 
+        assert!(registry.contains_key("Effect"));
         assert!(registry.contains_key("RenderOperation"));
     }
 }

--- a/crux_core/tests/typegen.rs
+++ b/crux_core/tests/typegen.rs
@@ -41,7 +41,6 @@ mod test {
         protocol::{HttpRequest, HttpResponse},
         Http,
     };
-    use std::env::temp_dir;
     use uuid::Uuid;
 
     // FIXME this test is quite slow
@@ -61,7 +60,8 @@ mod test {
 
         gen.register_type::<ViewModel>().unwrap();
 
-        let output_root = temp_dir().join("crux_core_typegen_test");
+        let temp = assert_fs::TempDir::new().unwrap();
+        let output_root = temp.join("crux_core_typegen_test");
 
         gen.swift("shared_types", output_root.join("swift"))
             .expect("swift type gen failed");
@@ -88,7 +88,7 @@ mod test {
     fn test_autodiscovery() {
         let mut gen = TypeGen::new();
 
-        gen.register_type_with_samples(vec![Event::SendUuid(Uuid::new_v4())])
+        gen.register_samples(vec![Event::SendUuid(Uuid::new_v4())])
             .unwrap();
 
         gen.register_app::<App>()

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -10,6 +10,9 @@ license.workspace = true
 keywords.workspace = true
 rust-version.workspace = true
 
+[features]
+typegen = ["crux_core/typegen"]
+
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1.68"
@@ -23,6 +26,7 @@ serde_json = "1.0.96"
 url = "2.3.1"
 
 [dev-dependencies]
+assert_fs = "1.0.13"
 futures-test = "0.3"
 assert_matches = "1.5"
 crux_macros = { version = "0.2", path = "../crux_macros" }

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -29,4 +29,5 @@ url = "2.3.1"
 assert_fs = "1.0.13"
 futures-test = "0.3"
 assert_matches = "1.5"
+crux_core = { version = "0.4", path = "../crux_core", features = ["typegen"] }
 crux_macros = { version = "0.2", path = "../crux_macros" }

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -10,9 +10,6 @@ license.workspace = true
 keywords.workspace = true
 rust-version.workspace = true
 
-[features]
-typegen = ["crux_core/typegen"]
-
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1.68"

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -134,11 +134,11 @@ mod shell {
 
 mod tests {
     use crate::{
-        shared::{App, Effect, EffectFfi, Event},
+        shared::{App, Effect, Event},
         shell::run,
     };
     use anyhow::Result;
-    use crux_core::{bridge::Request, typegen::TypeGen, Core};
+    use crux_core::{typegen::TypeGen, Core};
     use crux_http::protocol::HttpRequest;
 
     #[test]
@@ -186,8 +186,6 @@ mod tests {
     #[test]
     fn generate_types() {
         let mut gen = TypeGen::new();
-
-        gen.register_type::<Request<EffectFfi>>().unwrap();
 
         gen.register_app::<App>().unwrap();
 

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -1,7 +1,7 @@
 mod shared {
     use crux_core::render::Render;
     use crux_http::Http;
-    use crux_macros::Effect;
+    use crux_macros::{Effect, Export};
     use serde::{Deserialize, Serialize};
 
     #[derive(Default)]
@@ -74,7 +74,7 @@ mod shared {
         }
     }
 
-    #[derive(Effect)]
+    #[derive(Effect, Export)]
     pub(crate) struct Capabilities {
         pub http: Http<Event>,
         pub render: Render<Event>,

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -130,11 +130,11 @@ mod shell {
 
 mod tests {
     use crate::{
-        shared::{App, Effect, Event},
+        shared::{App, Effect, EffectFfi, Event},
         shell::run,
     };
     use anyhow::Result;
-    use crux_core::Core;
+    use crux_core::{bridge::Request, typegen::TypeGen, Core};
     use crux_http::protocol::HttpRequest;
 
     #[test]
@@ -177,5 +177,26 @@ mod tests {
         );
         assert_eq!(core.view().result, "Status: 0, Body: , Json Body: Hello");
         Ok(())
+    }
+
+    #[test]
+    fn generate_types() {
+        let mut gen = TypeGen::new();
+
+        gen.register_type::<Request<EffectFfi>>().unwrap();
+
+        gen.register_app::<App>().unwrap();
+
+        let temp = assert_fs::TempDir::new().unwrap();
+        let output_root = temp.join("crux_http_typegen_test");
+
+        gen.swift("shared_types", output_root.join("swift"))
+            .expect("swift type gen failed");
+
+        gen.java("com.example.counter.shared_types", output_root.join("java"))
+            .expect("java type gen failed");
+
+        gen.typescript("shared_types", output_root.join("typescript"))
+            .expect("typescript type gen failed");
     }
 }

--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -116,6 +116,7 @@ impl ToTokens for EffectStructReceiver {
                     #(#output_type_exports)*
 
                     generator.register_type::<#ffi_effect_name>()?;
+                    generator.register_type::<::crux_core::bridge::Request<#ffi_effect_name>>()?;
 
                     Ok(())
                 }
@@ -234,6 +235,7 @@ mod tests {
                         >>::Operation as ::crux_core::capability::Operation>::Output,
                     >()?;
                 generator.register_type::<EffectFfi>()?;
+                generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
                 Ok(())
             }
         }
@@ -430,6 +432,7 @@ mod tests {
                         >>::Operation as ::crux_core::capability::Operation>::Output,
                     >()?;
                 generator.register_type::<MyEffectFfi>()?;
+                generator.register_type::<::crux_core::bridge::Request<MyEffectFfi>>()?;
                 Ok(())
             }
         }

--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -121,6 +121,13 @@ impl ToTokens for EffectStructReceiver {
                     Ok(())
                 }
             }
+
+            #[cfg(not(feature = "typegen"))]
+            impl ::crux_core::typegen::Export for #ident {
+                fn register_types(generator: &mut ::crux_core::typegen::TypeGen) -> ::crux_core::typegen::Result {
+                    Err(::crux_core::typegen::TypeGenError::TypeTracing("you should import your shared library with the `typegen` feature enabled".to_string()))
+                }
+            }
         })
     }
 }

--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -223,6 +223,10 @@ mod tests {
             ) -> ::crux_core::typegen::Result {
                 generator
                     .register_type::<
+                        <Render<Event> as ::crux_core::capability::Capability<Event>>::Operation,
+                    >()?;
+                generator
+                    .register_type::<
                         <<Render<
                             Event,
                         > as ::crux_core::capability::Capability<
@@ -357,11 +361,23 @@ mod tests {
             ) -> ::crux_core::typegen::Result {
                 generator
                     .register_type::<
+                        <crux_http::Http<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                    >()?;
+                generator
+                    .register_type::<
                         <<crux_http::Http<
                             MyEvent,
                         > as ::crux_core::capability::Capability<
                             MyEvent,
                         >>::Operation as ::crux_core::capability::Operation>::Output,
+                    >()?;
+                generator
+                    .register_type::<
+                        <KeyValue<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
                     >()?;
                 generator
                     .register_type::<
@@ -373,6 +389,12 @@ mod tests {
                     >()?;
                 generator
                     .register_type::<
+                        <Platform<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                    >()?;
+                generator
+                    .register_type::<
                         <<Platform<
                             MyEvent,
                         > as ::crux_core::capability::Capability<
@@ -381,11 +403,23 @@ mod tests {
                     >()?;
                 generator
                     .register_type::<
+                        <Render<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                    >()?;
+                generator
+                    .register_type::<
                         <<Render<
                             MyEvent,
                         > as ::crux_core::capability::Capability<
                             MyEvent,
                         >>::Operation as ::crux_core::capability::Operation>::Output,
+                    >()?;
+                generator
+                    .register_type::<
+                        <Time<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
                     >()?;
                 generator
                     .register_type::<

--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -246,6 +246,19 @@ mod tests {
                 Ok(())
             }
         }
+        #[cfg(not(feature = "typegen"))]
+        impl ::crux_core::typegen::Export for Capabilities {
+            fn register_types(
+                generator: &mut ::crux_core::typegen::TypeGen,
+            ) -> ::crux_core::typegen::Result {
+                Err(
+                    ::crux_core::typegen::TypeGenError::TypeTracing(
+                        "you should import your shared library with the `typegen` feature enabled"
+                            .to_string(),
+                    ),
+                )
+            }
+        }
         "###);
     }
 
@@ -441,6 +454,19 @@ mod tests {
                 generator.register_type::<MyEffectFfi>()?;
                 generator.register_type::<::crux_core::bridge::Request<MyEffectFfi>>()?;
                 Ok(())
+            }
+        }
+        #[cfg(not(feature = "typegen"))]
+        impl ::crux_core::typegen::Export for MyCapabilities {
+            fn register_types(
+                generator: &mut ::crux_core::typegen::TypeGen,
+            ) -> ::crux_core::typegen::Result {
+                Err(
+                    ::crux_core::typegen::TypeGenError::TypeTracing(
+                        "you should import your shared library with the `typegen` feature enabled"
+                            .to_string(),
+                    ),
+                )
             }
         }
         "###);

--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -74,6 +74,7 @@ impl ToTokens for EffectStructReceiver {
             ffi_variants.push(quote! { #variant(<#capability<#event> as ::crux_core::capability::Capability<#event>>::Operation) });
             match_arms.push(quote! { #effect_name::#variant(request) => request.serialize(#ffi_effect_name::#variant) });
             output_type_exports.push(quote! {
+                generator.register_type::<<#capability<#event> as ::crux_core::capability::Capability<#event>>::Operation>()?;
                 generator
                     .register_type::<<<#capability<#event> as ::crux_core::capability::Capability<#event>>::Operation as ::crux_core::capability::Operation>::Output>()?;
             });

--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -66,18 +66,12 @@ impl ToTokens for EffectStructReceiver {
         let mut with_context_fields = Vec::new();
         let mut ffi_variants = Vec::new();
         let mut match_arms = Vec::new();
-        let mut output_type_exports = Vec::new();
 
         for (field_name, (capability, variant, event)) in fields.iter() {
             variants.push(quote! { #variant(::crux_core::Request<<#capability<#event> as ::crux_core::capability::Capability<#event>>::Operation>) });
             with_context_fields.push(quote! { #field_name: #capability::new(context.specialize(#effect_name::#variant)) });
             ffi_variants.push(quote! { #variant(<#capability<#event> as ::crux_core::capability::Capability<#event>>::Operation) });
             match_arms.push(quote! { #effect_name::#variant(request) => request.serialize(#ffi_effect_name::#variant) });
-            output_type_exports.push(quote! {
-                generator.register_type::<<#capability<#event> as ::crux_core::capability::Capability<#event>>::Operation>()?;
-                generator
-                    .register_type::<<<#capability<#event> as ::crux_core::capability::Capability<#event>>::Operation as ::crux_core::capability::Operation>::Output>()?;
-            });
         }
 
         tokens.extend(quote! {
@@ -107,25 +101,6 @@ impl ToTokens for EffectStructReceiver {
                     #ident {
                         #(#with_context_fields ,)*
                     }
-                }
-            }
-
-            #[cfg(feature = "typegen")]
-            impl ::crux_core::typegen::Export for #ident {
-                fn register_types(generator: &mut ::crux_core::typegen::TypeGen) -> ::crux_core::typegen::Result {
-                    #(#output_type_exports)*
-
-                    generator.register_type::<#ffi_effect_name>()?;
-                    generator.register_type::<::crux_core::bridge::Request<#ffi_effect_name>>()?;
-
-                    Ok(())
-                }
-            }
-
-            #[cfg(not(feature = "typegen"))]
-            impl ::crux_core::typegen::Export for #ident {
-                fn register_types(generator: &mut ::crux_core::typegen::TypeGen) -> ::crux_core::typegen::Result {
-                    Err(::crux_core::typegen::TypeGenError::TypeTracing("you should import your shared library with the `typegen` feature enabled".to_string()))
                 }
             }
         })
@@ -222,41 +197,6 @@ mod tests {
                 Capabilities {
                     render: Render::new(context.specialize(Effect::Render)),
                 }
-            }
-        }
-        #[cfg(feature = "typegen")]
-        impl ::crux_core::typegen::Export for Capabilities {
-            fn register_types(
-                generator: &mut ::crux_core::typegen::TypeGen,
-            ) -> ::crux_core::typegen::Result {
-                generator
-                    .register_type::<
-                        <Render<Event> as ::crux_core::capability::Capability<Event>>::Operation,
-                    >()?;
-                generator
-                    .register_type::<
-                        <<Render<
-                            Event,
-                        > as ::crux_core::capability::Capability<
-                            Event,
-                        >>::Operation as ::crux_core::capability::Operation>::Output,
-                    >()?;
-                generator.register_type::<EffectFfi>()?;
-                generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
-                Ok(())
-            }
-        }
-        #[cfg(not(feature = "typegen"))]
-        impl ::crux_core::typegen::Export for Capabilities {
-            fn register_types(
-                generator: &mut ::crux_core::typegen::TypeGen,
-            ) -> ::crux_core::typegen::Result {
-                Err(
-                    ::crux_core::typegen::TypeGenError::TypeTracing(
-                        "you should import your shared library with the `typegen` feature enabled"
-                            .to_string(),
-                    ),
-                )
             }
         }
         "###);
@@ -374,99 +314,6 @@ mod tests {
                     render: Render::new(context.specialize(MyEffect::Render)),
                     time: Time::new(context.specialize(MyEffect::Time)),
                 }
-            }
-        }
-        #[cfg(feature = "typegen")]
-        impl ::crux_core::typegen::Export for MyCapabilities {
-            fn register_types(
-                generator: &mut ::crux_core::typegen::TypeGen,
-            ) -> ::crux_core::typegen::Result {
-                generator
-                    .register_type::<
-                        <crux_http::Http<
-                            MyEvent,
-                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
-                    >()?;
-                generator
-                    .register_type::<
-                        <<crux_http::Http<
-                            MyEvent,
-                        > as ::crux_core::capability::Capability<
-                            MyEvent,
-                        >>::Operation as ::crux_core::capability::Operation>::Output,
-                    >()?;
-                generator
-                    .register_type::<
-                        <KeyValue<
-                            MyEvent,
-                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
-                    >()?;
-                generator
-                    .register_type::<
-                        <<KeyValue<
-                            MyEvent,
-                        > as ::crux_core::capability::Capability<
-                            MyEvent,
-                        >>::Operation as ::crux_core::capability::Operation>::Output,
-                    >()?;
-                generator
-                    .register_type::<
-                        <Platform<
-                            MyEvent,
-                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
-                    >()?;
-                generator
-                    .register_type::<
-                        <<Platform<
-                            MyEvent,
-                        > as ::crux_core::capability::Capability<
-                            MyEvent,
-                        >>::Operation as ::crux_core::capability::Operation>::Output,
-                    >()?;
-                generator
-                    .register_type::<
-                        <Render<
-                            MyEvent,
-                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
-                    >()?;
-                generator
-                    .register_type::<
-                        <<Render<
-                            MyEvent,
-                        > as ::crux_core::capability::Capability<
-                            MyEvent,
-                        >>::Operation as ::crux_core::capability::Operation>::Output,
-                    >()?;
-                generator
-                    .register_type::<
-                        <Time<
-                            MyEvent,
-                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
-                    >()?;
-                generator
-                    .register_type::<
-                        <<Time<
-                            MyEvent,
-                        > as ::crux_core::capability::Capability<
-                            MyEvent,
-                        >>::Operation as ::crux_core::capability::Operation>::Output,
-                    >()?;
-                generator.register_type::<MyEffectFfi>()?;
-                generator.register_type::<::crux_core::bridge::Request<MyEffectFfi>>()?;
-                Ok(())
-            }
-        }
-        #[cfg(not(feature = "typegen"))]
-        impl ::crux_core::typegen::Export for MyCapabilities {
-            fn register_types(
-                generator: &mut ::crux_core::typegen::TypeGen,
-            ) -> ::crux_core::typegen::Result {
-                Err(
-                    ::crux_core::typegen::TypeGenError::TypeTracing(
-                        "you should import your shared library with the `typegen` feature enabled"
-                            .to_string(),
-                    ),
-                )
             }
         }
         "###);

--- a/crux_macros/src/export.rs
+++ b/crux_macros/src/export.rs
@@ -1,0 +1,267 @@
+use darling::{ast, util, FromDeriveInput, FromField, ToTokens};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{DeriveInput, GenericArgument, Ident, PathArguments, Type};
+
+#[derive(FromDeriveInput, Debug)]
+#[darling(supports(struct_named))]
+struct ExportStructReceiver {
+    ident: Ident,
+    name: Option<Ident>,
+    data: ast::Data<util::Ignored, ExportFieldReceiver>,
+}
+
+#[derive(FromField, Debug)]
+pub struct ExportFieldReceiver {
+    ty: Type,
+}
+
+impl ToTokens for ExportStructReceiver {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let ident = &self.ident;
+
+        let ffi_export_name = match self.name {
+            Some(ref name) => {
+                let ffi_ef_name = format_ident!("{}Ffi", name);
+
+                quote!(#ffi_ef_name)
+            }
+            None => quote!(EffectFfi),
+        };
+
+        let fields = self
+            .data
+            .as_ref()
+            .take_struct()
+            .expect("Should never be enum")
+            .fields;
+
+        let mut output_type_exports = Vec::new();
+
+        for (capability, event) in fields.iter().map(|f| split_on_generic(&f.ty)) {
+            output_type_exports.push(quote! {
+                generator.register_type::<<#capability<#event> as ::crux_core::capability::Capability<#event>>::Operation>()?;
+                generator
+                    .register_type::<<<#capability<#event> as ::crux_core::capability::Capability<#event>>::Operation as ::crux_core::capability::Operation>::Output>()?;
+            });
+        }
+
+        tokens.extend(quote! {
+            impl ::crux_core::typegen::Export for #ident {
+                fn register_types(generator: &mut ::crux_core::typegen::TypeGen) -> ::crux_core::typegen::Result {
+                    #(#output_type_exports)*
+
+                    generator.register_type::<#ffi_export_name>()?;
+                    generator.register_type::<::crux_core::bridge::Request<#ffi_export_name>>()?;
+
+                    Ok(())
+                }
+            }
+        })
+    }
+}
+
+pub(crate) fn export_impl(input: &DeriveInput) -> TokenStream {
+    let input = match ExportStructReceiver::from_derive_input(input) {
+        Ok(v) => v,
+        Err(e) => {
+            return e.write_errors();
+        }
+    };
+
+    quote!(#input)
+}
+
+fn split_on_generic(ty: &Type) -> (Type, Type) {
+    let ty = ty.clone();
+    match ty {
+        Type::Path(mut path) if path.qself.is_none() => {
+            // Get the last segment of the path where the generic parameter should be
+
+            let last = path.path.segments.last_mut().expect("type has no segments");
+            let type_params = std::mem::take(&mut last.arguments);
+
+            // It should have only one angle-bracketed param
+            let generic_arg = match type_params {
+                PathArguments::AngleBracketed(params) => params.args.first().cloned(),
+                _ => None,
+            };
+
+            // This argument must be a type
+            match generic_arg {
+                Some(GenericArgument::Type(t2)) => Some((Type::Path(path), t2)),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+    .expect("capabilities should be generic over a single event type")
+}
+
+#[cfg(test)]
+mod tests {
+    use darling::{FromDeriveInput, FromMeta};
+    use quote::quote;
+    use syn::{parse_str, Type};
+
+    use crate::export::ExportStructReceiver;
+
+    use super::split_on_generic;
+
+    #[test]
+    fn defaults() {
+        let input = r#"
+            #[derive(Export)]
+            pub struct Capabilities {
+                pub render: Render<Event>,
+            }
+        "#;
+        let input = parse_str(input).unwrap();
+        let input = ExportStructReceiver::from_derive_input(&input).unwrap();
+
+        let actual = quote!(#input);
+
+        insta::assert_snapshot!(pretty_print(&actual), @r###"
+        impl ::crux_core::typegen::Export for Capabilities {
+            fn register_types(
+                generator: &mut ::crux_core::typegen::TypeGen,
+            ) -> ::crux_core::typegen::Result {
+                generator
+                    .register_type::<
+                        <Render<Event> as ::crux_core::capability::Capability<Event>>::Operation,
+                    >()?;
+                generator
+                    .register_type::<
+                        <<Render<
+                            Event,
+                        > as ::crux_core::capability::Capability<
+                            Event,
+                        >>::Operation as ::crux_core::capability::Operation>::Output,
+                    >()?;
+                generator.register_type::<EffectFfi>()?;
+                generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
+                Ok(())
+            }
+        }
+        "###);
+    }
+
+    #[test]
+    fn split_event_types_preserves_path() {
+        let ty = Type::from_string("crux_core::render::Render<Event>").unwrap();
+
+        let (actual_type, actual_event) = split_on_generic(&ty);
+
+        assert_eq!(
+            quote!(#actual_type).to_string(),
+            quote!(crux_core::render::Render).to_string()
+        );
+
+        assert_eq!(quote!(#actual_event).to_string(), quote!(Event).to_string());
+    }
+
+    #[test]
+    fn full() {
+        let input = r#"
+            #[derive(Export)]
+            pub struct MyCapabilities {
+                pub http: crux_http::Http<MyEvent>,
+                pub key_value: KeyValue<MyEvent>,
+                pub platform: Platform<MyEvent>,
+                pub render: Render<MyEvent>,
+                pub time: Time<MyEvent>,
+            }
+        "#;
+        let input = parse_str(input).unwrap();
+        let input = ExportStructReceiver::from_derive_input(&input).unwrap();
+
+        let actual = quote!(#input);
+
+        insta::assert_snapshot!(pretty_print(&actual), @r###"
+        impl ::crux_core::typegen::Export for MyCapabilities {
+            fn register_types(
+                generator: &mut ::crux_core::typegen::TypeGen,
+            ) -> ::crux_core::typegen::Result {
+                generator
+                    .register_type::<
+                        <crux_http::Http<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                    >()?;
+                generator
+                    .register_type::<
+                        <<crux_http::Http<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<
+                            MyEvent,
+                        >>::Operation as ::crux_core::capability::Operation>::Output,
+                    >()?;
+                generator
+                    .register_type::<
+                        <KeyValue<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                    >()?;
+                generator
+                    .register_type::<
+                        <<KeyValue<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<
+                            MyEvent,
+                        >>::Operation as ::crux_core::capability::Operation>::Output,
+                    >()?;
+                generator
+                    .register_type::<
+                        <Platform<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                    >()?;
+                generator
+                    .register_type::<
+                        <<Platform<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<
+                            MyEvent,
+                        >>::Operation as ::crux_core::capability::Operation>::Output,
+                    >()?;
+                generator
+                    .register_type::<
+                        <Render<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                    >()?;
+                generator
+                    .register_type::<
+                        <<Render<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<
+                            MyEvent,
+                        >>::Operation as ::crux_core::capability::Operation>::Output,
+                    >()?;
+                generator
+                    .register_type::<
+                        <Time<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                    >()?;
+                generator
+                    .register_type::<
+                        <<Time<
+                            MyEvent,
+                        > as ::crux_core::capability::Capability<
+                            MyEvent,
+                        >>::Operation as ::crux_core::capability::Operation>::Output,
+                    >()?;
+                generator.register_type::<EffectFfi>()?;
+                generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
+                Ok(())
+            }
+        }
+        "###);
+    }
+
+    fn pretty_print(ts: &proc_macro2::TokenStream) -> String {
+        let file = syn::parse_file(&ts.to_string()).unwrap();
+        prettyplease::unparse(&file)
+    }
+}

--- a/crux_macros/src/lib.rs
+++ b/crux_macros/src/lib.rs
@@ -1,10 +1,17 @@
 mod effect;
+mod export;
 
 use effect::effect_impl;
+use export::export_impl;
 use proc_macro::TokenStream;
 use syn::parse_macro_input;
 
 #[proc_macro_derive(Effect, attributes(effect))]
 pub fn effect(input: TokenStream) -> TokenStream {
     effect_impl(&parse_macro_input!(input)).into()
+}
+
+#[proc_macro_derive(Export)]
+pub fn export(input: TokenStream) -> TokenStream {
+    export_impl(&parse_macro_input!(input)).into()
 }

--- a/docs/src/getting_started/core.md
+++ b/docs/src/getting_started/core.md
@@ -41,6 +41,9 @@ The library's manifest, at `/shared/Cargo.toml`, should look something like the 
   - `lib` is the default rust library when linking into a rust binary, e.g. in the `web-yew`, or `cli`, variant
   - `staticlib` is a static library (`libshared.a`) for including in the Swift iOS app variant
   - `cdylib` is a C-ABI dynamic library (`libshared.so`) for use with JNA when included in the Kotlin Android app variant
+- we need to declare a feature called `typegen` that depends on the feature with the same name in the `crux_core` crate. This is used by
+its sister library (often called `shared_types`) that will generate types for
+use across the FFI boundary (see the section below on generating shared types).
 - the `path` fields on the crux dependencies are for the [examples in the Crux repo](https://github.com/redbadger/crux/tree/master/examples) and so you will probably not need them
 - the uniffi dependencies and `uniffi-bindgen` target should make sense after you read the next section
 
@@ -115,11 +118,15 @@ cargo build
 
 This crate serves as the container for type generation for the foreign languages.
 
-1. Copy over the [shared_types](https://github.com/redbadger/crux/tree/master/examples/counter/shared_types) folder from the counter example.
+- Copy over the [shared_types](https://github.com/redbadger/crux/tree/master/examples/counter/shared_types) folder from the counter example.
 
-1. Edit the `build.rs` file and make sure to only list types you need.
+- Edit the `build.rs` file and make sure that your app type is registered. You may also need to register any nested enum types (due to a current limitation with the reflection library, see <https://github.com/zefchain/serde-reflection/tree/main/serde-reflection#supported-features>). Here is an example of this from the [`build.rs`](https://github.com/redbadger/crux/blob/master/examples/notes/shared_types/build.rs) file in the `shared_types` crate of the `notes` example:
 
-1. Make sure everything builds and foreign types get generated into the `generated` folder.
+```rust
+{{#include ../../../examples/notes/shared_types/build.rs}}
+```
+
+- Make sure everything builds and foreign types get generated into the `generated` folder.
 
    ```sh
    cargo build -vv

--- a/docs/src/getting_started/core.md
+++ b/docs/src/getting_started/core.md
@@ -120,10 +120,21 @@ This crate serves as the container for type generation for the foreign languages
 
 - Copy over the [shared_types](https://github.com/redbadger/crux/tree/master/examples/counter/shared_types) folder from the counter example.
 
-- Edit the `build.rs` file and make sure that your app type is registered. You may also need to register any nested enum types (due to a current limitation with the reflection library, see <https://github.com/zefchain/serde-reflection/tree/main/serde-reflection#supported-features>). Here is an example of this from the [`build.rs`](https://github.com/redbadger/crux/blob/master/examples/notes/shared_types/build.rs) file in the `shared_types` crate of the `notes` example:
+- Edit the `build.rs` file and make sure that your app type is registered. You may also need to register any nested enum types (due to a current limitation with the reflection library, see <https://github.com/zefchain/serde-reflection/tree/main/serde-reflection#supported-features>). Here is an example of this from the [`build.rs`](https://github.com/redbadger/crux/blob/master/examples/notes/shared_types/build.rs) file in the `shared_types` crate of the [notes example](https://github.com/redbadger/crux/tree/master/examples/notes):
 
 ```rust
 {{#include ../../../examples/notes/shared_types/build.rs}}
+```
+
+```admonish note
+For the above to compile, your `Capabilities` struct must implement the `Export` trait. There is a derive macro that can do this for you, e.g.:
+
+    #[derive(crux_macros::Effect, crux_macros::Export)]
+    pub struct Capabilities {
+        pub render: Render<Event>,
+        pub http: Http<Event>,
+    }
+
 ```
 
 - Make sure everything builds and foreign types get generated into the `generated` folder.

--- a/examples/cat_facts/shared/Cargo.toml
+++ b/examples/cat_facts/shared/Cargo.toml
@@ -8,6 +8,9 @@ rust-version = "1.66"
 crate-type = ["lib", "staticlib", "cdylib"]
 name = "shared"
 
+[features]
+typegen = ["crux_core/typegen"]
+
 [dependencies]
 anyhow.workspace = true
 bincode = "1.3.3"

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -6,7 +6,7 @@ pub use crux_core::App;
 use crux_core::{render::Render, Capability};
 use crux_http::Http;
 use crux_kv::{KeyValue, KeyValueOutput};
-use crux_macros::Effect;
+use crux_macros::{Effect, Export};
 use crux_platform::Platform;
 use crux_time::{Time, TimeResponse};
 
@@ -81,6 +81,7 @@ pub struct CatFacts {
     platform: platform::Platform,
 }
 
+#[cfg_attr(feature = "typegen", derive(Export))]
 #[derive(Effect)]
 #[effect(app = "CatFacts")]
 pub struct CatFactCapabilities {

--- a/examples/cat_facts/shared_types/Cargo.toml
+++ b/examples/cat_facts/shared_types/Cargo.toml
@@ -12,9 +12,11 @@ rust-version.workspace = true
 
 [build-dependencies]
 anyhow.workspace = true
-crux_core = { version = "0.4", path = "../../../crux_core", features = ["typegen"] }
+crux_core = { version = "0.4", path = "../../../crux_core", features = [
+  "typegen"
+] }
 crux_http = { version = "0.3", path = "../../../crux_http" }
 crux_kv = { version = "0.1", path = "../../../crux_kv" }
 crux_platform = { version = "0.1", path = "../../../crux_platform" }
 crux_time = { version = "0.1", path = "../../../crux_time" }
-shared = { path = "../shared" }
+shared = { path = "../shared", features = ["typegen"] }

--- a/examples/cat_facts/shared_types/build.rs
+++ b/examples/cat_facts/shared_types/build.rs
@@ -1,13 +1,11 @@
-use crux_core::{bridge::Request, typegen::TypeGen};
-use shared::{app::platform::PlatformEvent, CatFacts, EffectFfi};
+use crux_core::typegen::TypeGen;
+use shared::{app::platform::PlatformEvent, CatFacts};
 use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rerun-if-changed=../shared");
 
     let mut gen = TypeGen::new();
-
-    gen.register_type::<Request<EffectFfi>>().expect("register");
 
     gen.register_app::<CatFacts>().expect("register");
 

--- a/examples/cat_facts/shared_types/build.rs
+++ b/examples/cat_facts/shared_types/build.rs
@@ -1,10 +1,5 @@
-use anyhow::Result;
 use crux_core::{bridge::Request, typegen::TypeGen};
-use crux_http::protocol::{HttpRequest, HttpResponse};
-use crux_kv::{KeyValueOperation, KeyValueOutput};
-use crux_platform::PlatformResponse;
-use crux_time::TimeResponse;
-use shared::{app::platform::PlatformEvent, EffectFfi, Event, ViewModel};
+use shared::{app::platform::PlatformEvent, CatFacts, EffectFfi};
 use std::path::PathBuf;
 
 fn main() {
@@ -12,7 +7,13 @@ fn main() {
 
     let mut gen = TypeGen::new();
 
-    register_types(&mut gen).expect("type registration failed");
+    gen.register_type::<Request<EffectFfi>>().expect("register");
+
+    gen.register_app::<CatFacts>().expect("register");
+
+    // Note: currently required as we can't find enums inside enums, see:
+    // https://github.com/zefchain/serde-reflection/tree/main/serde-reflection#supported-features
+    gen.register_type::<PlatformEvent>().expect("register");
 
     let output_root = PathBuf::from("./generated");
 
@@ -27,23 +28,4 @@ fn main() {
 
     gen.typescript("shared_types", output_root.join("typescript"))
         .expect("typescript type gen failed");
-}
-
-fn register_types(gen: &mut TypeGen) -> Result<()> {
-    gen.register_type::<Request<EffectFfi>>()?;
-
-    gen.register_type::<EffectFfi>()?;
-    gen.register_type::<HttpRequest>()?;
-    gen.register_type::<KeyValueOperation>()?;
-
-    gen.register_type::<Event>()?;
-    gen.register_type::<HttpResponse>()?;
-    gen.register_type::<KeyValueOutput>()?;
-    gen.register_type::<TimeResponse>()?;
-
-    gen.register_type::<PlatformEvent>()?;
-    gen.register_type::<PlatformResponse>()?;
-
-    gen.register_type::<ViewModel>()?;
-    Ok(())
 }

--- a/examples/counter/iOS/CounterApp.xcodeproj/xcuserdata/stuartharris.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/examples/counter/iOS/CounterApp.xcodeproj/xcuserdata/stuartharris.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>CounterApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/examples/counter/shared/Cargo.toml
+++ b/examples/counter/shared/Cargo.toml
@@ -8,6 +8,9 @@ rust-version = "1.66"
 crate-type = ["lib", "staticlib", "cdylib"]
 name = "shared"
 
+[features]
+typegen = ["crux_core/typegen"]
+
 [dependencies]
 anyhow.workspace = true
 async-sse = "5.1.0"

--- a/examples/counter/shared/shared.xcodeproj/xcuserdata/stuartharris.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/examples/counter/shared/shared.xcodeproj/xcuserdata/stuartharris.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -12,7 +12,7 @@
 		<key>shared-staticlib.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>uniffi-bindgen-bin.xcscheme_^#shared#^_</key>
 		<dict>

--- a/examples/counter/shared/src/app.rs
+++ b/examples/counter/shared/src/app.rs
@@ -2,7 +2,7 @@ use crate::capabilities::sse::ServerSentEvents;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use crux_core::render::Render;
 use crux_http::Http;
-use crux_macros::Effect;
+use crux_macros::{Effect, Export};
 use serde::{Deserialize, Serialize};
 use url::Url;
 use uuid::Uuid;
@@ -36,6 +36,7 @@ pub enum Event {
     WatchUpdate(Counter),
 }
 
+#[cfg_attr(feature = "typegen", derive(Export))]
 #[derive(Effect)]
 pub struct Capabilities {
     pub http: Http<Event>,

--- a/examples/counter/shared_types/Cargo.toml
+++ b/examples/counter/shared_types/Cargo.toml
@@ -19,5 +19,5 @@ crux_http = { version = "0.3", path = "../../../crux_http" }
 crux_kv = { version = "0.1", path = "../../../crux_kv" }
 crux_platform = { version = "0.1", path = "../../../crux_platform" }
 crux_time = { version = "0.1", path = "../../../crux_time" }
-shared = { path = "../shared" }
+shared = { path = "../shared", features = ["typegen"] }
 uuid = { workspace = true }

--- a/examples/counter/shared_types/build.rs
+++ b/examples/counter/shared_types/build.rs
@@ -1,7 +1,5 @@
-use anyhow::Result;
 use crux_core::{bridge::Request, typegen::TypeGen};
-use crux_http::protocol::{HttpRequest, HttpResponse};
-use shared::{sse::SseResponse, EffectFfi, Event, ViewModel};
+use shared::{App, EffectFfi, Event};
 use std::path::PathBuf;
 use uuid::Uuid;
 
@@ -10,7 +8,12 @@ fn main() {
 
     let mut gen = TypeGen::new();
 
-    register_types(&mut gen).expect("type registration failed");
+    gen.register_type::<Request<EffectFfi>>().expect("register");
+
+    let sample_events = vec![Event::SendUuid(Uuid::new_v4())];
+    gen.register_samples(sample_events).expect("register");
+
+    gen.register_app::<App>().expect("register");
 
     let output_root = PathBuf::from("./generated");
 
@@ -22,20 +25,4 @@ fn main() {
 
     gen.typescript("shared_types", output_root.join("typescript"))
         .expect("typescript type gen failed");
-}
-
-fn register_types(gen: &mut TypeGen) -> Result<()> {
-    gen.register_type::<Request<EffectFfi>>()?;
-
-    gen.register_type::<EffectFfi>()?;
-    gen.register_type::<HttpRequest>()?;
-
-    let sample_events = vec![Event::SendUuid(Uuid::new_v4())];
-    gen.register_type_with_samples(sample_events)?;
-
-    gen.register_type::<HttpResponse>()?;
-    gen.register_type::<SseResponse>()?;
-
-    gen.register_type::<ViewModel>()?;
-    Ok(())
 }

--- a/examples/counter/shared_types/build.rs
+++ b/examples/counter/shared_types/build.rs
@@ -1,5 +1,5 @@
-use crux_core::{bridge::Request, typegen::TypeGen};
-use shared::{App, EffectFfi, Event};
+use crux_core::typegen::TypeGen;
+use shared::{App, Event};
 use std::path::PathBuf;
 use uuid::Uuid;
 
@@ -7,8 +7,6 @@ fn main() {
     println!("cargo:rerun-if-changed=../shared");
 
     let mut gen = TypeGen::new();
-
-    gen.register_type::<Request<EffectFfi>>().expect("register");
 
     let sample_events = vec![Event::SendUuid(Uuid::new_v4())];
     gen.register_samples(sample_events).expect("register");

--- a/examples/counter/web-nextjs/pnpm-lock.yaml
+++ b/examples/counter/web-nextjs/pnpm-lock.yaml
@@ -11,7 +11,7 @@ specifiers:
   typescript: 4.9.4
 
 dependencies:
-  next: 13.2.4_biqbaboplfbrettd7655fr4n2y
+  next: 13.4.1_biqbaboplfbrettd7655fr4n2y
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
   shared_types: link:../shared_types/generated/typescript
@@ -24,30 +24,12 @@ devDependencies:
 
 packages:
 
-  /@next/env/13.2.4:
-    resolution: {integrity: sha512-+Mq3TtpkeeKFZanPturjcXt+KHfKYnLlX6jMLyCrmpq6OOs4i1GqBOAauSkii9QeKCMTYzGppar21JU57b/GEA==}
+  /@next/env/13.4.1:
+    resolution: {integrity: sha512-eD6WCBMFjLFooLM19SIhSkWBHtaFrZFfg2Cxnyl3vS3DAdFRfnx5TY2RxlkuKXdIRCC0ySbtK9JXXt8qLCqzZg==}
     dev: false
 
-  /@next/swc-android-arm-eabi/13.2.4:
-    resolution: {integrity: sha512-DWlalTSkLjDU11MY11jg17O1gGQzpRccM9Oes2yTqj2DpHndajrXHGxj9HGtJ+idq2k7ImUdJVWS2h2l/EDJOw==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-android-arm64/13.2.4:
-    resolution: {integrity: sha512-sRavmUImUCf332Gy+PjIfLkMhiRX1Ez4SI+3vFDRs1N5eXp+uNzjFUK/oLMMOzk6KFSkbiK/3Wt8+dHQR/flNg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-darwin-arm64/13.2.4:
-    resolution: {integrity: sha512-S6vBl+OrInP47TM3LlYx65betocKUUlTZDDKzTiRDbsRESeyIkBtZ6Qi5uT2zQs4imqllJznVjFd1bXLx3Aa6A==}
+  /@next/swc-darwin-arm64/13.4.1:
+    resolution: {integrity: sha512-eF8ARHtYfnoYtDa6xFHriUKA/Mfj/cCbmKb3NofeKhMccs65G6/loZ15a6wYCCx4rPAd6x4t1WmVYtri7EdeBg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -55,8 +37,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-darwin-x64/13.2.4:
-    resolution: {integrity: sha512-a6LBuoYGcFOPGd4o8TPo7wmv5FnMr+Prz+vYHopEDuhDoMSHOnC+v+Ab4D7F0NMZkvQjEJQdJS3rqgFhlZmKlw==}
+  /@next/swc-darwin-x64/13.4.1:
+    resolution: {integrity: sha512-7cmDgF9tGWTgn5Gw+vP17miJbH4wcraMHDCOHTYWkO/VeKT73dUWG23TNRLfgtCNSPgH4V5B4uLHoZTanx9bAw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -64,26 +46,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-freebsd-x64/13.2.4:
-    resolution: {integrity: sha512-kkbzKVZGPaXRBPisoAQkh3xh22r+TD+5HwoC5bOkALraJ0dsOQgSMAvzMXKsN3tMzJUPS0tjtRf1cTzrQ0I5vQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-linux-arm-gnueabihf/13.2.4:
-    resolution: {integrity: sha512-7qA1++UY0fjprqtjBZaOA6cas/7GekpjVsZn/0uHvquuITFCdKGFCsKNBx3S0Rpxmx6WYo0GcmhNRM9ru08BGg==}
-    engines: {node: '>= 10'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
-  /@next/swc-linux-arm64-gnu/13.2.4:
-    resolution: {integrity: sha512-xzYZdAeq883MwXgcwc72hqo/F/dwUxCukpDOkx/j1HTq/J0wJthMGjinN9wH5bPR98Mfeh1MZJ91WWPnZOedOg==}
+  /@next/swc-linux-arm64-gnu/13.4.1:
+    resolution: {integrity: sha512-qwJqmCri2ie8aTtE5gjTSr8S6O8B67KCYgVZhv9gKH44yvc/zXbAY8u23QGULsYOyh1islWE5sWfQNLOj9iryg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -91,8 +55,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-musl/13.2.4:
-    resolution: {integrity: sha512-8rXr3WfmqSiYkb71qzuDP6I6R2T2tpkmf83elDN8z783N9nvTJf2E7eLx86wu2OJCi4T05nuxCsh4IOU3LQ5xw==}
+  /@next/swc-linux-arm64-musl/13.4.1:
+    resolution: {integrity: sha512-qcC54tWNGDv/VVIFkazxhqH1Bnagjfs4enzELVRlUOoJPD2BGJTPI7z08pQPbbgxLtRiu8gl2mXvpB8WlOkMeA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -100,8 +64,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-gnu/13.2.4:
-    resolution: {integrity: sha512-Ngxh51zGSlYJ4EfpKG4LI6WfquulNdtmHg1yuOYlaAr33KyPJp4HeN/tivBnAHcZkoNy0hh/SbwDyCnz5PFJQQ==}
+  /@next/swc-linux-x64-gnu/13.4.1:
+    resolution: {integrity: sha512-9TeWFlpLsBosZ+tsm/rWBaMwt5It9tPH8m3nawZqFUUrZyGRfGcI67js774vtx0k3rL9qbyY6+3pw9BCVpaYUA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -109,8 +73,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-musl/13.2.4:
-    resolution: {integrity: sha512-gOvwIYoSxd+j14LOcvJr+ekd9fwYT1RyMAHOp7znA10+l40wkFiMONPLWiZuHxfRk+Dy7YdNdDh3ImumvL6VwA==}
+  /@next/swc-linux-x64-musl/13.4.1:
+    resolution: {integrity: sha512-sNDGaWmSqTS4QRUzw61wl4mVPeSqNIr1OOjLlQTRuyInxMxtqImRqdvzDvFTlDfdeUMU/DZhWGYoHrXLlZXe6A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -118,8 +82,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-arm64-msvc/13.2.4:
-    resolution: {integrity: sha512-q3NJzcfClgBm4HvdcnoEncmztxrA5GXqKeiZ/hADvC56pwNALt3ngDC6t6qr1YW9V/EPDxCYeaX4zYxHciW4Dw==}
+  /@next/swc-win32-arm64-msvc/13.4.1:
+    resolution: {integrity: sha512-+CXZC7u1iXdLRudecoUYbhbsXpglYv8KFYsFxKBPn7kg+bk7eJo738wAA4jXIl8grTF2mPdmO93JOQym+BlYGA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -127,8 +91,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-ia32-msvc/13.2.4:
-    resolution: {integrity: sha512-/eZ5ncmHUYtD2fc6EUmAIZlAJnVT2YmxDsKs1Ourx0ttTtvtma/WKlMV5NoUsyOez0f9ExLyOpeCoz5aj+MPXw==}
+  /@next/swc-win32-ia32-msvc/13.4.1:
+    resolution: {integrity: sha512-vIoXVVc7UYO68VwVMDKwJC2+HqAZQtCYiVlApyKEeIPIQpz2gpufzGxk1z3/gwrJt/kJ5CDZjlhYDCzd3hdz+g==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -136,8 +100,8 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-x64-msvc/13.2.4:
-    resolution: {integrity: sha512-0MffFmyv7tBLlji01qc0IaPP/LVExzvj7/R5x1Jph1bTAIj4Vu81yFQWHHQAP6r4ff9Ukj1mBK6MDNVXm7Tcvw==}
+  /@next/swc-win32-x64-msvc/13.4.1:
+    resolution: {integrity: sha512-n8V5ImLQZibKTu10UUdI3nIeTLkliEXe628qxqW9v8My3BAH2a7H0SaCqkV2OgqFnn8sG1wxKYw9/SNJ632kSA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -145,8 +109,8 @@ packages:
     dev: false
     optional: true
 
-  /@swc/helpers/0.4.14:
-    resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
+  /@swc/helpers/0.5.1:
+    resolution: {integrity: sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==}
     dependencies:
       tslib: 2.4.1
     dev: false
@@ -186,6 +150,13 @@ packages:
     dependencies:
       color-convert: 1.9.3
     dev: true
+
+  /busboy/1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+    dependencies:
+      streamsearch: 1.1.0
+    dev: false
 
   /caniuse-lite/1.0.30001439:
     resolution: {integrity: sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==}
@@ -261,12 +232,12 @@ packages:
     hasBin: true
     dev: false
 
-  /next/13.2.4_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==}
-    engines: {node: '>=14.6.0'}
+  /next/13.4.1_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-JBw2kAIyhKDpjhEWvNVoFeIzNp9xNxg8wrthDOtMctfn3EpqGCmW0FSviNyGgOSOSn6zDaX48pmvbdf6X2W9xA==}
+    engines: {node: '>=16.8.0'}
     hasBin: true
     peerDependencies:
-      '@opentelemetry/api': ^1.4.0
+      '@opentelemetry/api': ^1.1.0
       fibers: '>= 3.1.0'
       node-sass: ^6.0.0 || ^7.0.0
       react: ^18.2.0
@@ -282,27 +253,25 @@ packages:
       sass:
         optional: true
     dependencies:
-      '@next/env': 13.2.4
-      '@swc/helpers': 0.4.14
+      '@next/env': 13.4.1
+      '@swc/helpers': 0.5.1
+      busboy: 1.6.0
       caniuse-lite: 1.0.30001439
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       styled-jsx: 5.1.1_react@18.2.0
+      zod: 3.21.4
     optionalDependencies:
-      '@next/swc-android-arm-eabi': 13.2.4
-      '@next/swc-android-arm64': 13.2.4
-      '@next/swc-darwin-arm64': 13.2.4
-      '@next/swc-darwin-x64': 13.2.4
-      '@next/swc-freebsd-x64': 13.2.4
-      '@next/swc-linux-arm-gnueabihf': 13.2.4
-      '@next/swc-linux-arm64-gnu': 13.2.4
-      '@next/swc-linux-arm64-musl': 13.2.4
-      '@next/swc-linux-x64-gnu': 13.2.4
-      '@next/swc-linux-x64-musl': 13.2.4
-      '@next/swc-win32-arm64-msvc': 13.2.4
-      '@next/swc-win32-ia32-msvc': 13.2.4
-      '@next/swc-win32-x64-msvc': 13.2.4
+      '@next/swc-darwin-arm64': 13.4.1
+      '@next/swc-darwin-x64': 13.4.1
+      '@next/swc-linux-arm64-gnu': 13.4.1
+      '@next/swc-linux-arm64-musl': 13.4.1
+      '@next/swc-linux-x64-gnu': 13.4.1
+      '@next/swc-linux-x64-musl': 13.4.1
+      '@next/swc-win32-arm64-msvc': 13.4.1
+      '@next/swc-win32-ia32-msvc': 13.4.1
+      '@next/swc-win32-x64-msvc': 13.4.1
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -347,6 +316,11 @@ packages:
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
+    dev: false
+
+  /streamsearch/1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
     dev: false
 
   /styled-jsx/5.1.1_react@18.2.0:
@@ -398,3 +372,7 @@ packages:
     dependencies:
       isexe: 2.0.0
     dev: true
+
+  /zod/3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+    dev: false

--- a/examples/hello_world/shared/Cargo.toml
+++ b/examples/hello_world/shared/Cargo.toml
@@ -8,6 +8,9 @@ rust-version = "1.66"
 crate-type = ["lib", "staticlib", "cdylib"]
 name = "shared"
 
+[features]
+typegen = ["crux_core/typegen"]
+
 [dependencies]
 crux_core = { version = "0.4", path = "../../../crux_core" }
 crux_macros = { version = "0.2", path = "../../../crux_macros" }

--- a/examples/hello_world/shared/src/counter.rs
+++ b/examples/hello_world/shared/src/counter.rs
@@ -1,5 +1,5 @@
 use crux_core::{render::Render, App};
-use crux_macros::Effect;
+use crux_macros::{Effect, Export};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -19,6 +19,7 @@ pub struct ViewModel {
     pub count: String,
 }
 
+#[cfg_attr(feature = "typegen", derive(Export))]
 #[derive(Effect)]
 #[effect(app = "Hello")]
 pub struct Capabilities {

--- a/examples/hello_world/shared_types/Cargo.toml
+++ b/examples/hello_world/shared_types/Cargo.toml
@@ -15,4 +15,4 @@ anyhow.workspace = true
 crux_core = { version = "0.4", path = "../../../crux_core", features = [
   "typegen"
 ] }
-shared = { path = "../shared" }
+shared = { path = "../shared", features = ["typegen"] }

--- a/examples/hello_world/shared_types/build.rs
+++ b/examples/hello_world/shared_types/build.rs
@@ -1,5 +1,5 @@
-use crux_core::{bridge::Request, typegen::TypeGen};
-use shared::{EffectFfi, Hello};
+use crux_core::typegen::TypeGen;
+use shared::Hello;
 use std::path::PathBuf;
 
 fn main() {
@@ -7,7 +7,6 @@ fn main() {
 
     let mut gen = TypeGen::new();
 
-    gen.register_type::<Request<EffectFfi>>().expect("register");
     gen.register_app::<Hello>().expect("register");
 
     let output_root = PathBuf::from("./generated");

--- a/examples/hello_world/shared_types/build.rs
+++ b/examples/hello_world/shared_types/build.rs
@@ -1,6 +1,5 @@
-use anyhow::Result;
 use crux_core::{bridge::Request, typegen::TypeGen};
-use shared::{EffectFfi, Event, ViewModel};
+use shared::{EffectFfi, Hello};
 use std::path::PathBuf;
 
 fn main() {
@@ -8,7 +7,8 @@ fn main() {
 
     let mut gen = TypeGen::new();
 
-    register_types(&mut gen).expect("type registration failed");
+    gen.register_type::<Request<EffectFfi>>().expect("register");
+    gen.register_app::<Hello>().expect("register");
 
     let output_root = PathBuf::from("./generated");
 
@@ -20,13 +20,4 @@ fn main() {
 
     gen.typescript("shared_types", output_root.join("typescript"))
         .expect("typescript type gen failed");
-}
-
-fn register_types(gen: &mut TypeGen) -> Result<()> {
-    gen.register_type::<Request<EffectFfi>>()?;
-    gen.register_type::<EffectFfi>()?;
-    gen.register_type::<Event>()?;
-    gen.register_type::<ViewModel>()?;
-
-    Ok(())
 }

--- a/examples/notes/shared/Cargo.toml
+++ b/examples/notes/shared/Cargo.toml
@@ -9,6 +9,9 @@ edition.workspace = true
 # keywords.workspace = true
 rust-version.workspace = true
 
+[features]
+typegen = ["crux_core/typegen"]
+
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]
 name = "shared"

--- a/examples/notes/shared/src/app.rs
+++ b/examples/notes/shared/src/app.rs
@@ -5,7 +5,7 @@ use std::ops::Range;
 use automerge::Change;
 use crux_core::{render::Render, App};
 use crux_kv::{KeyValue, KeyValueOutput};
-use crux_macros::Effect;
+use crux_macros::{Effect, Export};
 use serde::{Deserialize, Serialize};
 
 use crate::capabilities::{
@@ -100,6 +100,7 @@ impl From<&Model> for ViewModel {
     }
 }
 
+#[cfg_attr(feature = "typegen", derive(Export))]
 #[derive(Effect)]
 #[effect(app = "NoteEditor")]
 pub struct Capabilities {

--- a/examples/notes/shared_types/Cargo.toml
+++ b/examples/notes/shared_types/Cargo.toml
@@ -8,11 +8,11 @@ license.workspace = true
 keywords.workspace = true
 rust-version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 
 [build-dependencies]
 anyhow.workspace = true
-crux_core = { version = "0.4", path = "../../../crux_core", features = ["typegen"] }
-shared = { path = "../shared" }
+crux_core = { version = "0.4", path = "../../../crux_core", features = [
+  "typegen"
+] }
+shared = { path = "../shared", features = ["typegen"] }

--- a/examples/notes/shared_types/build.rs
+++ b/examples/notes/shared_types/build.rs
@@ -1,14 +1,11 @@
-use crux_core::{bridge::Request, typegen::TypeGen};
-
-use shared::{EffectFfi, NoteEditor, TextCursor};
+use crux_core::typegen::TypeGen;
+use shared::{NoteEditor, TextCursor};
 use std::path::PathBuf;
 
 fn main() {
     println!("cargo:rerun-if-changed=../shared");
 
     let mut gen = TypeGen::new();
-
-    gen.register_type::<Request<EffectFfi>>().expect("register");
 
     gen.register_app::<NoteEditor>().expect("register");
 

--- a/examples/notes/shared_types/build.rs
+++ b/examples/notes/shared_types/build.rs
@@ -1,14 +1,6 @@
-use anyhow::Result;
 use crux_core::{bridge::Request, typegen::TypeGen};
 
-use shared::{
-    capabilities::{
-        pub_sub::{Message, PubSubOperation},
-        timer::{TimerOperation, TimerOutput},
-        KeyValueOperation, KeyValueOutput,
-    },
-    EffectFfi, Event, TextCursor, ViewModel,
-};
+use shared::{EffectFfi, NoteEditor, TextCursor};
 use std::path::PathBuf;
 
 fn main() {
@@ -16,7 +8,13 @@ fn main() {
 
     let mut gen = TypeGen::new();
 
-    register_types(&mut gen).expect("type registration failed");
+    gen.register_type::<Request<EffectFfi>>().expect("register");
+
+    gen.register_app::<NoteEditor>().expect("register");
+
+    // Note: currently required as we can't find enums inside enums, see:
+    // https://github.com/zefchain/serde-reflection/tree/main/serde-reflection#supported-features
+    gen.register_type::<TextCursor>().expect("register");
 
     let output_root = PathBuf::from("./generated");
 
@@ -30,24 +28,4 @@ fn main() {
 
     gen.typescript("shared_types", output_root.join("typescript"))
         .expect("typescript type gen failed");
-}
-
-fn register_types(gen: &mut TypeGen) -> Result<()> {
-    gen.register_type::<Request<EffectFfi>>()?;
-    gen.register_type::<EffectFfi>()?;
-
-    gen.register_type::<PubSubOperation>()?;
-    gen.register_type::<Message>()?;
-
-    gen.register_type::<TimerOperation>()?;
-    gen.register_type::<TimerOutput>()?;
-
-    gen.register_type::<KeyValueOperation>()?;
-    gen.register_type::<KeyValueOutput>()?;
-
-    gen.register_type::<Event>()?;
-    gen.register_type::<TextCursor>()?;
-
-    gen.register_type::<ViewModel>()?;
-    Ok(())
 }

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cargo nextest run --all-features
+
+cargo test --doc --all-features
+
+for example in ./examples/*; do
+  (cd "$example" && cargo nextest run --all-features)
+done


### PR DESCRIPTION
It is possible for us to find all the types used by a Crux app by starting with the top-level type implementing the `App` trait and registering the `Event`, `ViewModel` and all the capability operations and their outputs. That is the total set of types which we will be sending across the FFI boundary (including all the types used within those types).

In this way we can avoid listing all the types manually and reduce the build.rs of the `shared_type` crates to a single line (and eventually hopefully remove it altogether).

# To do
- [x] Basic scanning of the App type
- [x] Macro generated walking of the Capabilities struct
- [x] Bridge machinery types (Request, EffectFfi, etc.)
- [x] Use in all examples
