### PR TITLE
Add response headers to HTTP Capability protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,7 @@ dependencies = [
  "async-trait",
  "crux_core",
  "crux_macros",
+ "derive_builder",
  "futures-test",
  "futures-util",
  "http-types",
@@ -344,7 +345,7 @@ dependencies = [
 name = "crux_macros"
 version = "0.3.2"
 dependencies = [
- "darling",
+ "darling 0.20.1",
  "insta",
  "prettyplease",
  "proc-macro-error",
@@ -375,12 +376,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.1",
+ "darling_macro 0.20.1",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -399,13 +424,55 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.1",
  "quote",
  "syn 2.0.22",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -15,6 +15,7 @@ anyhow.workspace = true
 async-trait = "0.1.68"
 crux_core = { version = ">=0.4", path = "../crux_core" }
 crux_macros = { version = "0.3", path = "../crux_macros" }
+derive_builder = "0.12.0"
 futures-util = "0.3"
 http-types = { version = "2.12", default-features = false, features = ["fs"] }
 pin-project-lite = "0.2.9"

--- a/crux_http/src/client.rs
+++ b/crux_http/src/client.rs
@@ -323,6 +323,7 @@ mod client_tests {
         shell.provide_response(HttpResponse {
             status: 200,
             body: "Hello World!".to_string().into_bytes(),
+            ..Default::default()
         });
 
         let client = Client::new(shell.clone());
@@ -335,8 +336,7 @@ mod client_tests {
             vec![HttpRequest {
                 method: "GET".into(),
                 url: "https://example.com/".into(),
-                headers: vec![],
-                body: vec![],
+                ..Default::default()
             }]
         )
     }

--- a/crux_http/src/client.rs
+++ b/crux_http/src/client.rs
@@ -320,11 +320,11 @@ mod client_tests {
     #[futures_test::test]
     async fn an_http_get() {
         let mut shell = FakeShell::default();
-        shell.provide_response(HttpResponse {
-            status: 200,
-            body: "Hello World!".to_string().into_bytes(),
-            ..Default::default()
-        });
+        shell.provide_response(
+            HttpResponse::status(200)
+                .body("Hello World!".to_string().into_bytes())
+                .build(),
+        );
 
         let client = Client::new(shell.clone());
 
@@ -333,11 +333,7 @@ mod client_tests {
 
         assert_eq!(
             shell.take_requests_received(),
-            vec![HttpRequest {
-                method: "GET".into(),
-                url: "https://example.com/".into(),
-                ..Default::default()
-            }]
+            vec![HttpRequest::get("https://example.com/").build()]
         )
     }
 }

--- a/crux_http/src/client.rs
+++ b/crux_http/src/client.rs
@@ -320,11 +320,7 @@ mod client_tests {
     #[futures_test::test]
     async fn an_http_get() {
         let mut shell = FakeShell::default();
-        shell.provide_response(
-            HttpResponse::status(200)
-                .body("Hello World!".to_string().into_bytes())
-                .build(),
-        );
+        shell.provide_response(HttpResponse::status(200).body("Hello World!").build());
 
         let client = Client::new(shell.clone());
 

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -60,6 +60,11 @@ impl HttpRequestBuilder {
         self
     }
 
+    pub fn json(&mut self, body: impl serde::Serialize) -> &mut Self {
+        self.body = Some(serde_json::to_vec(&body).unwrap());
+        self
+    }
+
     pub fn build(&self) -> HttpRequest {
         self.fallible_build()
             .expect("All required fields were initialized")
@@ -95,6 +100,11 @@ impl HttpResponseBuilder {
             name: name.into(),
             value: value.into(),
         });
+        self
+    }
+
+    pub fn json(&mut self, body: impl serde::Serialize) -> &mut Self {
+        self.body = Some(serde_json::to_vec(&body).unwrap());
         self
     }
 
@@ -188,7 +198,7 @@ mod tests {
     fn test_http_request_get_with_fields() {
         let req = HttpRequest::get("https://example.com")
             .header("foo", "bar")
-            .body(vec![1, 2, 3])
+            .body("123")
             .build();
 
         assert_eq!(
@@ -200,7 +210,7 @@ mod tests {
                     name: "foo".to_string(),
                     value: "bar".to_string(),
                 }],
-                body: vec![1, 2, 3],
+                body: "123".as_bytes().to_vec(),
             }
         );
     }

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -5,6 +5,7 @@
 //! This module defines the protocol for crux_http to communicate with the shell.
 
 use async_trait::async_trait;
+use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -13,19 +14,94 @@ pub struct HttpHeader {
     pub value: String,
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq, Builder)]
+#[builder(
+    custom_constructor,
+    build_fn(private, name = "fallible_build"),
+    setter(into)
+)]
 pub struct HttpRequest {
     pub method: String,
     pub url: String,
+    #[builder(setter(custom))]
     pub headers: Vec<HttpHeader>,
     pub body: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+macro_rules! http_method {
+    ($name:ident, $method:expr) => {
+        pub fn $name(url: impl Into<String>) -> HttpRequestBuilder {
+            HttpRequestBuilder {
+                method: Some($method.to_string()),
+                url: Some(url.into()),
+                headers: Some(vec![]),
+                body: Some(vec![]),
+            }
+        }
+    };
+}
+
+impl HttpRequest {
+    http_method!(get, "GET");
+    http_method!(put, "PUT");
+    http_method!(delete, "DELETE");
+    http_method!(post, "POST");
+    http_method!(patch, "PATCH");
+    http_method!(head, "HEAD");
+    http_method!(options, "OPTIONS");
+}
+
+impl HttpRequestBuilder {
+    pub fn header(&mut self, name: impl Into<String>, value: impl Into<String>) -> &mut Self {
+        self.headers.get_or_insert_with(Vec::new).push(HttpHeader {
+            name: name.into(),
+            value: value.into(),
+        });
+        self
+    }
+
+    pub fn build(&self) -> HttpRequest {
+        self.fallible_build()
+            .expect("All required fields were initialized")
+    }
+}
+
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq, Builder)]
+#[builder(
+    custom_constructor,
+    build_fn(private, name = "fallible_build"),
+    setter(into)
+)]
 pub struct HttpResponse {
     pub status: u16, // FIXME this probably should be a giant enum instead.
+    #[builder(setter(custom))]
     pub headers: Vec<HttpHeader>,
     pub body: Vec<u8>,
+}
+
+impl HttpResponse {
+    pub fn status(status: u16) -> HttpResponseBuilder {
+        HttpResponseBuilder {
+            status: Some(status.into()),
+            headers: Some(vec![]),
+            body: Some(vec![]),
+        }
+    }
+}
+
+impl HttpResponseBuilder {
+    pub fn header(&mut self, name: impl Into<String>, value: impl Into<String>) -> &mut Self {
+        self.headers.get_or_insert_with(Vec::new).push(HttpHeader {
+            name: name.into(),
+            value: value.into(),
+        });
+        self
+    }
+
+    pub fn build(&self) -> HttpResponse {
+        self.fallible_build()
+            .expect("All required fields were initialized")
+    }
 }
 
 impl crux_core::capability::Operation for HttpRequest {
@@ -87,5 +163,78 @@ impl From<HttpResponse> for crate::ResponseAsync {
         }
 
         crate::ResponseAsync::new(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_http_request_get() {
+        let req = HttpRequest::get("https://example.com").build();
+
+        assert_eq!(
+            req,
+            HttpRequest {
+                method: "GET".to_string(),
+                url: "https://example.com".to_string(),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_http_request_get_with_fields() {
+        let req = HttpRequest::get("https://example.com")
+            .header("foo", "bar")
+            .body(vec![1, 2, 3])
+            .build();
+
+        assert_eq!(
+            req,
+            HttpRequest {
+                method: "GET".to_string(),
+                url: "https://example.com".to_string(),
+                headers: vec![HttpHeader {
+                    name: "foo".to_string(),
+                    value: "bar".to_string(),
+                }],
+                body: vec![1, 2, 3],
+            }
+        );
+    }
+
+    #[test]
+    fn test_http_response_status() {
+        let req = HttpResponse::status(302).build();
+
+        assert_eq!(
+            req,
+            HttpResponse {
+                status: 302,
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_http_response_status_with_fields() {
+        let req = HttpResponse::status(302)
+            .header("foo", "bar")
+            .body("hello world")
+            .build();
+
+        assert_eq!(
+            req,
+            HttpResponse {
+                status: 302,
+                headers: vec![HttpHeader {
+                    name: "foo".to_string(),
+                    value: "bar".to_string(),
+                }],
+                body: "hello world".as_bytes().to_vec(),
+            }
+        );
     }
 }

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -13,7 +13,7 @@ pub struct HttpHeader {
     pub value: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
 pub struct HttpRequest {
     pub method: String,
     pub url: String,
@@ -21,10 +21,11 @@ pub struct HttpRequest {
     pub body: Vec<u8>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq, Eq)]
 pub struct HttpResponse {
-    pub status: u16,   // FIXME this probably should be a giant enum instead.
-    pub body: Vec<u8>, // TODO support headers
+    pub status: u16, // FIXME this probably should be a giant enum instead.
+    pub headers: Vec<HttpHeader>,
+    pub body: Vec<u8>,
 }
 
 impl crux_core::capability::Operation for HttpRequest {
@@ -81,6 +82,10 @@ impl From<HttpResponse> for crate::ResponseAsync {
     fn from(effect_response: HttpResponse) -> Self {
         let mut res = crate::http::Response::new(effect_response.status);
         res.set_body(effect_response.body);
+        for header in effect_response.headers {
+            res.append_header(header.name.as_str(), header.value);
+        }
+
         crate::ResponseAsync::new(res)
     }
 }

--- a/crux_http/src/testing/response_builder.rs
+++ b/crux_http/src/testing/response_builder.rs
@@ -14,7 +14,12 @@ pub struct ResponseBuilder<Body> {
 impl ResponseBuilder<Vec<u8>> {
     /// Constructs a new ResponseBuilder with the 200 OK status code.
     pub fn ok() -> ResponseBuilder<Vec<u8>> {
-        let response = Response::new_with_status(http::StatusCode::Ok);
+        ResponseBuilder::with_status(http::StatusCode::Ok)
+    }
+
+    /// Constructs a new ResponseBuilder with the specified status code.
+    pub fn with_status(status: http::StatusCode) -> ResponseBuilder<Vec<u8>> {
+        let response = Response::new_with_status(status);
 
         ResponseBuilder { response }
     }

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -113,11 +113,9 @@ mod shell {
                         let http_request = &request.operation;
 
                         received.push(http_request.clone());
-                        let response = HttpResponse {
-                            status: 200,
-                            body: "\"Hello\"".as_bytes().to_owned(),
-                            ..Default::default()
-                        };
+                        let response = HttpResponse::status(200)
+                            .body("\"Hello\"".as_bytes().to_owned())
+                            .build();
 
                         enqueue_effects(&mut queue, core.resolve(&mut request, response));
                     }
@@ -150,11 +148,7 @@ mod tests {
 
         assert_eq!(
             received,
-            vec![HttpRequest {
-                method: "GET".to_string(),
-                url: "http://example.com/".to_string(),
-                ..Default::default()
-            }]
+            vec![HttpRequest::get("http://example.com/").build()]
         );
 
         assert_eq!(
@@ -172,11 +166,7 @@ mod tests {
 
         assert_eq!(
             received,
-            vec![HttpRequest {
-                method: "GET".to_string(),
-                url: "http://example.com/".to_string(),
-                ..Default::default()
-            }]
+            vec![HttpRequest::get("http://example.com/").build()]
         );
         assert_eq!(core.view().result, "Status: 0, Body: , Json Body: Hello");
         Ok(())

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -113,9 +113,7 @@ mod shell {
                         let http_request = &request.operation;
 
                         received.push(http_request.clone());
-                        let response = HttpResponse::status(200)
-                            .body("\"Hello\"".as_bytes().to_owned())
-                            .build();
+                        let response = HttpResponse::status(200).json("Hello").build();
 
                         enqueue_effects(&mut queue, core.resolve(&mut request, response));
                     }

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -116,6 +116,7 @@ mod shell {
                         let response = HttpResponse {
                             status: 200,
                             body: "\"Hello\"".as_bytes().to_owned(),
+                            ..Default::default()
                         };
 
                         enqueue_effects(&mut queue, core.resolve(&mut request, response));
@@ -152,8 +153,7 @@ mod tests {
             vec![HttpRequest {
                 method: "GET".to_string(),
                 url: "http://example.com/".to_string(),
-                headers: vec![],
-                body: vec![],
+                ..Default::default()
             }]
         );
 
@@ -175,8 +175,7 @@ mod tests {
             vec![HttpRequest {
                 method: "GET".to_string(),
                 url: "http://example.com/".to_string(),
-                headers: vec![],
-                body: vec![]
+                ..Default::default()
             }]
         );
         assert_eq!(core.view().result, "Status: 0, Body: , Json Body: Hello");

--- a/crux_http/tests/with_tester.rs
+++ b/crux_http/tests/with_tester.rs
@@ -81,7 +81,7 @@ mod tests {
 
     use crate::shared::{App, Effect, Event, Model};
     use crux_core::testing::AppTester;
-    use crux_http::protocol::{HttpHeader, HttpRequest, HttpResponse};
+    use crux_http::protocol::{HttpRequest, HttpResponse};
 
     #[test]
     fn get() {
@@ -95,34 +95,19 @@ mod tests {
 
         assert_eq!(
             *http_request,
-            HttpRequest {
-                method: "GET".to_string(),
-                url: "http://example.com/".to_string(),
-                headers: vec![HttpHeader {
-                    name: "authorization".to_string(),
-                    value: "secret-token".to_string()
-                }],
-                ..Default::default()
-            }
+            HttpRequest::get("http://example.com/")
+                .header("authorization", "secret-token")
+                .build()
         );
 
         let update = app
             .resolve(
                 request,
-                HttpResponse {
-                    status: 200,
-                    body: serde_json::to_vec("hello").unwrap(),
-                    headers: vec![
-                        HttpHeader {
-                            name: "my_header".to_string(),
-                            value: "my_value1".to_string(),
-                        },
-                        HttpHeader {
-                            name: "my_header".to_string(),
-                            value: "my_value2".to_string(),
-                        },
-                    ],
-                },
+                HttpResponse::status(200)
+                    .body(serde_json::to_vec("hello").unwrap())
+                    .header("my_header", "my_value1")
+                    .header("my_header", "my_value2")
+                    .build(),
             )
             .expect("Resolves successfully");
 
@@ -152,25 +137,18 @@ mod tests {
 
         assert_eq!(
             request.operation,
-            HttpRequest {
-                method: "POST".to_string(),
-                url: "http://example.com/".to_string(),
-                headers: vec![HttpHeader {
-                    name: "content-type".to_string(),
-                    value: "application/octet-stream".to_string()
-                }],
-                body: "The Body".as_bytes().to_vec(),
-            }
+            HttpRequest::post("http://example.com/")
+                .header("content-type", "application/octet-stream")
+                .body("The Body")
+                .build()
         );
 
         let update = app
             .resolve(
                 request,
-                HttpResponse {
-                    status: 200,
-                    body: serde_json::to_vec("The Body").unwrap(),
-                    ..Default::default()
-                },
+                HttpResponse::status(200)
+                    .body(serde_json::to_vec("The Body").unwrap())
+                    .build(),
             )
             .expect("Resolves successfully");
 

--- a/crux_http/tests/with_tester.rs
+++ b/crux_http/tests/with_tester.rs
@@ -104,7 +104,7 @@ mod tests {
             .resolve(
                 request,
                 HttpResponse::status(200)
-                    .body(serde_json::to_vec("hello").unwrap())
+                    .json("hello")
                     .header("my_header", "my_value1")
                     .header("my_header", "my_value2")
                     .build(),
@@ -144,12 +144,7 @@ mod tests {
         );
 
         let update = app
-            .resolve(
-                request,
-                HttpResponse::status(200)
-                    .body(serde_json::to_vec("The Body").unwrap())
-                    .build(),
-            )
+            .resolve(request, HttpResponse::status(200).json("The Body").build())
             .expect("Resolves successfully");
 
         let actual = update.events;

--- a/examples/cat_facts/Android/app/src/main/java/com/example/android/MainActivity.kt
+++ b/examples/cat_facts/Android/app/src/main/java/com/example/android/MainActivity.kt
@@ -181,7 +181,7 @@ fun CatFacts(model: Model = viewModel()) {
         ) {
             model.view.image.getOrNull()?.let {
                 Image(
-                    painter = rememberAsyncImagePainter(it.file),
+                    painter = rememberAsyncImagePainter(it.href),
                     contentDescription = "cat image",
                     modifier = Modifier
                         .height(250.dp)

--- a/examples/cat_facts/Android/app/src/main/java/com/example/android/http.kt
+++ b/examples/cat_facts/Android/app/src/main/java/com/example/android/http.kt
@@ -1,10 +1,12 @@
 package com.example.android
 
+import com.redbadger.catfacts.shared_types.HttpHeader
 import com.redbadger.catfacts.shared_types.HttpResponse
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
+import io.ktor.util.flattenEntries
 
 suspend fun http(
     client: HttpClient,
@@ -15,5 +17,7 @@ suspend fun http(
         this.method = method
     }
     val bytes: ByteArray = response.body()
-    return HttpResponse(response.status.value.toShort(), bytes.toList())
+
+    val headers = response.headers.flattenEntries().map { HttpHeader(it.first, it.second) }
+    return HttpResponse(response.status.value.toShort(), headers, bytes.toList())
 }

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/CatImage.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/CatImage.java
@@ -2,16 +2,16 @@ package com.redbadger.catfacts.shared_types;
 
 
 public final class CatImage {
-    public final String file;
+    public final String href;
 
-    public CatImage(String file) {
-        java.util.Objects.requireNonNull(file, "file must not be null");
-        this.file = file;
+    public CatImage(String href) {
+        java.util.Objects.requireNonNull(href, "href must not be null");
+        this.href = href;
     }
 
     public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
         serializer.increase_container_depth();
-        serializer.serialize_str(file);
+        serializer.serialize_str(href);
         serializer.decrease_container_depth();
     }
 
@@ -24,7 +24,7 @@ public final class CatImage {
     public static CatImage deserialize(com.novi.serde.Deserializer deserializer) throws com.novi.serde.DeserializationError {
         deserializer.increase_container_depth();
         Builder builder = new Builder();
-        builder.file = deserializer.deserialize_str();
+        builder.href = deserializer.deserialize_str();
         deserializer.decrease_container_depth();
         return builder.build();
     }
@@ -46,22 +46,22 @@ public final class CatImage {
         if (obj == null) return false;
         if (getClass() != obj.getClass()) return false;
         CatImage other = (CatImage) obj;
-        if (!java.util.Objects.equals(this.file, other.file)) { return false; }
+        if (!java.util.Objects.equals(this.href, other.href)) { return false; }
         return true;
     }
 
     public int hashCode() {
         int value = 7;
-        value = 31 * value + (this.file != null ? this.file.hashCode() : 0);
+        value = 31 * value + (this.href != null ? this.href.hashCode() : 0);
         return value;
     }
 
     public static final class Builder {
-        public String file;
+        public String href;
 
         public CatImage build() {
             return new CatImage(
-                file
+                href
             );
         }
     }

--- a/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/HttpResponse.java
+++ b/examples/cat_facts/Android/shared/src/main/java/com/redbadger/catfacts/shared_types/HttpResponse.java
@@ -3,18 +3,22 @@ package com.redbadger.catfacts.shared_types;
 
 public final class HttpResponse {
     public final @com.novi.serde.Unsigned Short status;
+    public final java.util.List<HttpHeader> headers;
     public final java.util.List<@com.novi.serde.Unsigned Byte> body;
 
-    public HttpResponse(@com.novi.serde.Unsigned Short status, java.util.List<@com.novi.serde.Unsigned Byte> body) {
+    public HttpResponse(@com.novi.serde.Unsigned Short status, java.util.List<HttpHeader> headers, java.util.List<@com.novi.serde.Unsigned Byte> body) {
         java.util.Objects.requireNonNull(status, "status must not be null");
+        java.util.Objects.requireNonNull(headers, "headers must not be null");
         java.util.Objects.requireNonNull(body, "body must not be null");
         this.status = status;
+        this.headers = headers;
         this.body = body;
     }
 
     public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
         serializer.increase_container_depth();
         serializer.serialize_u16(status);
+        TraitHelpers.serialize_vector_HttpHeader(headers, serializer);
         TraitHelpers.serialize_vector_u8(body, serializer);
         serializer.decrease_container_depth();
     }
@@ -29,6 +33,7 @@ public final class HttpResponse {
         deserializer.increase_container_depth();
         Builder builder = new Builder();
         builder.status = deserializer.deserialize_u16();
+        builder.headers = TraitHelpers.deserialize_vector_HttpHeader(deserializer);
         builder.body = TraitHelpers.deserialize_vector_u8(deserializer);
         deserializer.decrease_container_depth();
         return builder.build();
@@ -52,6 +57,7 @@ public final class HttpResponse {
         if (getClass() != obj.getClass()) return false;
         HttpResponse other = (HttpResponse) obj;
         if (!java.util.Objects.equals(this.status, other.status)) { return false; }
+        if (!java.util.Objects.equals(this.headers, other.headers)) { return false; }
         if (!java.util.Objects.equals(this.body, other.body)) { return false; }
         return true;
     }
@@ -59,17 +65,20 @@ public final class HttpResponse {
     public int hashCode() {
         int value = 7;
         value = 31 * value + (this.status != null ? this.status.hashCode() : 0);
+        value = 31 * value + (this.headers != null ? this.headers.hashCode() : 0);
         value = 31 * value + (this.body != null ? this.body.hashCode() : 0);
         return value;
     }
 
     public static final class Builder {
         public @com.novi.serde.Unsigned Short status;
+        public java.util.List<HttpHeader> headers;
         public java.util.List<@com.novi.serde.Unsigned Byte> body;
 
         public HttpResponse build() {
             return new HttpResponse(
                 status,
+                headers,
                 body
             );
         }

--- a/examples/cat_facts/Cargo.lock
+++ b/examples/cat_facts/Cargo.lock
@@ -677,6 +677,7 @@ dependencies = [
  "async-trait",
  "crux_core",
  "crux_macros",
+ "derive_builder",
  "futures-util",
  "http-types",
  "pin-project-lite",
@@ -699,7 +700,7 @@ dependencies = [
 name = "crux_macros"
 version = "0.3.2"
 dependencies = [
- "darling",
+ "darling 0.20.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -778,12 +779,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.1",
+ "darling_macro 0.20.1",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -802,13 +827,55 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.1",
  "quote",
  "syn 2.0.22",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/examples/cat_facts/cli/src/main.rs
+++ b/examples/cat_facts/cli/src/main.rs
@@ -64,11 +64,7 @@ async fn main() -> Result<()> {
                     let HttpRequest { ref url, .. } = request.operation;
                     match surf::get(url).recv_bytes().await {
                         Ok(bytes) => {
-                            let response = HttpResponse {
-                                status: 200,
-                                body: bytes,
-                                ..Default::default()
-                            };
+                            let response = HttpResponse::status(200).body(bytes).build();
 
                             enqueue_effects(&mut queue, core.resolve(&mut request, response));
                         }

--- a/examples/cat_facts/cli/src/main.rs
+++ b/examples/cat_facts/cli/src/main.rs
@@ -67,6 +67,7 @@ async fn main() -> Result<()> {
                             let response = HttpResponse {
                                 status: 200,
                                 body: bytes,
+                                ..Default::default()
                             };
 
                             enqueue_effects(&mut queue, core.resolve(&mut request, response));

--- a/examples/cat_facts/iOS/CatFacts/ContentView.swift
+++ b/examples/cat_facts/iOS/CatFacts/ContentView.swift
@@ -29,7 +29,7 @@ class Model: ObservableObject {
     private func httpGet(uuid: [UInt8], url: String) {
         Task {
             let (data, _) = try! await URLSession.shared.data(from: URL(string: url)!)
-            self.update(msg: .response(uuid, .http(HttpResponse(status: 200, body: [UInt8](data)))))
+            self.update(msg: .response(uuid, .http(HttpResponse(status: 200, headers: [], body: [UInt8](data)))))
         }
     }
 
@@ -107,7 +107,7 @@ struct ContentView: View {
                 AnyView(
                     // For the loading image to work properly, we'd need to add
                     // caching here
-                    AsyncImage(url: URL(string: image.file)) { image in
+                    AsyncImage(url: URL(string: image.href)) { image in
                         image
                             .resizable()
                             .scaledToFit()

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -14,7 +14,7 @@ use platform::{PlatformCapabilities, PlatformEvent};
 
 const CAT_LOADING_URL: &str = "https://c.tenor.com/qACzaJ1EBVYAAAAd/tenor.gif";
 const FACT_API_URL: &str = "https://catfact.ninja/fact";
-const IMAGE_API_URL: &str = "https://aws.random.cat/meow";
+const IMAGE_API_URL: &str = "https://crux-counter.fly.dev/cat";
 
 #[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
 pub struct CatFact {
@@ -38,13 +38,13 @@ pub struct Model {
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub struct CatImage {
-    pub file: String,
+    pub href: String,
 }
 
 impl Default for CatImage {
     fn default() -> Self {
         Self {
-            file: CAT_LOADING_URL.to_string(),
+            href: CAT_LOADING_URL.to_string(),
         }
     }
 }
@@ -251,9 +251,7 @@ mod tests {
             length: 13,
         };
 
-        let response = HttpResponse::status(200)
-            .body(serde_json::to_vec(&a_fact).unwrap())
-            .build();
+        let response = HttpResponse::status(200).json(&a_fact).build();
         let update = app
             .resolve(request, response)
             .expect("should resolve successfully");

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -229,12 +229,7 @@ mod tests {
 
         assert_let!(Effect::Http(request), update.effects().next().unwrap());
         let actual = &request.operation;
-        let expected = &HttpRequest {
-            method: "GET".into(),
-            url: FACT_API_URL.into(),
-            headers: vec![],
-            body: vec![],
-        };
+        let expected = &HttpRequest::get(FACT_API_URL).build();
 
         assert_eq!(actual, expected);
     }
@@ -248,12 +243,7 @@ mod tests {
 
         assert_let!(Effect::Http(request), update.effects_mut().next().unwrap());
         let actual = &request.operation;
-        let expected = &HttpRequest {
-            method: "GET".into(),
-            url: FACT_API_URL.into(),
-            headers: vec![],
-            body: vec![],
-        };
+        let expected = &HttpRequest::get(FACT_API_URL).build();
         assert_eq!(actual, expected);
 
         let a_fact = CatFact {
@@ -261,11 +251,9 @@ mod tests {
             length: 13,
         };
 
-        let response = HttpResponse {
-            status: 200,
-            body: serde_json::to_vec(&a_fact).unwrap(),
-            ..Default::default()
-        };
+        let response = HttpResponse::status(200)
+            .body(serde_json::to_vec(&a_fact).unwrap())
+            .build();
         let update = app
             .resolve(request, response)
             .expect("should resolve successfully");

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -264,6 +264,7 @@ mod tests {
         let response = HttpResponse {
             status: 200,
             body: serde_json::to_vec(&a_fact).unwrap(),
+            ..Default::default()
         };
         let update = app
             .resolve(request, response)

--- a/examples/cat_facts/web-nextjs/next.config.js
+++ b/examples/cat_facts/web-nextjs/next.config.js
@@ -33,21 +33,13 @@ module.exports = {
           {
             key: "Content-Security-Policy",
             value:
-              "default-src 'self' 'unsafe-inline' 'unsafe-eval' catfact.ninja *.tenor.com aws.random.cat *.dream.io cdn.jsdelivr.net",
+              "default-src 'self' 'unsafe-inline' 'unsafe-eval' catfact.ninja *.tenor.com crux-counter.fly.dev *.dream.io cdn.jsdelivr.net; img-src https://*",
           },
           {
             key: "Referrer-Policy",
             value: "origin-when-cross-origin",
           },
         ],
-      },
-    ];
-  },
-  async rewrites() {
-    return [
-      {
-        source: "/",
-        destination: "https://aws.random.cat/meow",
       },
     ];
   },

--- a/examples/cat_facts/web-nextjs/pages/httpRequest.ts
+++ b/examples/cat_facts/web-nextjs/pages/httpRequest.ts
@@ -1,0 +1,30 @@
+import {
+  HttpRequest,
+  HttpResponse,
+  HttpHeader,
+} from "shared_types/types/shared_types";
+
+export async function httpRequest(
+  httpRequest: HttpRequest
+): Promise<HttpResponse> {
+  const req = new Request(httpRequest.url, {
+    method: httpRequest.method,
+    headers: httpRequest.headers.map((header) => [header.name, header.value]),
+  });
+
+  const res = await fetch(req);
+
+  const responseHeaders = Array.from(
+    res.headers.entries(),
+    ([name, value]) => new HttpHeader(name, value)
+  );
+
+  const body = await res.arrayBuffer();
+
+  const httpResponse = new HttpResponse(
+    res.status,
+    responseHeaders,
+    Array.from(new Uint8Array(body))
+  );
+  return httpResponse;
+}

--- a/examples/cat_facts/web-nextjs/pages/index.tsx
+++ b/examples/cat_facts/web-nextjs/pages/index.tsx
@@ -21,10 +21,10 @@ interface Response {
   kind: "response";
   uuid: number[];
   outcome:
-  | types.PlatformResponse
-  | types.TimeResponse
-  | types.HttpResponse
-  | types.KeyValueOutput;
+    | types.PlatformResponse
+    | types.TimeResponse
+    | types.HttpResponse
+    | types.KeyValueOutput;
 }
 
 type State = {
@@ -121,7 +121,7 @@ const Home: NextPage = () => {
           respond({
             kind: "response",
             uuid: request.uuid,
-            outcome: new types.HttpResponse(resp.status, response_bytes),
+            outcome: new types.HttpResponse(resp.status, [], response_bytes),
           });
           break;
         default:
@@ -145,6 +145,7 @@ const Home: NextPage = () => {
     }
 
     loadCore();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -162,7 +163,7 @@ const Home: NextPage = () => {
             // eslint-disable-next-line @next/next/no-img-element
             <img
               alt="A funny cat. Or at least a cute one."
-              src={state.image?.file}
+              src={state.image?.href}
               style={{ height: "200px" }}
             />
           )}

--- a/examples/cat_facts/web-nextjs/pages/index.tsx
+++ b/examples/cat_facts/web-nextjs/pages/index.tsx
@@ -11,6 +11,7 @@ import init_core, {
 import * as types from "shared_types/types/shared_types";
 import * as bincode from "shared_types/bincode/mod";
 import { Optional } from "shared_types/serde/mod";
+import { httpRequest } from "./httpRequest";
 
 interface Event {
   kind: "event";
@@ -77,9 +78,9 @@ const Home: NextPage = () => {
   const handleRequests = async (bytes: any) => {
     let requests = deserializeRequests(bytes);
 
-    for (const request of requests) {
-      switch (request.effect.constructor) {
-        case types.EffectVariantRender:
+    for (const { uuid, effect } of requests) {
+      switch (effect.constructor) {
+        case types.EffectVariantRender: {
           let bytes = view();
           let viewDeserializer = new bincode.BincodeDeserializer(bytes);
           let viewModel = types.ViewModel.deserialize(viewDeserializer);
@@ -92,38 +93,31 @@ const Home: NextPage = () => {
           });
 
           break;
-        case types.EffectVariantTime:
-          respond({
-            kind: "response",
-            uuid: request.uuid,
-            outcome: new types.TimeResponse(new Date().toISOString()),
-          });
+        }
 
+        case types.EffectVariantTime: {
+          const outcome = new types.TimeResponse(new Date().toISOString());
+          respond({ kind: "response", uuid, outcome });
           break;
-        case types.EffectVariantPlatform:
-          respond({
-            kind: "response",
-            uuid: request.uuid,
-            outcome: new types.PlatformResponse(
-              new UAParser(navigator.userAgent).getBrowser().name || "Unknown"
-            ),
-          });
+        }
+
+        case types.EffectVariantPlatform: {
+          const outcome = new types.PlatformResponse(
+            new UAParser(navigator.userAgent).getBrowser().name || "Unknown"
+          );
+          respond({ kind: "response", uuid, outcome });
           break;
+        }
+
         case types.EffectVariantKeyValue:
           break;
-        case types.EffectVariantHttp:
-          const { url } = (request.effect as types.EffectVariantHttp).value;
 
-          const resp = await fetch(url);
-          const body = await resp.arrayBuffer();
-          const response_bytes = Array.from(new Uint8Array(body));
-
-          respond({
-            kind: "response",
-            uuid: request.uuid,
-            outcome: new types.HttpResponse(resp.status, [], response_bytes),
-          });
+        case types.EffectVariantHttp: {
+          const request = (effect as types.EffectVariantHttp).value;
+          const outcome = await httpRequest(request);
+          respond({ kind: "response", uuid, outcome });
           break;
+        }
         default:
       }
     }

--- a/examples/cat_facts/web-nextjs/pnpm-lock.yaml
+++ b/examples/cat_facts/web-nextjs/pnpm-lock.yaml
@@ -1,40 +1,55 @@
-lockfileVersion: 5.4
+lockfileVersion: '6.0'
 
-specifiers:
-  '@types/node': 18.11.9
-  '@types/react': 18.0.25
-  '@types/react-dom': 18.0.8
-  '@types/ua-parser-js': ^0.7.36
-  '@wasm-tool/wasm-pack-plugin': ^1.6.0
-  eslint: 8.27.0
-  eslint-config-next: 13.0.3
-  next: 13.0.3
-  react: 18.2.0
-  react-dom: 18.2.0
-  shared_types: ../shared_types/generated/typescript
-  typescript: 4.8.4
-  ua-parser-js: ^1.0.32
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
-  eslint: 8.27.0
-  eslint-config-next: 13.0.3_rmayb2veg2btbq6mbmnyivgasy
-  next: 13.0.3_biqbaboplfbrettd7655fr4n2y
-  react: 18.2.0
-  react-dom: 18.2.0_react@18.2.0
-  shared_types: link:../shared_types/generated/typescript
-  typescript: 4.8.4
-  ua-parser-js: 1.0.32
+  eslint:
+    specifier: 8.27.0
+    version: 8.27.0
+  eslint-config-next:
+    specifier: 13.0.3
+    version: 13.0.3(eslint@8.27.0)(typescript@4.8.4)
+  next:
+    specifier: 13.0.3
+    version: 13.0.3(react-dom@18.2.0)(react@18.2.0)
+  react:
+    specifier: 18.2.0
+    version: 18.2.0
+  react-dom:
+    specifier: 18.2.0
+    version: 18.2.0(react@18.2.0)
+  shared_types:
+    specifier: ../shared_types/generated/typescript
+    version: link:../shared_types/generated/typescript
+  typescript:
+    specifier: 4.8.4
+    version: 4.8.4
+  ua-parser-js:
+    specifier: ^1.0.32
+    version: 1.0.32
 
 devDependencies:
-  '@types/node': 18.11.9
-  '@types/react': 18.0.25
-  '@types/react-dom': 18.0.8
-  '@types/ua-parser-js': 0.7.36
-  '@wasm-tool/wasm-pack-plugin': 1.6.0
+  '@types/node':
+    specifier: 18.11.9
+    version: 18.11.9
+  '@types/react':
+    specifier: 18.0.25
+    version: 18.0.25
+  '@types/react-dom':
+    specifier: 18.0.8
+    version: 18.0.8
+  '@types/ua-parser-js':
+    specifier: ^0.7.36
+    version: 0.7.36
+  '@wasm-tool/wasm-pack-plugin':
+    specifier: ^1.6.0
+    version: 1.6.0
 
 packages:
 
-  /@babel/runtime-corejs3/7.20.1:
+  /@babel/runtime-corejs3@7.20.1:
     resolution: {integrity: sha512-CGulbEDcg/ND1Im7fUNRZdGXmX2MTWVVZacQi/6DiKE5HNwZ3aVTm5PV4lO8HHz0B2h8WQyvKKjbX5XgTtydsg==}
     engines: {node: '>=6.9.0'}
     dependencies:
@@ -42,14 +57,14 @@ packages:
       regenerator-runtime: 0.13.10
     dev: false
 
-  /@babel/runtime/7.20.1:
+  /@babel/runtime@7.20.1:
     resolution: {integrity: sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.10
     dev: false
 
-  /@eslint/eslintrc/1.3.3:
+  /@eslint/eslintrc@1.3.3:
     resolution: {integrity: sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
@@ -66,7 +81,7 @@ packages:
       - supports-color
     dev: false
 
-  /@humanwhocodes/config-array/0.11.7:
+  /@humanwhocodes/config-array@0.11.7:
     resolution: {integrity: sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==}
     engines: {node: '>=10.10.0'}
     dependencies:
@@ -77,26 +92,26 @@ packages:
       - supports-color
     dev: false
 
-  /@humanwhocodes/module-importer/1.0.1:
+  /@humanwhocodes/module-importer@1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
     dev: false
 
-  /@humanwhocodes/object-schema/1.2.1:
+  /@humanwhocodes/object-schema@1.2.1:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: false
 
-  /@next/env/13.0.3:
+  /@next/env@13.0.3:
     resolution: {integrity: sha512-/4WzeG61Ot/PxsghXkSqQJ6UohFfwXoZ3dtsypmR9EBP+OIax9JRq0trq8Z/LCT9Aq4JbihVkaazRWguORjTAw==}
     dev: false
 
-  /@next/eslint-plugin-next/13.0.3:
+  /@next/eslint-plugin-next@13.0.3:
     resolution: {integrity: sha512-slmTAHNKDyc7jhx4VF8lFbmOPWJ3PShtUUWpb6x9+ga59CyOxgP6AdcDhxfapnWYACKe/TwYiaveufu7LqXgZg==}
     dependencies:
       glob: 7.1.7
     dev: false
 
-  /@next/swc-android-arm-eabi/13.0.3:
+  /@next/swc-android-arm-eabi@13.0.3:
     resolution: {integrity: sha512-uxfUoj65CdFc1gX2q7GtBX3DhKv9Kn343LMqGNvXyuTpYTGMmIiVY7b9yF8oLWRV0gVKqhZBZifUmoPE8SJU6Q==}
     engines: {node: '>= 10'}
     cpu: [arm]
@@ -105,7 +120,7 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-android-arm64/13.0.3:
+  /@next/swc-android-arm64@13.0.3:
     resolution: {integrity: sha512-t2k+WDfg7Cq2z/EnalKGsd/9E5F4Hdo1xu+UzZXYDpKUI9zgE6Bz8ajQb8m8txv3qOaWdKuDa5j5ziq9Acd1Xw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
@@ -114,7 +129,7 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-darwin-arm64/13.0.3:
+  /@next/swc-darwin-arm64@13.0.3:
     resolution: {integrity: sha512-wV6j6SZ1bc/YHOLCLk9JVqaZTCCey6HBV7inl2DriHsHqIcO6F3+QiYf0KXwRP9BE0GSZZrYd5mZQm2JPTHdJA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
@@ -123,7 +138,7 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-darwin-x64/13.0.3:
+  /@next/swc-darwin-x64@13.0.3:
     resolution: {integrity: sha512-jaI2CMuYWvUtRixV3AIjUhnxUDU1FKOR+8hADMhYt3Yz+pCKuj4RZ0n0nY5qUf3qT1AtvnJXEgyatSFJhSp/wQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
@@ -132,7 +147,7 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-freebsd-x64/13.0.3:
+  /@next/swc-freebsd-x64@13.0.3:
     resolution: {integrity: sha512-nbyT0toBTJrcj5TCB9pVnQpGJ3utGyQj4CWegZs1ulaeUQ5Z7CS/qt8nRyYyOKYHtOdSCJ9Nw5F/RgKNkdpOdw==}
     engines: {node: '>= 10'}
     cpu: [x64]
@@ -141,7 +156,7 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm-gnueabihf/13.0.3:
+  /@next/swc-linux-arm-gnueabihf@13.0.3:
     resolution: {integrity: sha512-1naLxYvRUQCoFCU1nMkcQueRc0Iux9xBv1L5pzH2ejtIWFg8BrSgyuluJG4nyAhFCx4WG863IEIkAaefOowVdA==}
     engines: {node: '>= 10'}
     cpu: [arm]
@@ -150,7 +165,7 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-gnu/13.0.3:
+  /@next/swc-linux-arm64-gnu@13.0.3:
     resolution: {integrity: sha512-3Z4A8JkuGWpMVbUhUPQInK/SLY+kijTT78Q/NZCrhLlyvwrVxaQALJNlXzxDLraUgv4oVH0Wz/FIw1W9PUUhxA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
@@ -159,7 +174,7 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-arm64-musl/13.0.3:
+  /@next/swc-linux-arm64-musl@13.0.3:
     resolution: {integrity: sha512-MoYe9SM40UaunTjC+01c9OILLH3uSoeri58kDMu3KF/EFEvn1LZ6ODeDj+SLGlAc95wn46hrRJS2BPmDDE+jFQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
@@ -168,7 +183,7 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-gnu/13.0.3:
+  /@next/swc-linux-x64-gnu@13.0.3:
     resolution: {integrity: sha512-z22T5WGnRanjLMXdF0NaNjSpBlEzzY43t5Ysp3nW1oI6gOkub6WdQNZeHIY7A2JwkgSWZmtjLtf+Fzzz38LHeQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
@@ -177,7 +192,7 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-linux-x64-musl/13.0.3:
+  /@next/swc-linux-x64-musl@13.0.3:
     resolution: {integrity: sha512-ZOMT7zjBFmkusAtr47k8xs/oTLsNlTH6xvYb+iux7yly2hZGwhfBLzPGBsbeMZukZ96IphJTagT+C033s6LNVA==}
     engines: {node: '>= 10'}
     cpu: [x64]
@@ -186,7 +201,7 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-arm64-msvc/13.0.3:
+  /@next/swc-win32-arm64-msvc@13.0.3:
     resolution: {integrity: sha512-Q4BM16Djl+Oah9UdGrvjFYgoftYB2jNd+rtRGPX5Mmxo09Ry/KiLbOZnoUyoIxKc1xPyfqMXuaVsAFQLYs0KEQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
@@ -195,7 +210,7 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-ia32-msvc/13.0.3:
+  /@next/swc-win32-ia32-msvc@13.0.3:
     resolution: {integrity: sha512-Sa8yGkNeRUsic8Qjf7MLIAfP0p0+einK/wIqJ8UO1y76j+8rRQu42AMs5H4Ax1fm9GEYq6I8njHtY59TVpTtGQ==}
     engines: {node: '>= 10'}
     cpu: [ia32]
@@ -204,7 +219,7 @@ packages:
     dev: false
     optional: true
 
-  /@next/swc-win32-x64-msvc/13.0.3:
+  /@next/swc-win32-x64-msvc@13.0.3:
     resolution: {integrity: sha512-IAptmSqA7k4tQzaw2NAkoEjj3+Dz9ceuvlEHwYh770MMDL4V0ku2m+UHrmn5HUCEDHhgwwjg2nyf6728q2jr1w==}
     engines: {node: '>= 10'}
     cpu: [x64]
@@ -213,7 +228,7 @@ packages:
     dev: false
     optional: true
 
-  /@nodelib/fs.scandir/2.1.5:
+  /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
     dependencies:
@@ -221,12 +236,12 @@ packages:
       run-parallel: 1.2.0
     dev: false
 
-  /@nodelib/fs.stat/2.0.5:
+  /@nodelib/fs.stat@2.0.5:
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
     engines: {node: '>= 8'}
     dev: false
 
-  /@nodelib/fs.walk/1.2.8:
+  /@nodelib/fs.walk@1.2.8:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
     dependencies:
@@ -234,35 +249,35 @@ packages:
       fastq: 1.13.0
     dev: false
 
-  /@rushstack/eslint-patch/1.2.0:
+  /@rushstack/eslint-patch@1.2.0:
     resolution: {integrity: sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==}
     dev: false
 
-  /@swc/helpers/0.4.11:
+  /@swc/helpers@0.4.11:
     resolution: {integrity: sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==}
     dependencies:
       tslib: 2.4.1
     dev: false
 
-  /@types/json5/0.0.29:
+  /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: false
 
-  /@types/node/18.11.9:
+  /@types/node@18.11.9:
     resolution: {integrity: sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==}
     dev: true
 
-  /@types/prop-types/15.7.5:
+  /@types/prop-types@15.7.5:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
     dev: true
 
-  /@types/react-dom/18.0.8:
+  /@types/react-dom@18.0.8:
     resolution: {integrity: sha512-C3GYO0HLaOkk9dDAz3Dl4sbe4AKUGTCfFIZsz3n/82dPNN8Du533HzKatDxeUYWu24wJgMP1xICqkWk1YOLOIw==}
     dependencies:
       '@types/react': 18.0.25
     dev: true
 
-  /@types/react/18.0.25:
+  /@types/react@18.0.25:
     resolution: {integrity: sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==}
     dependencies:
       '@types/prop-types': 15.7.5
@@ -270,15 +285,15 @@ packages:
       csstype: 3.1.1
     dev: true
 
-  /@types/scheduler/0.16.2:
+  /@types/scheduler@0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
     dev: true
 
-  /@types/ua-parser-js/0.7.36:
+  /@types/ua-parser-js@0.7.36:
     resolution: {integrity: sha512-N1rW+njavs70y2cApeIw1vLMYXRwfBy+7trgavGuuTfOd7j1Yh7QTRc/yqsPl6ncokt72ZXuxEU0PiCp9bSwNQ==}
     dev: true
 
-  /@typescript-eslint/parser/5.42.1_rmayb2veg2btbq6mbmnyivgasy:
+  /@typescript-eslint/parser@5.42.1(eslint@8.27.0)(typescript@4.8.4):
     resolution: {integrity: sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -290,7 +305,7 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.42.1
       '@typescript-eslint/types': 5.42.1
-      '@typescript-eslint/typescript-estree': 5.42.1_typescript@4.8.4
+      '@typescript-eslint/typescript-estree': 5.42.1(typescript@4.8.4)
       debug: 4.3.4
       eslint: 8.27.0
       typescript: 4.8.4
@@ -298,7 +313,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/scope-manager/5.42.1:
+  /@typescript-eslint/scope-manager@5.42.1:
     resolution: {integrity: sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
@@ -306,12 +321,12 @@ packages:
       '@typescript-eslint/visitor-keys': 5.42.1
     dev: false
 
-  /@typescript-eslint/types/5.42.1:
+  /@typescript-eslint/types@5.42.1:
     resolution: {integrity: sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.42.1_typescript@4.8.4:
+  /@typescript-eslint/typescript-estree@5.42.1(typescript@4.8.4):
     resolution: {integrity: sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -326,13 +341,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0_typescript@4.8.4
+      tsutils: 3.21.0(typescript@4.8.4)
       typescript: 4.8.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/visitor-keys/5.42.1:
+  /@typescript-eslint/visitor-keys@5.42.1:
     resolution: {integrity: sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
@@ -340,7 +355,7 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: false
 
-  /@wasm-tool/wasm-pack-plugin/1.6.0:
+  /@wasm-tool/wasm-pack-plugin@1.6.0:
     resolution: {integrity: sha512-Iax4nEgIvVCZqrmuseJm7ln/muWpg7uT5fXMAT0crYo+k5JTuZE58DJvBQoeIAegA3IM9cZgfkcZjAOUCPsT1g==}
     dependencies:
       chalk: 2.4.2
@@ -349,7 +364,7 @@ packages:
       which: 2.0.2
     dev: true
 
-  /acorn-jsx/5.3.2_acorn@8.8.1:
+  /acorn-jsx@5.3.2(acorn@8.8.1):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -357,13 +372,13 @@ packages:
       acorn: 8.8.1
     dev: false
 
-  /acorn/8.8.1:
+  /acorn@8.8.1:
     resolution: {integrity: sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: false
 
-  /ajv/6.12.6:
+  /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
       fast-deep-equal: 3.1.3
@@ -372,30 +387,30 @@ packages:
       uri-js: 4.4.1
     dev: false
 
-  /ansi-regex/5.0.1:
+  /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
     dev: false
 
-  /ansi-styles/3.2.1:
+  /ansi-styles@3.2.1:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
     engines: {node: '>=4'}
     dependencies:
       color-convert: 1.9.3
     dev: true
 
-  /ansi-styles/4.3.0:
+  /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
     dev: false
 
-  /argparse/2.0.1:
+  /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
     dev: false
 
-  /aria-query/4.2.2:
+  /aria-query@4.2.2:
     resolution: {integrity: sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==}
     engines: {node: '>=6.0'}
     dependencies:
@@ -403,7 +418,7 @@ packages:
       '@babel/runtime-corejs3': 7.20.1
     dev: false
 
-  /array-includes/3.1.6:
+  /array-includes@3.1.6:
     resolution: {integrity: sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -414,12 +429,12 @@ packages:
       is-string: 1.0.7
     dev: false
 
-  /array-union/2.1.0:
+  /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
     dev: false
 
-  /array.prototype.flat/1.3.1:
+  /array.prototype.flat@1.3.1:
     resolution: {integrity: sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -429,7 +444,7 @@ packages:
       es-shim-unscopables: 1.0.0
     dev: false
 
-  /array.prototype.flatmap/1.3.1:
+  /array.prototype.flatmap@1.3.1:
     resolution: {integrity: sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -439,54 +454,54 @@ packages:
       es-shim-unscopables: 1.0.0
     dev: false
 
-  /ast-types-flow/0.0.7:
+  /ast-types-flow@0.0.7:
     resolution: {integrity: sha512-eBvWn1lvIApYMhzQMsu9ciLfkBY499mFZlNqG+/9WR7PVlroQw0vG30cOQQbaKz3sCEc44TAOu2ykzqXSNnwag==}
     dev: false
 
-  /axe-core/4.5.1:
+  /axe-core@4.5.1:
     resolution: {integrity: sha512-1exVbW0X1O/HSr/WMwnaweyqcWOgZgLiVxdLG34pvSQk4NlYQr9OUy0JLwuhFfuVNQzzqgH57eYzkFBCb3bIsQ==}
     engines: {node: '>=4'}
     dev: false
 
-  /axobject-query/2.2.0:
+  /axobject-query@2.2.0:
     resolution: {integrity: sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==}
     dev: false
 
-  /balanced-match/1.0.2:
+  /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
     dev: false
 
-  /brace-expansion/1.1.11:
+  /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
     dev: false
 
-  /braces/3.0.2:
+  /braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
     dev: false
 
-  /call-bind/1.0.2:
+  /call-bind@1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.1.3
     dev: false
 
-  /callsites/3.1.0:
+  /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
     dev: false
 
-  /caniuse-lite/1.0.30001431:
+  /caniuse-lite@1.0.30001431:
     resolution: {integrity: sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==}
     dev: false
 
-  /chalk/2.4.2:
+  /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
     dependencies:
@@ -495,7 +510,7 @@ packages:
       supports-color: 5.5.0
     dev: true
 
-  /chalk/4.1.2:
+  /chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
     dependencies:
@@ -503,45 +518,45 @@ packages:
       supports-color: 7.2.0
     dev: false
 
-  /client-only/0.0.1:
+  /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
     dev: false
 
-  /color-convert/1.9.3:
+  /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
       color-name: 1.1.3
     dev: true
 
-  /color-convert/2.0.1:
+  /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
     dev: false
 
-  /color-name/1.1.3:
+  /color-name@1.1.3:
     resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=}
     dev: true
 
-  /color-name/1.1.4:
+  /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: false
 
-  /command-exists/1.2.9:
+  /command-exists@1.2.9:
     resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
     dev: true
 
-  /concat-map/0.0.1:
+  /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
     dev: false
 
-  /core-js-pure/3.26.0:
+  /core-js-pure@3.26.0:
     resolution: {integrity: sha512-LiN6fylpVBVwT8twhhluD9TzXmZQQsr2I2eIKtWNbZI1XMfBT7CV18itaN6RA7EtQd/SDdRx/wzvAShX2HvhQA==}
     requiresBuild: true
     dev: false
 
-  /cross-spawn/7.0.3:
+  /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
     dependencies:
@@ -550,15 +565,15 @@ packages:
       which: 2.0.2
     dev: false
 
-  /csstype/3.1.1:
+  /csstype@3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
     dev: true
 
-  /damerau-levenshtein/1.0.8:
+  /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: false
 
-  /debug/2.6.9:
+  /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
       supports-color: '*'
@@ -569,7 +584,7 @@ packages:
       ms: 2.0.0
     dev: false
 
-  /debug/3.2.7:
+  /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
       supports-color: '*'
@@ -580,7 +595,7 @@ packages:
       ms: 2.1.3
     dev: false
 
-  /debug/4.3.4:
+  /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -592,11 +607,11 @@ packages:
       ms: 2.1.2
     dev: false
 
-  /deep-is/0.1.4:
+  /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: false
 
-  /define-properties/1.1.4:
+  /define-properties@1.1.4:
     resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -604,32 +619,32 @@ packages:
       object-keys: 1.1.1
     dev: false
 
-  /dir-glob/3.0.1:
+  /dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
     dependencies:
       path-type: 4.0.0
     dev: false
 
-  /doctrine/2.1.0:
+  /doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
     dependencies:
       esutils: 2.0.3
     dev: false
 
-  /doctrine/3.0.0:
+  /doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
     dependencies:
       esutils: 2.0.3
     dev: false
 
-  /emoji-regex/9.2.2:
+  /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: false
 
-  /es-abstract/1.20.4:
+  /es-abstract@1.20.4:
     resolution: {integrity: sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -659,13 +674,13 @@ packages:
       unbox-primitive: 1.0.2
     dev: false
 
-  /es-shim-unscopables/1.0.0:
+  /es-shim-unscopables@1.0.0:
     resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==}
     dependencies:
       has: 1.0.3
     dev: false
 
-  /es-to-primitive/1.2.1:
+  /es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -674,17 +689,17 @@ packages:
       is-symbol: 1.0.4
     dev: false
 
-  /escape-string-regexp/1.0.5:
+  /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
     dev: true
 
-  /escape-string-regexp/4.0.0:
+  /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
     dev: false
 
-  /eslint-config-next/13.0.3_rmayb2veg2btbq6mbmnyivgasy:
+  /eslint-config-next@13.0.3(eslint@8.27.0)(typescript@4.8.4):
     resolution: {integrity: sha512-i2JoQP8gGv303GjXTonA27fm1ckRRkRoAP1WYEQgN0D2DDoFeBPqlJgHlMHnXKWjmNct/sW8jQEvy9am2juc8g==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -695,21 +710,21 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 13.0.3
       '@rushstack/eslint-patch': 1.2.0
-      '@typescript-eslint/parser': 5.42.1_rmayb2veg2btbq6mbmnyivgasy
+      '@typescript-eslint/parser': 5.42.1(eslint@8.27.0)(typescript@4.8.4)
       eslint: 8.27.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1_dcpv4nbdr5ks2h5677xdltrk6e
-      eslint-plugin-import: 2.26.0_fjrawv2a4e2kreqduevmayjdry
-      eslint-plugin-jsx-a11y: 6.6.1_eslint@8.27.0
-      eslint-plugin-react: 7.31.10_eslint@8.27.0
-      eslint-plugin-react-hooks: 4.6.0_eslint@8.27.0
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.27.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.42.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.27.0)
+      eslint-plugin-jsx-a11y: 6.6.1(eslint@8.27.0)
+      eslint-plugin-react: 7.31.10(eslint@8.27.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.27.0)
       typescript: 4.8.4
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
     dev: false
 
-  /eslint-import-resolver-node/0.3.6:
+  /eslint-import-resolver-node@0.3.6:
     resolution: {integrity: sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==}
     dependencies:
       debug: 3.2.7
@@ -718,7 +733,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-import-resolver-typescript/2.7.1_dcpv4nbdr5ks2h5677xdltrk6e:
+  /eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.26.0)(eslint@8.27.0):
     resolution: {integrity: sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -727,7 +742,7 @@ packages:
     dependencies:
       debug: 4.3.4
       eslint: 8.27.0
-      eslint-plugin-import: 2.26.0_fjrawv2a4e2kreqduevmayjdry
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.42.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.27.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.1
@@ -736,7 +751,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils/2.7.4_c5vbubjxm3sqe7zyydgtitlaga:
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.42.1)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)(eslint@8.27.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -757,16 +772,16 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.42.1_rmayb2veg2btbq6mbmnyivgasy
+      '@typescript-eslint/parser': 5.42.1(eslint@8.27.0)(typescript@4.8.4)
       debug: 3.2.7
       eslint: 8.27.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1_dcpv4nbdr5ks2h5677xdltrk6e
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.27.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-plugin-import/2.26.0_fjrawv2a4e2kreqduevmayjdry:
+  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.42.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.27.0):
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -776,14 +791,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.42.1_rmayb2veg2btbq6mbmnyivgasy
+      '@typescript-eslint/parser': 5.42.1(eslint@8.27.0)(typescript@4.8.4)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.27.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4_c5vbubjxm3sqe7zyydgtitlaga
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.42.1)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)(eslint@8.27.0)
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -797,7 +812,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-jsx-a11y/6.6.1_eslint@8.27.0:
+  /eslint-plugin-jsx-a11y@6.6.1(eslint@8.27.0):
     resolution: {integrity: sha512-sXgFVNHiWffBq23uiS/JaP6eVR622DqwB4yTzKvGZGcPq6/yZ3WmOZfuBks/vHWo9GaFOqC2ZK4i6+C35knx7Q==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -819,7 +834,7 @@ packages:
       semver: 6.3.0
     dev: false
 
-  /eslint-plugin-react-hooks/4.6.0_eslint@8.27.0:
+  /eslint-plugin-react-hooks@4.6.0(eslint@8.27.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -828,7 +843,7 @@ packages:
       eslint: 8.27.0
     dev: false
 
-  /eslint-plugin-react/7.31.10_eslint@8.27.0:
+  /eslint-plugin-react@7.31.10(eslint@8.27.0):
     resolution: {integrity: sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -851,7 +866,7 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: false
 
-  /eslint-scope/7.1.1:
+  /eslint-scope@7.1.1:
     resolution: {integrity: sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
@@ -859,7 +874,7 @@ packages:
       estraverse: 5.3.0
     dev: false
 
-  /eslint-utils/3.0.0_eslint@8.27.0:
+  /eslint-utils@3.0.0(eslint@8.27.0):
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
@@ -869,17 +884,17 @@ packages:
       eslint-visitor-keys: 2.1.0
     dev: false
 
-  /eslint-visitor-keys/2.1.0:
+  /eslint-visitor-keys@2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
     engines: {node: '>=10'}
     dev: false
 
-  /eslint-visitor-keys/3.3.0:
+  /eslint-visitor-keys@3.3.0:
     resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /eslint/8.27.0:
+  /eslint@8.27.0:
     resolution: {integrity: sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
@@ -895,7 +910,7 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
-      eslint-utils: 3.0.0_eslint@8.27.0
+      eslint-utils: 3.0.0(eslint@8.27.0)
       eslint-visitor-keys: 3.3.0
       espree: 9.4.1
       esquery: 1.4.0
@@ -927,44 +942,44 @@ packages:
       - supports-color
     dev: false
 
-  /espree/9.4.1:
+  /espree@9.4.1:
     resolution: {integrity: sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       acorn: 8.8.1
-      acorn-jsx: 5.3.2_acorn@8.8.1
+      acorn-jsx: 5.3.2(acorn@8.8.1)
       eslint-visitor-keys: 3.3.0
     dev: false
 
-  /esquery/1.4.0:
+  /esquery@1.4.0:
     resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
     dev: false
 
-  /esrecurse/4.3.0:
+  /esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
     engines: {node: '>=4.0'}
     dependencies:
       estraverse: 5.3.0
     dev: false
 
-  /estraverse/5.3.0:
+  /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
     dev: false
 
-  /esutils/2.0.3:
+  /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /fast-deep-equal/3.1.3:
+  /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: false
 
-  /fast-glob/3.2.12:
+  /fast-glob@3.2.12:
     resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
     engines: {node: '>=8.6.0'}
     dependencies:
@@ -975,35 +990,35 @@ packages:
       micromatch: 4.0.5
     dev: false
 
-  /fast-json-stable-stringify/2.1.0:
+  /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
     dev: false
 
-  /fast-levenshtein/2.0.6:
+  /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: false
 
-  /fastq/1.13.0:
+  /fastq@1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
     dependencies:
       reusify: 1.0.4
     dev: false
 
-  /file-entry-cache/6.0.1:
+  /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       flat-cache: 3.0.4
     dev: false
 
-  /fill-range/7.0.1:
+  /fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
     dev: false
 
-  /find-up/5.0.0:
+  /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
     dependencies:
@@ -1011,7 +1026,7 @@ packages:
       path-exists: 4.0.0
     dev: false
 
-  /flat-cache/3.0.4:
+  /flat-cache@3.0.4:
     resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
@@ -1019,19 +1034,19 @@ packages:
       rimraf: 3.0.2
     dev: false
 
-  /flatted/3.2.7:
+  /flatted@3.2.7:
     resolution: {integrity: sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==}
     dev: false
 
-  /fs.realpath/1.0.0:
+  /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: false
 
-  /function-bind/1.1.1:
+  /function-bind@1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
     dev: false
 
-  /function.prototype.name/1.1.5:
+  /function.prototype.name@1.1.5:
     resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1041,11 +1056,11 @@ packages:
       functions-have-names: 1.2.3
     dev: false
 
-  /functions-have-names/1.2.3:
+  /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: false
 
-  /get-intrinsic/1.1.3:
+  /get-intrinsic@1.1.3:
     resolution: {integrity: sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==}
     dependencies:
       function-bind: 1.1.1
@@ -1053,7 +1068,7 @@ packages:
       has-symbols: 1.0.3
     dev: false
 
-  /get-symbol-description/1.0.0:
+  /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1061,25 +1076,25 @@ packages:
       get-intrinsic: 1.1.3
     dev: false
 
-  /glob-parent/5.1.2:
+  /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
     dev: false
 
-  /glob-parent/6.0.2:
+  /glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
     dependencies:
       is-glob: 4.0.3
     dev: false
 
-  /glob-to-regexp/0.4.1:
+  /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
     dev: true
 
-  /glob/7.1.7:
+  /glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
     dependencies:
       fs.realpath: 1.0.0
@@ -1090,7 +1105,7 @@ packages:
       path-is-absolute: 1.0.1
     dev: false
 
-  /glob/7.2.3:
+  /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     dependencies:
       fs.realpath: 1.0.0
@@ -1101,14 +1116,14 @@ packages:
       path-is-absolute: 1.0.1
     dev: false
 
-  /globals/13.17.0:
+  /globals@13.17.0:
     resolution: {integrity: sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
     dev: false
 
-  /globby/11.1.0:
+  /globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
     dependencies:
@@ -1120,59 +1135,59 @@ packages:
       slash: 3.0.0
     dev: false
 
-  /graceful-fs/4.2.10:
+  /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
     dev: true
 
-  /grapheme-splitter/1.0.4:
+  /grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: false
 
-  /has-bigints/1.0.2:
+  /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
     dev: false
 
-  /has-flag/3.0.0:
+  /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
     dev: true
 
-  /has-flag/4.0.0:
+  /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
     dev: false
 
-  /has-property-descriptors/1.0.0:
+  /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
       get-intrinsic: 1.1.3
     dev: false
 
-  /has-symbols/1.0.3:
+  /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
     dev: false
 
-  /has-tostringtag/1.0.0:
+  /has-tostringtag@1.0.0:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
     dev: false
 
-  /has/1.0.3:
+  /has@1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
     dev: false
 
-  /ignore/5.2.0:
+  /ignore@5.2.0:
     resolution: {integrity: sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==}
     engines: {node: '>= 4'}
     dev: false
 
-  /import-fresh/3.3.0:
+  /import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
     dependencies:
@@ -1180,23 +1195,23 @@ packages:
       resolve-from: 4.0.0
     dev: false
 
-  /imurmurhash/0.1.4:
+  /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
     dev: false
 
-  /inflight/1.0.6:
+  /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
     dev: false
 
-  /inherits/2.0.4:
+  /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
     dev: false
 
-  /internal-slot/1.0.3:
+  /internal-slot@1.0.3:
     resolution: {integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1205,13 +1220,13 @@ packages:
       side-channel: 1.0.4
     dev: false
 
-  /is-bigint/1.0.4:
+  /is-bigint@1.0.4:
     resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==}
     dependencies:
       has-bigints: 1.0.2
     dev: false
 
-  /is-boolean-object/1.1.2:
+  /is-boolean-object@1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1219,59 +1234,59 @@ packages:
       has-tostringtag: 1.0.0
     dev: false
 
-  /is-callable/1.2.7:
+  /is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
     dev: false
 
-  /is-core-module/2.11.0:
+  /is-core-module@2.11.0:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
     dev: false
 
-  /is-date-object/1.0.5:
+  /is-date-object@1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
     dev: false
 
-  /is-extglob/2.1.1:
+  /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /is-glob/4.0.3:
+  /is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
     dev: false
 
-  /is-negative-zero/2.0.2:
+  /is-negative-zero@2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
     dev: false
 
-  /is-number-object/1.0.7:
+  /is-number-object@1.0.7:
     resolution: {integrity: sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
     dev: false
 
-  /is-number/7.0.0:
+  /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
     dev: false
 
-  /is-path-inside/3.0.3:
+  /is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
     dev: false
 
-  /is-regex/1.1.4:
+  /is-regex@1.1.4:
     resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1279,66 +1294,66 @@ packages:
       has-tostringtag: 1.0.0
     dev: false
 
-  /is-shared-array-buffer/1.0.2:
+  /is-shared-array-buffer@1.0.2:
     resolution: {integrity: sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==}
     dependencies:
       call-bind: 1.0.2
     dev: false
 
-  /is-string/1.0.7:
+  /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
     dev: false
 
-  /is-symbol/1.0.4:
+  /is-symbol@1.0.4:
     resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.0.3
     dev: false
 
-  /is-weakref/1.0.2:
+  /is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
     dependencies:
       call-bind: 1.0.2
     dev: false
 
-  /isexe/2.0.0:
+  /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  /js-sdsl/4.1.5:
+  /js-sdsl@4.1.5:
     resolution: {integrity: sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==}
     dev: false
 
-  /js-tokens/4.0.0:
+  /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
     dev: false
 
-  /js-yaml/4.1.0:
+  /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
     dependencies:
       argparse: 2.0.1
     dev: false
 
-  /json-schema-traverse/0.4.1:
+  /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
     dev: false
 
-  /json-stable-stringify-without-jsonify/1.0.1:
+  /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: false
 
-  /json5/1.0.1:
+  /json5@1.0.1:
     resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==}
     hasBin: true
     dependencies:
       minimist: 1.2.7
     dev: false
 
-  /jsx-ast-utils/3.3.3:
+  /jsx-ast-utils@3.3.3:
     resolution: {integrity: sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==}
     engines: {node: '>=4.0'}
     dependencies:
@@ -1346,17 +1361,17 @@ packages:
       object.assign: 4.1.4
     dev: false
 
-  /language-subtag-registry/0.3.22:
+  /language-subtag-registry@0.3.22:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
     dev: false
 
-  /language-tags/1.0.5:
+  /language-tags@1.0.5:
     resolution: {integrity: sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==}
     dependencies:
       language-subtag-registry: 0.3.22
     dev: false
 
-  /levn/0.4.1:
+  /levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
     dependencies:
@@ -1364,37 +1379,37 @@ packages:
       type-check: 0.4.0
     dev: false
 
-  /locate-path/6.0.0:
+  /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
     dependencies:
       p-locate: 5.0.0
     dev: false
 
-  /lodash.merge/4.6.2:
+  /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: false
 
-  /loose-envify/1.4.0:
+  /loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
     dev: false
 
-  /lru-cache/6.0.0:
+  /lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
     dev: false
 
-  /merge2/1.4.1:
+  /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
     dev: false
 
-  /micromatch/4.0.5:
+  /micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
     engines: {node: '>=8.6'}
     dependencies:
@@ -1402,39 +1417,39 @@ packages:
       picomatch: 2.3.1
     dev: false
 
-  /minimatch/3.1.2:
+  /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
       brace-expansion: 1.1.11
     dev: false
 
-  /minimist/1.2.7:
+  /minimist@1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
     dev: false
 
-  /ms/2.0.0:
+  /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
     dev: false
 
-  /ms/2.1.2:
+  /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: false
 
-  /ms/2.1.3:
+  /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: false
 
-  /nanoid/3.3.4:
+  /nanoid@3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: false
 
-  /natural-compare/1.4.0:
+  /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: false
 
-  /next/13.0.3_biqbaboplfbrettd7655fr4n2y:
+  /next@13.0.3(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-rFQeepcenRxKzeKlh1CsmEnxsJwhIERtbUjmYnKZyDInZsU06lvaGw5DT44rlNp1Rv2MT/e9vffZ8vK+ytwXHA==}
     engines: {node: '>=14.6.0'}
     hasBin: true
@@ -1457,9 +1472,9 @@ packages:
       caniuse-lite: 1.0.30001431
       postcss: 8.4.14
       react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      styled-jsx: 5.1.0_react@18.2.0
-      use-sync-external-store: 1.2.0_react@18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-jsx: 5.1.0(react@18.2.0)
+      use-sync-external-store: 1.2.0(react@18.2.0)
     optionalDependencies:
       '@next/swc-android-arm-eabi': 13.0.3
       '@next/swc-android-arm64': 13.0.3
@@ -1479,21 +1494,21 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /object-assign/4.1.1:
+  /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /object-inspect/1.12.2:
+  /object-inspect@1.12.2:
     resolution: {integrity: sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==}
     dev: false
 
-  /object-keys/1.1.1:
+  /object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
     dev: false
 
-  /object.assign/4.1.4:
+  /object.assign@4.1.4:
     resolution: {integrity: sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1503,7 +1518,7 @@ packages:
       object-keys: 1.1.1
     dev: false
 
-  /object.entries/1.1.6:
+  /object.entries@1.1.6:
     resolution: {integrity: sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1512,7 +1527,7 @@ packages:
       es-abstract: 1.20.4
     dev: false
 
-  /object.fromentries/2.0.6:
+  /object.fromentries@2.0.6:
     resolution: {integrity: sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1521,14 +1536,14 @@ packages:
       es-abstract: 1.20.4
     dev: false
 
-  /object.hasown/1.1.2:
+  /object.hasown@1.1.2:
     resolution: {integrity: sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==}
     dependencies:
       define-properties: 1.1.4
       es-abstract: 1.20.4
     dev: false
 
-  /object.values/1.1.6:
+  /object.values@1.1.6:
     resolution: {integrity: sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1537,13 +1552,13 @@ packages:
       es-abstract: 1.20.4
     dev: false
 
-  /once/1.4.0:
+  /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
     dev: false
 
-  /optionator/0.9.1:
+  /optionator@0.9.1:
     resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
     engines: {node: '>= 0.8.0'}
     dependencies:
@@ -1555,61 +1570,61 @@ packages:
       word-wrap: 1.2.3
     dev: false
 
-  /p-limit/3.1.0:
+  /p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
     dev: false
 
-  /p-locate/5.0.0:
+  /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
     dev: false
 
-  /parent-module/1.0.1:
+  /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
     dev: false
 
-  /path-exists/4.0.0:
+  /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
     dev: false
 
-  /path-is-absolute/1.0.1:
+  /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /path-key/3.1.1:
+  /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
     dev: false
 
-  /path-parse/1.0.7:
+  /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
     dev: false
 
-  /path-type/4.0.0:
+  /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
     dev: false
 
-  /picocolors/1.0.0:
+  /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: false
 
-  /picomatch/2.3.1:
+  /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
     dev: false
 
-  /postcss/8.4.14:
+  /postcss@8.4.14:
     resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
@@ -1618,12 +1633,12 @@ packages:
       source-map-js: 1.0.2
     dev: false
 
-  /prelude-ls/1.2.1:
+  /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
     dev: false
 
-  /prop-types/15.8.1:
+  /prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
     dependencies:
       loose-envify: 1.4.0
@@ -1631,16 +1646,16 @@ packages:
       react-is: 16.13.1
     dev: false
 
-  /punycode/2.1.1:
+  /punycode@2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
     dev: false
 
-  /queue-microtask/1.2.3:
+  /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: false
 
-  /react-dom/18.2.0_react@18.2.0:
+  /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
       react: ^18.2.0
@@ -1650,22 +1665,22 @@ packages:
       scheduler: 0.23.0
     dev: false
 
-  /react-is/16.13.1:
+  /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: false
 
-  /react/18.2.0:
+  /react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
     dev: false
 
-  /regenerator-runtime/0.13.10:
+  /regenerator-runtime@0.13.10:
     resolution: {integrity: sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==}
     dev: false
 
-  /regexp.prototype.flags/1.4.3:
+  /regexp.prototype.flags@1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
     engines: {node: '>= 0.4'}
     dependencies:
@@ -1674,17 +1689,17 @@ packages:
       functions-have-names: 1.2.3
     dev: false
 
-  /regexpp/3.2.0:
+  /regexpp@3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
     dev: false
 
-  /resolve-from/4.0.0:
+  /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
     dev: false
 
-  /resolve/1.22.1:
+  /resolve@1.22.1:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
     hasBin: true
     dependencies:
@@ -1693,7 +1708,7 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: false
 
-  /resolve/2.0.0-next.4:
+  /resolve@2.0.0-next.4:
     resolution: {integrity: sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==}
     hasBin: true
     dependencies:
@@ -1702,25 +1717,25 @@ packages:
       supports-preserve-symlinks-flag: 1.0.0
     dev: false
 
-  /reusify/1.0.4:
+  /reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
     dev: false
 
-  /rimraf/3.0.2:
+  /rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     hasBin: true
     dependencies:
       glob: 7.2.3
     dev: false
 
-  /run-parallel/1.2.0:
+  /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
     dev: false
 
-  /safe-regex-test/1.0.0:
+  /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
       call-bind: 1.0.2
@@ -1728,18 +1743,18 @@ packages:
       is-regex: 1.1.4
     dev: false
 
-  /scheduler/0.23.0:
+  /scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
       loose-envify: 1.4.0
     dev: false
 
-  /semver/6.3.0:
+  /semver@6.3.0:
     resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
     dev: false
 
-  /semver/7.3.8:
+  /semver@7.3.8:
     resolution: {integrity: sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==}
     engines: {node: '>=10'}
     hasBin: true
@@ -1747,19 +1762,19 @@ packages:
       lru-cache: 6.0.0
     dev: false
 
-  /shebang-command/2.0.0:
+  /shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
     dev: false
 
-  /shebang-regex/3.0.0:
+  /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
     dev: false
 
-  /side-channel/1.0.4:
+  /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
@@ -1767,17 +1782,17 @@ packages:
       object-inspect: 1.12.2
     dev: false
 
-  /slash/3.0.0:
+  /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
     dev: false
 
-  /source-map-js/1.0.2:
+  /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /string.prototype.matchall/4.0.8:
+  /string.prototype.matchall@4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
     dependencies:
       call-bind: 1.0.2
@@ -1790,7 +1805,7 @@ packages:
       side-channel: 1.0.4
     dev: false
 
-  /string.prototype.trimend/1.0.6:
+  /string.prototype.trimend@1.0.6:
     resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
     dependencies:
       call-bind: 1.0.2
@@ -1798,7 +1813,7 @@ packages:
       es-abstract: 1.20.4
     dev: false
 
-  /string.prototype.trimstart/1.0.6:
+  /string.prototype.trimstart@1.0.6:
     resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
     dependencies:
       call-bind: 1.0.2
@@ -1806,24 +1821,24 @@ packages:
       es-abstract: 1.20.4
     dev: false
 
-  /strip-ansi/6.0.1:
+  /strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
     dev: false
 
-  /strip-bom/3.0.0:
+  /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
     dev: false
 
-  /strip-json-comments/3.1.1:
+  /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
     dev: false
 
-  /styled-jsx/5.1.0_react@18.2.0:
+  /styled-jsx@5.1.0(react@18.2.0):
     resolution: {integrity: sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -1840,37 +1855,37 @@ packages:
       react: 18.2.0
     dev: false
 
-  /supports-color/5.5.0:
+  /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
     dependencies:
       has-flag: 3.0.0
     dev: true
 
-  /supports-color/7.2.0:
+  /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
     dev: false
 
-  /supports-preserve-symlinks-flag/1.0.0:
+  /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: false
 
-  /text-table/0.2.0:
+  /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: false
 
-  /to-regex-range/5.0.1:
+  /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
     dev: false
 
-  /tsconfig-paths/3.14.1:
+  /tsconfig-paths@3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
       '@types/json5': 0.0.29
@@ -1879,15 +1894,15 @@ packages:
       strip-bom: 3.0.0
     dev: false
 
-  /tslib/1.14.1:
+  /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: false
 
-  /tslib/2.4.1:
+  /tslib@2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
     dev: false
 
-  /tsutils/3.21.0_typescript@4.8.4:
+  /tsutils@3.21.0(typescript@4.8.4):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -1897,29 +1912,29 @@ packages:
       typescript: 4.8.4
     dev: false
 
-  /type-check/0.4.0:
+  /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.2.1
     dev: false
 
-  /type-fest/0.20.2:
+  /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
     dev: false
 
-  /typescript/4.8.4:
+  /typescript@4.8.4:
     resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: false
 
-  /ua-parser-js/1.0.32:
+  /ua-parser-js@1.0.32:
     resolution: {integrity: sha512-dXVsz3M4j+5tTiovFVyVqssXBu5HM47//YSOeZ9fQkdDKkfzv2v3PP1jmH6FUyPW+yCSn7aBVK1fGGKNhowdDA==}
     dev: false
 
-  /unbox-primitive/1.0.2:
+  /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
       call-bind: 1.0.2
@@ -1928,13 +1943,13 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: false
 
-  /uri-js/4.4.1:
+  /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.1.1
     dev: false
 
-  /use-sync-external-store/1.2.0_react@18.2.0:
+  /use-sync-external-store@1.2.0(react@18.2.0):
     resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -1942,7 +1957,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  /watchpack/2.4.0:
+  /watchpack@2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
     engines: {node: '>=10.13.0'}
     dependencies:
@@ -1950,7 +1965,7 @@ packages:
       graceful-fs: 4.2.10
     dev: true
 
-  /which-boxed-primitive/1.0.2:
+  /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
     dependencies:
       is-bigint: 1.0.4
@@ -1960,27 +1975,27 @@ packages:
       is-symbol: 1.0.4
     dev: false
 
-  /which/2.0.2:
+  /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
     dependencies:
       isexe: 2.0.0
 
-  /word-wrap/1.2.3:
+  /word-wrap@1.2.3:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /wrappy/1.0.2:
+  /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
     dev: false
 
-  /yallist/4.0.0:
+  /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: false
 
-  /yocto-queue/0.1.0:
+  /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: false

--- a/examples/cat_facts/web-yew/src/main.rs
+++ b/examples/cat_facts/web-yew/src/main.rs
@@ -94,6 +94,7 @@ impl Component for HelloWorld {
                             let response = HttpResponse {
                                 status: 200,
                                 body: bytes,
+                                ..Default::default()
                             };
 
                             send_effects(&link, core.resolve(&mut request, response))

--- a/examples/cat_facts/web-yew/src/main.rs
+++ b/examples/cat_facts/web-yew/src/main.rs
@@ -132,7 +132,7 @@ impl Component for HelloWorld {
                 </section>
                 <section class="section container has-text-centered">
                     if let Some(image) = &view.image {
-                        <img src={image.file.clone()} style="height: 400px" />
+                        <img src={image.href.clone()} style="height: 400px" />
                     }
                 </section>
                 <section class="section container has-text-centered">

--- a/examples/cat_facts/web-yew/src/main.rs
+++ b/examples/cat_facts/web-yew/src/main.rs
@@ -91,11 +91,7 @@ impl Component for HelloWorld {
 
                         async move {
                             let bytes = http_get(&url).await.unwrap_or_default();
-                            let response = HttpResponse {
-                                status: 200,
-                                body: bytes,
-                                ..Default::default()
-                            };
+                            let response = HttpResponse::status(200).body(bytes).build();
 
                             send_effects(&link, core.resolve(&mut request, response))
                         }

--- a/examples/counter/Android/app/src/main/java/com/example/counter/http.kt
+++ b/examples/counter/Android/app/src/main/java/com/example/counter/http.kt
@@ -6,6 +6,7 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
+import io.ktor.util.flattenEntries
 
 suspend fun http(
     client: HttpClient,
@@ -22,5 +23,6 @@ suspend fun http(
         }
     }
     val bytes: ByteArray = response.body()
-    return HttpResponse(response.status.value.toShort(), bytes.toList())
+    val headers = response.headers.flattenEntries().map { HttpHeader(it.first, it.second) }
+    return HttpResponse(response.status.value.toShort(), headers, bytes.toList())
 }

--- a/examples/counter/Android/shared/src/main/java/com/example/counter/shared_types/HttpResponse.java
+++ b/examples/counter/Android/shared/src/main/java/com/example/counter/shared_types/HttpResponse.java
@@ -3,18 +3,22 @@ package com.example.counter.shared_types;
 
 public final class HttpResponse {
     public final @com.novi.serde.Unsigned Short status;
+    public final java.util.List<HttpHeader> headers;
     public final java.util.List<@com.novi.serde.Unsigned Byte> body;
 
-    public HttpResponse(@com.novi.serde.Unsigned Short status, java.util.List<@com.novi.serde.Unsigned Byte> body) {
+    public HttpResponse(@com.novi.serde.Unsigned Short status, java.util.List<HttpHeader> headers, java.util.List<@com.novi.serde.Unsigned Byte> body) {
         java.util.Objects.requireNonNull(status, "status must not be null");
+        java.util.Objects.requireNonNull(headers, "headers must not be null");
         java.util.Objects.requireNonNull(body, "body must not be null");
         this.status = status;
+        this.headers = headers;
         this.body = body;
     }
 
     public void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {
         serializer.increase_container_depth();
         serializer.serialize_u16(status);
+        TraitHelpers.serialize_vector_HttpHeader(headers, serializer);
         TraitHelpers.serialize_vector_u8(body, serializer);
         serializer.decrease_container_depth();
     }
@@ -29,6 +33,7 @@ public final class HttpResponse {
         deserializer.increase_container_depth();
         Builder builder = new Builder();
         builder.status = deserializer.deserialize_u16();
+        builder.headers = TraitHelpers.deserialize_vector_HttpHeader(deserializer);
         builder.body = TraitHelpers.deserialize_vector_u8(deserializer);
         deserializer.decrease_container_depth();
         return builder.build();
@@ -52,6 +57,7 @@ public final class HttpResponse {
         if (getClass() != obj.getClass()) return false;
         HttpResponse other = (HttpResponse) obj;
         if (!java.util.Objects.equals(this.status, other.status)) { return false; }
+        if (!java.util.Objects.equals(this.headers, other.headers)) { return false; }
         if (!java.util.Objects.equals(this.body, other.body)) { return false; }
         return true;
     }
@@ -59,17 +65,20 @@ public final class HttpResponse {
     public int hashCode() {
         int value = 7;
         value = 31 * value + (this.status != null ? this.status.hashCode() : 0);
+        value = 31 * value + (this.headers != null ? this.headers.hashCode() : 0);
         value = 31 * value + (this.body != null ? this.body.hashCode() : 0);
         return value;
     }
 
     public static final class Builder {
         public @com.novi.serde.Unsigned Short status;
+        public java.util.List<HttpHeader> headers;
         public java.util.List<@com.novi.serde.Unsigned Byte> body;
 
         public HttpResponse build() {
             return new HttpResponse(
                 status,
+                headers,
                 body
             );
         }

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -1218,6 +1218,7 @@ dependencies = [
  "async-trait",
  "crux_core",
  "crux_macros",
+ "derive_builder",
  "futures-util",
  "http-types",
  "pin-project-lite",
@@ -1240,7 +1241,7 @@ dependencies = [
 name = "crux_macros"
 version = "0.3.2"
 dependencies = [
- "darling",
+ "darling 0.20.1",
  "proc-macro-error",
  "proc-macro2 1.0.63",
  "quote 1.0.29",
@@ -1366,12 +1367,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.1",
+ "darling_macro 0.20.1",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2 1.0.63",
+ "quote 1.0.29",
+ "strsim",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1390,11 +1415,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
+ "quote 1.0.29",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.1",
  "quote 1.0.29",
  "syn 2.0.22",
 ]
@@ -1408,6 +1444,37 @@ dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
  "syn 2.0.22",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2 1.0.63",
+ "quote 1.0.29",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4747,7 +4814,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
 dependencies = [
- "darling",
+ "darling 0.20.1",
  "proc-macro2 1.0.63",
  "quote 1.0.29",
  "syn 2.0.22",

--- a/examples/counter/cli/src/main.rs
+++ b/examples/counter/cli/src/main.rs
@@ -166,11 +166,7 @@ async fn http(
     let status = response.status().into();
 
     match response.body_bytes().await {
-        Ok(body) => Ok(HttpResponse {
-            status,
-            body,
-            ..Default::default()
-        }),
+        Ok(body) => Ok(HttpResponse::status(status).body(body).build()),
         Err(e) => bail!("{method} {url}: error {e}"),
     }
 }

--- a/examples/counter/cli/src/main.rs
+++ b/examples/counter/cli/src/main.rs
@@ -166,7 +166,11 @@ async fn http(
     let status = response.status().into();
 
     match response.body_bytes().await {
-        Ok(body) => Ok(HttpResponse { status, body }),
+        Ok(body) => Ok(HttpResponse {
+            status,
+            body,
+            ..Default::default()
+        }),
         Err(e) => bail!("{method} {url}: error {e}"),
     }
 }

--- a/examples/counter/iOS/CounterApp/ContentView.swift
+++ b/examples/counter/iOS/CounterApp/ContentView.swift
@@ -34,7 +34,7 @@ class Model: ObservableObject {
             if let httpResponse = response as? HTTPURLResponse {
                 let status = UInt16(httpResponse.statusCode)
                 let body = [UInt8](data)
-                self.update(msg: .response(uuid, .http(HttpResponse(status: status, body: body))))
+                self.update(msg: .response(uuid, .http(HttpResponse(status: status, headers: [], body: body))))
             }
         }
     }

--- a/examples/counter/shared/src/app.rs
+++ b/examples/counter/shared/src/app.rs
@@ -141,6 +141,7 @@ mod tests {
         testing::ResponseBuilder,
     };
 
+    // ANCHOR: simple_tests
     #[test]
     fn get_counter() {
         let app = AppTester::<App, _>::default();
@@ -149,25 +150,21 @@ mod tests {
         let mut update = app.update(Event::Get, &mut model);
 
         assert_let!(Effect::Http(request), update.effects_mut().next().unwrap());
-        let actual = &request.operation;
-        let expected = &HttpRequest {
-            method: "GET".to_string(),
-            url: "https://crux-counter.fly.dev/".to_string(),
-            headers: vec![],
-            body: vec![],
-        };
 
+        let actual = &request.operation;
+        let expected = &HttpRequest::get("https://crux-counter.fly.dev/").build();
         assert_eq!(actual, expected);
 
-        let response = HttpResponse {
-            status: 200,
-            body: serde_json::to_vec(&Counter {
-                value: 1,
-                updated_at: 1,
-            })
-            .unwrap(),
-            ..Default::default()
-        };
+        let response = HttpResponse::status(200)
+            .body(
+                serde_json::to_vec(&Counter {
+                    value: 1,
+                    updated_at: 1,
+                })
+                .unwrap(),
+            )
+            .build();
+
         let update = app.resolve(request, response).expect("an update");
 
         let actual = update.events;
@@ -192,6 +189,7 @@ mod tests {
         let expected = Some(true);
         assert_eq!(actual, expected);
     }
+    // ANCHOR_END: simple_tests
 
     #[test]
     fn increment_counter() {
@@ -211,25 +209,20 @@ mod tests {
         assert_eq!(actual, expected);
 
         assert_let!(Effect::Http(request), update.effects_mut().nth(1).unwrap());
-        let expected = &HttpRequest {
-            method: "POST".to_string(),
-            url: "https://crux-counter.fly.dev/inc".to_string(),
-            headers: vec![],
-            body: vec![],
-        };
         let actual = &request.operation;
+        let expected = &HttpRequest::post("https://crux-counter.fly.dev/inc").build();
 
         assert_eq!(actual, expected);
 
-        let response = HttpResponse {
-            status: 200,
-            body: serde_json::to_vec(&Counter {
-                value: 1,
-                updated_at: 1,
-            })
-            .unwrap(),
-            ..Default::default()
-        };
+        let response = HttpResponse::status(200)
+            .body(
+                serde_json::to_vec(&Counter {
+                    value: 1,
+                    updated_at: 1,
+                })
+                .unwrap(),
+            )
+            .build();
 
         let update = app.resolve(request, response).expect("Update to succeed");
 
@@ -256,24 +249,19 @@ mod tests {
         assert_eq!(actual, expected);
 
         assert_let!(Effect::Http(request), update.effects_mut().nth(1).unwrap());
-        let actual = request.operation.clone();
-        let expected = HttpRequest {
-            method: "POST".to_string(),
-            url: "https://crux-counter.fly.dev/dec".to_string(),
-            headers: vec![],
-            body: vec![],
-        };
+        let actual = &request.operation;
+        let expected = &HttpRequest::post("https://crux-counter.fly.dev/dec").build();
         assert_eq!(actual, expected);
 
-        let response = HttpResponse {
-            status: 200,
-            body: serde_json::to_vec(&Counter {
-                value: -1,
-                updated_at: 1,
-            })
-            .unwrap(),
-            ..Default::default()
-        };
+        let response = HttpResponse::status(200)
+            .body(
+                serde_json::to_vec(&Counter {
+                    value: -1,
+                    updated_at: 1,
+                })
+                .unwrap(),
+            )
+            .build();
 
         let update = app.resolve(request, response).expect("a successful update");
 

--- a/examples/counter/shared/src/app.rs
+++ b/examples/counter/shared/src/app.rs
@@ -166,6 +166,7 @@ mod tests {
                 updated_at: 1,
             })
             .unwrap(),
+            ..Default::default()
         };
         let update = app.resolve(request, response).expect("an update");
 
@@ -227,6 +228,7 @@ mod tests {
                 updated_at: 1,
             })
             .unwrap(),
+            ..Default::default()
         };
 
         let update = app.resolve(request, response).expect("Update to succeed");
@@ -270,6 +272,7 @@ mod tests {
                 updated_at: 1,
             })
             .unwrap(),
+            ..Default::default()
         };
 
         let update = app.resolve(request, response).expect("a successful update");

--- a/examples/counter/shared/src/app.rs
+++ b/examples/counter/shared/src/app.rs
@@ -156,13 +156,10 @@ mod tests {
         assert_eq!(actual, expected);
 
         let response = HttpResponse::status(200)
-            .body(
-                serde_json::to_vec(&Counter {
-                    value: 1,
-                    updated_at: 1,
-                })
-                .unwrap(),
-            )
+            .json(&Counter {
+                value: 1,
+                updated_at: 1,
+            })
             .build();
 
         let update = app.resolve(request, response).expect("an update");
@@ -215,13 +212,10 @@ mod tests {
         assert_eq!(actual, expected);
 
         let response = HttpResponse::status(200)
-            .body(
-                serde_json::to_vec(&Counter {
-                    value: 1,
-                    updated_at: 1,
-                })
-                .unwrap(),
-            )
+            .json(&Counter {
+                value: 1,
+                updated_at: 1,
+            })
             .build();
 
         let update = app.resolve(request, response).expect("Update to succeed");
@@ -254,13 +248,10 @@ mod tests {
         assert_eq!(actual, expected);
 
         let response = HttpResponse::status(200)
-            .body(
-                serde_json::to_vec(&Counter {
-                    value: -1,
-                    updated_at: 1,
-                })
-                .unwrap(),
-            )
+            .json(&Counter {
+                value: -1,
+                updated_at: 1,
+            })
             .build();
 
         let update = app.resolve(request, response).expect("a successful update");

--- a/examples/counter/tauri/src-tauri/src/http.rs
+++ b/examples/counter/tauri/src-tauri/src/http.rs
@@ -30,11 +30,7 @@ pub async fn http(http_request: &HttpRequest) -> Result<HttpResponse, Error> {
     let status = response.status().into();
 
     match response.body_bytes().await {
-        Ok(body) => Ok(HttpResponse {
-            status,
-            body,
-            ..Default::default()
-        }),
+        Ok(body) => Ok(HttpResponse::status(status).body(body).build()),
         Err(e) => Err(e.into()),
     }
 }

--- a/examples/counter/tauri/src-tauri/src/http.rs
+++ b/examples/counter/tauri/src-tauri/src/http.rs
@@ -30,7 +30,11 @@ pub async fn http(http_request: &HttpRequest) -> Result<HttpResponse, Error> {
     let status = response.status().into();
 
     match response.body_bytes().await {
-        Ok(body) => Ok(HttpResponse { status, body }),
+        Ok(body) => Ok(HttpResponse {
+            status,
+            body,
+            ..Default::default()
+        }),
         Err(e) => Err(e.into()),
     }
 }

--- a/examples/counter/web-leptos/src/http.rs
+++ b/examples/counter/web-leptos/src/http.rs
@@ -24,9 +24,5 @@ pub async fn request(request: &HttpRequest) -> Result<HttpResponse> {
     let response = request.send().await?;
     let body = response.binary().await?;
 
-    Ok(HttpResponse {
-        status: response.status(),
-        body,
-        ..Default::default()
-    })
+    Ok(HttpResponse::status(response.status()).body(body).build())
 }

--- a/examples/counter/web-leptos/src/http.rs
+++ b/examples/counter/web-leptos/src/http.rs
@@ -27,5 +27,6 @@ pub async fn request(request: &HttpRequest) -> Result<HttpResponse> {
     Ok(HttpResponse {
         status: response.status(),
         body,
+        ..Default::default()
     })
 }

--- a/examples/counter/web-nextjs/pages/httpRequest.ts
+++ b/examples/counter/web-nextjs/pages/httpRequest.ts
@@ -1,0 +1,30 @@
+import {
+  HttpRequest,
+  HttpResponse,
+  HttpHeader,
+} from "shared_types/types/shared_types";
+
+export async function httpRequest(
+  httpRequest: HttpRequest
+): Promise<HttpResponse> {
+  const req = new Request(httpRequest.url, {
+    method: httpRequest.method,
+    headers: httpRequest.headers.map((header) => [header.name, header.value]),
+  });
+
+  const res = await fetch(req);
+
+  const responseHeaders = Array.from(
+    res.headers.entries(),
+    ([name, value]) => new HttpHeader(name, value)
+  );
+
+  const body = await res.arrayBuffer();
+
+  const httpResponse = new HttpResponse(
+    res.status,
+    responseHeaders,
+    Array.from(new Uint8Array(body))
+  );
+  return httpResponse;
+}

--- a/examples/counter/web-nextjs/pages/index.tsx
+++ b/examples/counter/web-nextjs/pages/index.tsx
@@ -9,6 +9,8 @@ import init_core, {
 } from "../shared/core";
 import * as types from "shared_types/types/shared_types";
 import * as bincode from "shared_types/bincode/mod";
+import { httpRequest } from "./httpRequest";
+import { sseRequest } from "./sseRequest";
 
 interface Event {
   kind: "event";
@@ -72,7 +74,7 @@ const Home: NextPage = () => {
 
     for (const { uuid, effect } of requests) {
       switch (effect.constructor) {
-        case types.EffectVariantRender:
+        case types.EffectVariantRender: {
           let bytes = view();
           let viewDeserializer = new bincode.BincodeDeserializer(bytes);
           let viewModel = types.ViewModel.deserialize(viewDeserializer);
@@ -81,51 +83,24 @@ const Home: NextPage = () => {
           setState({
             text: viewModel.text,
           });
-
           break;
+        }
+
         case types.EffectVariantHttp: {
-          const { method, url, headers } = (effect as types.EffectVariantHttp)
-            .value;
-          const req = new Request(url, {
-            method,
-            headers: headers.map((header) => [header.name, header.value]),
-          });
-          const res = await fetch(req);
-          const body = await res.arrayBuffer();
-          const response_bytes = Array.from(new Uint8Array(body));
-
-          respond({
-            kind: "response",
-            uuid,
-            outcome: new types.HttpResponse(res.status, [], response_bytes),
-          });
+          const request = (effect as types.EffectVariantHttp).value;
+          const outcome = await httpRequest(request);
+          respond({ kind: "response", uuid, outcome });
           break;
         }
+
         case types.EffectVariantServerSentEvents: {
-          const { url } = (effect as types.EffectVariantServerSentEvents).value;
-          const req = new Request(url);
-          const res = await fetch(req);
-          const reader = await res.body.getReader();
-          try {
-            while (true) {
-              const { done, value: chunk } = await reader.read();
-              respond({
-                kind: "response",
-                uuid,
-                outcome: done
-                  ? new types.SseResponseVariantDone()
-                  : new types.SseResponseVariantChunk(Array.from(chunk)),
-              });
-              if (done) {
-                break;
-              }
-            }
-          } finally {
-            reader.releaseLock();
+          const request = (effect as types.EffectVariantServerSentEvents).value;
+          for await (const outcome of sseRequest(request)) {
+            respond({ kind: "response", uuid, outcome });
           }
-
           break;
         }
+
         default:
       }
     }

--- a/examples/counter/web-nextjs/pages/index.tsx
+++ b/examples/counter/web-nextjs/pages/index.tsx
@@ -19,9 +19,9 @@ interface Response {
   kind: "response";
   uuid: number[];
   outcome:
-  | types.HttpResponse
-  | types.SseResponseVariantChunk
-  | types.SseResponseVariantDone;
+    | types.HttpResponse
+    | types.SseResponseVariantChunk
+    | types.SseResponseVariantDone;
 }
 
 type State = {
@@ -97,7 +97,7 @@ const Home: NextPage = () => {
           respond({
             kind: "response",
             uuid,
-            outcome: new types.HttpResponse(res.status, response_bytes),
+            outcome: new types.HttpResponse(res.status, [], response_bytes),
           });
           break;
         }

--- a/examples/counter/web-nextjs/pages/sseRequest.ts
+++ b/examples/counter/web-nextjs/pages/sseRequest.ts
@@ -1,0 +1,26 @@
+import {
+  SseRequest,
+  SseResponseVariantDone,
+  SseResponseVariantChunk,
+} from "shared_types/types/shared_types";
+
+export async function* sseRequest(sseRequest: SseRequest) {
+  const req = new Request(sseRequest.url);
+
+  const res = await fetch(req);
+
+  const reader = res.body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      yield done
+        ? new SseResponseVariantDone()
+        : new SseResponseVariantChunk(Array.from(value));
+      if (done) {
+        break;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/examples/counter/web-yew/src/http.rs
+++ b/examples/counter/web-yew/src/http.rs
@@ -24,9 +24,5 @@ pub async fn request(request: &HttpRequest) -> Result<HttpResponse> {
     let response = request.send().await?;
     let body = response.binary().await?;
 
-    Ok(HttpResponse {
-        status: response.status(),
-        body,
-        ..Default::default()
-    })
+    Ok(HttpResponse::status(response.status()).body(body).build())
 }

--- a/examples/counter/web-yew/src/http.rs
+++ b/examples/counter/web-yew/src/http.rs
@@ -27,5 +27,6 @@ pub async fn request(request: &HttpRequest) -> Result<HttpResponse> {
     Ok(HttpResponse {
         status: response.status(),
         body,
+        ..Default::default()
     })
 }

--- a/examples/hello_world/shared/src/hello_world.rs
+++ b/examples/hello_world/shared/src/hello_world.rs
@@ -1,3 +1,5 @@
+// ANCHOR: app
+
 use crux_core::{render::Render, App};
 use crux_macros::Effect;
 use serde::{Deserialize, Serialize};
@@ -41,6 +43,9 @@ impl App for Hello {
     }
 }
 
+// ANCHOR_END: app
+
+// ANCHOR: test
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -63,3 +68,5 @@ mod tests {
         assert_eq!(actual_view, expected_view);
     }
 }
+
+// ANCHOR_END: test

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # run the tests
 cargo nextest run --all-features
 


### PR DESCRIPTION
Adds ability to use HTTP headers returned from requests. 

- [x] Add headers to `HttpResponse`
- [x] Add builder pattern to avoid having to add `..Default::default()` everywhere