### PR TITLE
Android improved documentation

### DIFF
--- a/docs/src/getting_started/Android/android.md
+++ b/docs/src/getting_started/Android/android.md
@@ -93,6 +93,12 @@ dynamic library and generating the runtime bindings and the shared types.
 
 Let's get started.
 
+Add the four rust android toolchains to your system:
+
+```sh
+$ rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+```
+
 Edit the **project**'s `build.gradle` (`/Android/build.gradle`) to look like
 this:
 
@@ -120,6 +126,12 @@ $ ls --tree Android/shared/build/rustJniLibs
 Android/shared/build/rustJniLibs
 └── android
    └── arm64-v8a
+      └── libshared.so
+   └── armeabi-v7a
+      └── libshared.so
+   └── x86
+      └── libshared.so
+   └── x86_64
       └── libshared.so
 ```
 

--- a/examples/cat_facts/Android/shared/build.gradle
+++ b/examples/cat_facts/Android/shared/build.gradle
@@ -56,7 +56,10 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 cargo {
     module  = "../.."
     libname = "shared"
-    targets = ["arm64"]
+    // these are the four recommended targets for Android that will ensure your library works on all mainline android devices
+    // make sure you have included the rust toolchain for each of these targets: \
+    // `rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android`
+    targets = ["arm", "arm64", "x86", "x86_64"]
     extraCargoBuildArguments = ['--package', 'shared']
 }
 

--- a/examples/counter/Android/shared/build.gradle
+++ b/examples/counter/Android/shared/build.gradle
@@ -54,7 +54,10 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 cargo {
     module = "../.."
     libname = "shared"
-    targets = ["arm64"]
+    // these are the four recommended targets for Android that will ensure your library works on all mainline android devices
+    // make sure you have included the rust toolchain for each of these targets: \
+    // `rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android`
+    targets = ["arm", "arm64", "x86", "x86_64"]
     extraCargoBuildArguments = ['--package', 'shared']
 }
 

--- a/examples/simple_counter/Android/shared/build.gradle
+++ b/examples/simple_counter/Android/shared/build.gradle
@@ -57,7 +57,10 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 cargo {
     module = "../.."
     libname = "shared"
-    targets = ["arm64"]
+    // these are the four recommended targets for Android that will ensure your library works on all mainline android devices
+    // make sure you have included the rust toolchain for each of these targets: \
+    // `rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android`
+    targets = ["arm", "arm64", "x86", "x86_64"]
     extraCargoBuildArguments = ['--package', 'shared']
 }
 

--- a/templates/simple_counter/Android/shared/build.gradle
+++ b/templates/simple_counter/Android/shared/build.gradle
@@ -57,7 +57,7 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 cargo {
     module = "../.."
     libname = "shared"
-    targets = ["arm64"]
+    targets = ["arm", "arm64", "x86", "x86_64"]
     extraCargoBuildArguments = ['--package', 'shared']
 }
 

--- a/templates/simple_counter/Android/shared/build.gradle
+++ b/templates/simple_counter/Android/shared/build.gradle
@@ -57,6 +57,9 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 cargo {
     module = "../.."
     libname = "shared"
+    // these are the four recommended targets for Android that will ensure your library works on all mainline android devices
+    // make sure you have included the rust toolchain for each of these targets: \
+    // `rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android`
     targets = ["arm", "arm64", "x86", "x86_64"]
     extraCargoBuildArguments = ['--package', 'shared']
 }


### PR DESCRIPTION
This PR improves documentation for Android and includes changes necessary to target all android devices supported by Mozilla's gradle plugin.

I have made changes to the android shared module's build.gradle in the template app; as well as, the relevant sample apps.

I have included instructions on the Android getting started covering the need to include the required rust toolchains and reflected the expected directory changes in the getting started guide.