### PR TITLE
full error message

### DIFF
--- a/crux_core/src/typegen.rs
+++ b/crux_core/src/typegen.rs
@@ -213,9 +213,9 @@ impl TypeGen {
             State::Registering(tracer, _) => match tracer.trace_simple_type::<T>() {
                 Ok(_) => Ok(()),
                 Err(e @ serde_reflection::Error::DeserializationError(_)) => {
-                    Err(TypeGenError::Deserialization(e.explanation()))
+                    Err(TypeGenError::Deserialization(format!("{}: {}",e.to_string(), e.explanation())))
                 }
-                Err(e) => Err(TypeGenError::TypeTracing(e.explanation())),
+                Err(e) => Err(TypeGenError::TypeTracing(format!("{}: {}",e.to_string(), e.explanation()))),
             },
             _ => Err(TypeGenError::LateRegistration),
         }
@@ -258,18 +258,18 @@ impl TypeGen {
                     match tracer.trace_value::<T>(samples, sample) {
                         Ok(_) => {}
                         Err(e @ serde_reflection::Error::DeserializationError(_)) => {
-                            return Err(TypeGenError::ValueTracing(e.explanation()))
+                            return Err(TypeGenError::ValueTracing(format!("{}: {}",e.to_string(), e.explanation())))
                         }
-                        Err(e) => return Err(TypeGenError::ValueTracing(e.explanation())),
+                        Err(e) => return Err(TypeGenError::ValueTracing(format!("{}: {}",e.to_string(), e.explanation()))),
                     }
                 }
 
                 match tracer.trace_type::<T>(samples) {
                     Ok(_) => Ok(()),
                     Err(e @ serde_reflection::Error::DeserializationError(_)) => {
-                        Err(TypeGenError::Deserialization(e.explanation()))
+                        Err(TypeGenError::Deserialization(format!("{}: {}",e.to_string(), e.explanation())))
                     }
-                    Err(e) => Err(TypeGenError::TypeTracing(e.explanation())),
+                    Err(e) => Err(TypeGenError::TypeTracing(format!("{}: {}",e.to_string(), e.explanation()))),
                 }
             }
             _ => Err(TypeGenError::LateRegistration),


### PR DESCRIPTION
Current errors from typegen can get very puzzling, as `e.explanation()` doesn't mention concrete types which caused the error. 

Example of error message before the change:

```
TypeTracing("\nTwo formats computed for the same entity do not match. This can happen if custom implementations of\nthe Serialize and Deserialize traits do not agree, e.g. if one uses `Vec<u8>` and the other one uses `&[u8]`\n(implying bytes) --- see the crate `serde_bytes` for more context in this particular example.\n\nVerify the implementations of Serialize and Deserialize for the given format.\n")
```

This PR adds full error message to tracing and deserialization errors. 

Here's an example error message with this change:

```
TypeTracing("Incompatible formats detected: TypeName(\"KeyValueOperation\") TypeName(\"NavigateOperation\"): \nTwo formats computed for the same entity do not match. This can happen if custom implementations of\nthe Serialize and Deserialize traits do not agree, e.g. if one uses `Vec<u8>` and the other one uses `&[u8]`\n(implying bytes) --- see the crate `serde_bytes` for more context in this particular example.\n\nVerify the implementations of Serialize and Deserialize for the given format.\n")
```