### PR TITLE
Generated java types general housekeeping

### DIFF
--- a/crux_core/src/typegen.rs
+++ b/crux_core/src/typegen.rs
@@ -355,6 +355,11 @@ impl TypeGen {
 
         fs::create_dir_all(&path)?;
 
+        let package_path = package_name.replace('.', "/");
+
+        // remove any existing generated shared types, this ensures that we remove no longer used types
+        fs::remove_dir_all(path.as_ref().to_path_buf().join(&package_path)).unwrap_or(());
+
         let config = serde_generate::CodeGeneratorConfig::new(package_name.to_string())
             .with_encodings(vec![Encoding::Bincode]);
 
@@ -374,8 +379,6 @@ impl TypeGen {
         installer
             .install_module(&config, registry)
             .map_err(|e| TypeGenError::Generation(e.to_string()))?;
-
-        let package_path = package_name.replace('.', "/");
 
         let requests = format!(
             "package {package_name};\n\n{}",

--- a/crux_core/src/typegen.rs
+++ b/crux_core/src/typegen.rs
@@ -358,7 +358,7 @@ impl TypeGen {
         let package_path = package_name.replace('.', "/");
 
         // remove any existing generated shared types, this ensures that we remove no longer used types
-        fs::remove_dir_all(path.as_ref().to_path_buf().join(&package_path)).unwrap_or(());
+        fs::remove_dir_all(path.as_ref().join(&package_path)).unwrap_or(());
 
         let config = serde_generate::CodeGeneratorConfig::new(package_name.to_string())
             .with_encodings(vec![Encoding::Bincode]);


### PR DESCRIPTION
When building the core app with an android target, java files are generated that we reference from kotlin to help facilitate our interaction with the core app. During this process, any types that were no longer being used were left in place. This PR updates the Java type generation helper clean up the shared types directory before generating the updated set of types.