### PR TITLE
Added Send trait to NewEv generic type inside Capability derive macro

### DIFF
--- a/crux_macros/src/capability.rs
+++ b/crux_macros/src/capability.rs
@@ -40,7 +40,7 @@ impl ToTokens for CapabilityStructReceiver {
             where
                 F: Fn(NewEv) -> Ev + Send + Sync + Copy + 'static,
                 Ev: 'static,
-                NewEv: 'static,
+                NewEv: 'static + Send,
             {
               #name::new(self.context.map_event(f))
             }

--- a/crux_macros/src/capability.rs
+++ b/crux_macros/src/capability.rs
@@ -40,7 +40,7 @@ impl ToTokens for CapabilityStructReceiver {
             where
                 F: Fn(NewEv) -> Ev + Send + Sync + Copy + 'static,
                 Ev: 'static,
-                NewEv: 'static + Send,
+                NewEv: 'static,
             {
               #name::new(self.context.map_event(f))
             }

--- a/docs/src/guide/capability_apis.md
+++ b/docs/src/guide/capability_apis.md
@@ -75,7 +75,10 @@ where
         Self { context }
     }
 
-    pub fn milliseconds(&self, millis: usize, event: Ev) {
+    pub fn milliseconds(&self, millis: usize, event: Ev)
+    where
+        Ev: Send,
+    {
         let ctx = self.context.clone();
         self.context.spawn(async move {
             ctx.request_from_shell(DelayOperation { millis }).await;

--- a/examples/tap_to_pay/shared/src/capabilities/delay.rs
+++ b/examples/tap_to_pay/shared/src/capabilities/delay.rs
@@ -1,4 +1,5 @@
-use crux_core::capability::{Capability, CapabilityContext, Operation};
+use crux_core::capability::{CapabilityContext, Operation};
+use crux_macros::Capability;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -10,19 +11,23 @@ impl Operation for DelayOperation {
     type Output = ();
 }
 
+#[derive(Capability)]
 pub struct Delay<Event> {
     context: CapabilityContext<DelayOperation, Event>,
 }
 
 impl<Ev> Delay<Ev>
 where
-    Ev: 'static + Send,
+    Ev: 'static,
 {
     pub fn new(context: CapabilityContext<DelayOperation, Ev>) -> Self {
         Self { context }
     }
 
-    pub fn start(&self, millis: usize, event: Ev) {
+    pub fn start(&self, millis: usize, event: Ev)
+    where
+        Ev: Send,
+    {
         self.context.spawn({
             let context = self.context.clone();
 
@@ -34,19 +39,5 @@ where
                 context.update_app(event);
             }
         })
-    }
-}
-
-impl<Ev> Capability<Ev> for Delay<Ev> {
-    type Operation = DelayOperation;
-    type MappedSelf<MappedEv> = Delay<MappedEv>;
-
-    fn map_event<F, NewEvent>(&self, f: F) -> Self::MappedSelf<NewEvent>
-    where
-        F: Fn(NewEvent) -> Ev + Send + Sync + Copy + 'static,
-        Ev: 'static,
-        NewEvent: 'static + Send,
-    {
-        Delay::new(self.context.map_event(f))
     }
 }


### PR DESCRIPTION
Fixes #147 by adding the Send trait to the generic type NewEv inside map_event function of the Capability macro.

In the tap_to_pay example, there is a Delay capability in which the same was done:
```rust
impl<Ev> Capability<Ev> for Delay<Ev> {
    type Operation = DelayOperation;
    type MappedSelf<MappedEv> = Delay<MappedEv>;

    fn map_event<F, NewEvent>(&self, f: F) -> Self::MappedSelf<NewEvent>
    where
        F: Fn(NewEvent) -> Ev + Send + Sync + Copy + 'static,
        Ev: 'static,
        NewEvent: 'static + Send, // <------------- Send trait was added
    {
        Delay::new(self.context.map_event(f))
    }
}
```