### PR TITLE
Add filtering and charting to the bridge perf example

### DIFF
--- a/examples/bridge_echo/shared/src/app.rs
+++ b/examples/bridge_echo/shared/src/app.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 // ANCHOR: app
 use crux_core::render::Render;
 use crux_macros::Effect;
@@ -5,14 +7,20 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum Event {
+    Start(usize),
+    Stop,
     Tick,
     NewPeriod,
 }
 
+const EMA_ALPHA: f64 = 0.2; // TODO tune!
+
 #[derive(Default, Debug, PartialEq)]
 pub struct Model {
+    sample_period: Option<Duration>,
     log: Vec<usize>,
     count: usize,
+    rate: f64, // per second
 }
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
@@ -38,9 +46,48 @@ impl crux_core::App for App {
 
     fn update(&self, event: Self::Event, model: &mut Self::Model, caps: &Self::Capabilities) {
         match event {
-            Event::Tick => model.count += 1,
+            Event::Start(msecs) => {
+                if model.sample_period.is_some() {
+                    return;
+                }
+
+                model.count = 0;
+                model.rate = 0.0;
+                model.log = vec![];
+                model.sample_period = Some(Duration::from_millis(msecs as u64));
+            }
+            Event::Stop => {
+                if model.sample_period.is_none() {
+                    return;
+                }
+
+                model.sample_period = None;
+            }
+            Event::Tick => {
+                if model.sample_period.is_none() {
+                    return;
+                }
+
+                model.count += 1
+            }
             Event::NewPeriod => {
-                model.log.push(model.count);
+                let Some(period_duration) = model.sample_period else {
+                    return;
+                };
+
+                // Normalise count to 'per second' scale
+                let count_per_second =
+                    model.count as f64 * (1000.0 / period_duration.as_millis() as f64);
+
+                model.log.push(count_per_second as usize);
+
+                // Filter with an exponential moving average
+                model.rate = if model.rate > 0.0 {
+                    model.rate * (1.0 - EMA_ALPHA) + EMA_ALPHA * count_per_second
+                } else {
+                    count_per_second
+                };
+
                 model.count = 0;
             }
         };
@@ -62,6 +109,94 @@ mod test {
     use crux_core::{assert_effect, testing::AppTester};
 
     #[test]
+    fn start_resets_everything() {
+        let app = AppTester::<App, _>::default();
+        let mut model = Model {
+            sample_period: None,
+            log: vec![20, 23, 42],
+            count: 57,
+            rate: 45.0,
+        };
+
+        app.update(Event::Start(1000), &mut model);
+
+        let expected = Model {
+            sample_period: Some(Duration::from_millis(1000)),
+            log: vec![],
+            count: 0,
+            rate: 0.0,
+        };
+
+        assert_eq!(model, expected);
+    }
+
+    #[test]
+    fn start_does_nothing_when_already_running() {
+        let app = AppTester::<App, _>::default();
+        let mut model = Model {
+            sample_period: Some(Duration::from_millis(300)),
+            log: vec![20, 23, 42],
+            count: 57,
+            rate: 45.0,
+        };
+
+        app.update(Event::Start(1000), &mut model);
+
+        let expected = Model {
+            sample_period: Some(Duration::from_millis(300)),
+            log: vec![20, 23, 42],
+            count: 57,
+            rate: 45.0,
+        };
+
+        assert_eq!(model, expected);
+    }
+
+    #[test]
+    fn stop_resets_sample_period() {
+        let app = AppTester::<App, _>::default();
+        let mut model = Model {
+            sample_period: Some(Duration::from_millis(300)),
+            log: vec![20, 23, 42],
+            count: 57,
+            rate: 45.0,
+        };
+
+        app.update(Event::Stop, &mut model);
+
+        let expected = Model {
+            sample_period: None,
+            log: vec![20, 23, 42],
+            count: 57,
+            rate: 45.0,
+        };
+
+        assert_eq!(model, expected);
+    }
+
+    #[test]
+    fn stop_does_nothing_when_not_running() {
+        let app = AppTester::<App, _>::default();
+        let mut model = Model {
+            sample_period: None,
+            log: vec![20, 23, 42],
+            count: 57,
+            rate: 45.0,
+        };
+
+        app.update(Event::Stop, &mut model);
+
+        let expected = Model {
+            sample_period: None,
+            log: vec![20, 23, 42],
+            count: 57,
+            rate: 45.0,
+        };
+
+        assert_eq!(model, expected);
+    }
+
+    #[test]
     fn shows_initial_count() {
         let app = AppTester::<App, _>::default();
         let model = Model::default();
@@ -73,10 +208,11 @@ mod test {
     }
 
     #[test]
-    fn increments_count() {
+    fn increments_count_when_running() {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
+        app.update(Event::Start(500), &mut model);
         app.update(Event::Tick, &mut model);
         app.update(Event::Tick, &mut model);
         app.update(Event::Tick, &mut model);
@@ -88,10 +224,26 @@ mod test {
     }
 
     #[test]
+    fn ignores_tick_when_not_running() {
+        let app = AppTester::<App, _>::default();
+        let mut model = Model::default();
+
+        app.update(Event::Tick, &mut model);
+        app.update(Event::Tick, &mut model);
+        app.update(Event::Tick, &mut model);
+
+        let actual_view = app.view(&model);
+        let expected_view = ViewModel { count: 0 };
+
+        assert_eq!(actual_view, expected_view);
+    }
+
+    #[test]
     fn logs_previous_counts() {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
+        app.update(Event::Start(200), &mut model);
         app.update(Event::Tick, &mut model);
         app.update(Event::Tick, &mut model);
         app.update(Event::Tick, &mut model);
@@ -102,8 +254,10 @@ mod test {
         app.update(Event::Tick, &mut model);
 
         let expected = Model {
-            log: vec![3, 2],
+            sample_period: Some(Duration::from_millis(200)),
+            log: vec![15, 10],
             count: 1,
+            rate: 15.0 * (1.0 - EMA_ALPHA) + 10.0 * EMA_ALPHA,
         };
         assert_eq!(model, expected);
     }
@@ -113,6 +267,7 @@ mod test {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
+        app.update(Event::Start(500), &mut model);
         let update = app.update(Event::Tick, &mut model);
 
         assert_effect!(update, Effect::Render(_));
@@ -123,6 +278,7 @@ mod test {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
+        app.update(Event::Start(500), &mut model);
         let update = app.update(Event::NewPeriod, &mut model);
 
         assert_effect!(update, Effect::Render(_));


### PR DESCRIPTION
Flesh out the bridge performance example a little bit.

### This adds:
- [ ] Start stop buttons
- [x] Normalisation to messages/second
- [x] Exponential moving average smoothing
   - [x] Core
   - [ ] Shells 
- [ ] Sparkline charting in the shells
   - [ ] Leptos
   - [ ] React
   - [ ] iOS
   - [ ] Android