### PR TITLE
Improve typegen error handling

### DIFF
--- a/examples/bridge_echo/shared_types/build.rs
+++ b/examples/bridge_echo/shared_types/build.rs
@@ -2,24 +2,23 @@ use crux_core::typegen::TypeGen;
 use shared::App;
 use std::path::PathBuf;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed=../shared");
 
     let mut gen = TypeGen::new();
 
-    gen.register_app::<App>().expect("register");
+    gen.register_app::<App>()?;
 
     let output_root = PathBuf::from("./generated");
 
-    gen.swift("SharedTypes", output_root.join("swift"))
-        .expect("swift type gen failed");
+    gen.swift("SharedTypes", output_root.join("swift"))?;
 
     gen.java(
         "com.example.bridge_echo.shared_types",
         output_root.join("java"),
-    )
-    .expect("java type gen failed");
+    )?;
 
-    gen.typescript("shared_types", output_root.join("typescript"))
-        .expect("typescript type gen failed");
+    gen.typescript("shared_types", output_root.join("typescript"))?;
+
+    Ok(())
 }

--- a/examples/cat_facts/shared_types/build.rs
+++ b/examples/cat_facts/shared_types/build.rs
@@ -2,24 +2,23 @@ use crux_core::typegen::TypeGen;
 use shared::CatFacts;
 use std::path::PathBuf;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed=../shared");
 
     let mut gen = TypeGen::new();
 
-    gen.register_app::<CatFacts>().expect("register");
+    gen.register_app::<CatFacts>()?;
 
     let output_root = PathBuf::from("./generated");
 
-    gen.swift("SharedTypes", output_root.join("swift"))
-        .expect("swift type gen failed");
+    gen.swift("SharedTypes", output_root.join("swift"))?;
 
     gen.java(
         "com.redbadger.catfacts.shared_types",
         output_root.join("java"),
-    )
-    .expect("java type gen failed");
+    )?;
 
-    gen.typescript("shared_types", output_root.join("typescript"))
-        .expect("typescript type gen failed");
+    gen.typescript("shared_types", output_root.join("typescript"))?;
+
+    Ok(())
 }

--- a/examples/counter/shared_types/build.rs
+++ b/examples/counter/shared_types/build.rs
@@ -2,21 +2,20 @@ use crux_core::typegen::TypeGen;
 use shared::App;
 use std::path::PathBuf;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed=../shared");
 
     let mut gen = TypeGen::new();
 
-    gen.register_app::<App>().expect("register");
+    gen.register_app::<App>()?;
 
     let output_root = PathBuf::from("./generated");
 
-    gen.swift("SharedTypes", output_root.join("swift"))
-        .expect("swift type gen failed");
+    gen.swift("SharedTypes", output_root.join("swift"))?;
 
-    gen.java("com.example.counter.shared_types", output_root.join("java"))
-        .expect("java type gen failed");
+    gen.java("com.example.counter.shared_types", output_root.join("java"))?;
 
-    gen.typescript("shared_types", output_root.join("typescript"))
-        .expect("typescript type gen failed");
+    gen.typescript("shared_types", output_root.join("typescript"))?;
+
+    Ok(())
 }

--- a/examples/notes/shared_types/build.rs
+++ b/examples/notes/shared_types/build.rs
@@ -2,27 +2,26 @@ use crux_core::typegen::TypeGen;
 use shared::{NoteEditor, TextCursor};
 use std::path::PathBuf;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed=../shared");
 
     let mut gen = TypeGen::new();
 
-    gen.register_app::<NoteEditor>().expect("register");
+    gen.register_app::<NoteEditor>()?;
 
     // Note: currently required as we can't find enums inside enums, see:
     // https://github.com/zefchain/serde-reflection/tree/main/serde-reflection#supported-features
-    gen.register_type::<TextCursor>().expect("register");
+    gen.register_type::<TextCursor>()?;
 
     let output_root = PathBuf::from("./generated");
 
-    gen.swift("SharedTypes", output_root.join("swift"))
-        .expect("swift type gen failed");
+    gen.swift("SharedTypes", output_root.join("swift"))?;
 
     // TODO these are for later
     //
-    // gen.java("com.example.counter.shared_types", output_root.join("java"))
-    //     .expect("java type gen failed");
+    // gen.java("com.example.counter.shared_types", output_root.join("java"))?;
 
-    gen.typescript("shared_types", output_root.join("typescript"))
-        .expect("typescript type gen failed");
+    gen.typescript("shared_types", output_root.join("typescript"))?;
+
+    Ok(())
 }

--- a/examples/simple_counter/shared_types/build.rs
+++ b/examples/simple_counter/shared_types/build.rs
@@ -2,24 +2,23 @@ use crux_core::typegen::TypeGen;
 use shared::Counter;
 use std::path::PathBuf;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed=../shared");
 
     let mut gen = TypeGen::new();
 
-    gen.register_app::<Counter>().expect("register");
+    gen.register_app::<Counter>()?;
 
     let output_root = PathBuf::from("./generated");
 
-    gen.swift("SharedTypes", output_root.join("swift"))
-        .expect("swift type gen failed");
+    gen.swift("SharedTypes", output_root.join("swift"))?;
 
     gen.java(
         "com.example.simple_counter.shared_types",
         output_root.join("java"),
-    )
-    .expect("java type gen failed");
+    )?;
 
-    gen.typescript("shared_types", output_root.join("typescript"))
-        .expect("typescript type gen failed");
+    gen.typescript("shared_types", output_root.join("typescript"))?;
+
+    Ok(())
 }

--- a/examples/tap_to_pay/shared/src/app.rs
+++ b/examples/tap_to_pay/shared/src/app.rs
@@ -38,6 +38,7 @@ pub enum Screen {
 
 #[derive(Effect)]
 #[effect(app = "App")]
+#[cfg_attr(feature = "typegen", derive(crux_macros::Export))]
 pub struct Capabilities {
     render: Render<Event>,
     delay: Delay<Event>,

--- a/examples/tap_to_pay/shared_types/build.rs
+++ b/examples/tap_to_pay/shared_types/build.rs
@@ -1,36 +1,20 @@
-use anyhow::Result;
-use crux_core::{bridge::Request, typegen::TypeGen};
-use crux_http::protocol::{HttpRequest, HttpResponse};
-use shared::{EffectFfi, Event, Payment, PaymentStatus, Receipt, ReceiptStatus, ViewModel};
+use crux_core::typegen::TypeGen;
+use shared::{App, PaymentStatus, ReceiptStatus};
 use std::path::PathBuf;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed=../shared");
 
     let mut gen = TypeGen::new();
 
-    register_types(&mut gen).expect("type registration failed");
+    gen.register_app::<App>()?;
+
+    gen.register_type::<PaymentStatus>()?;
+    gen.register_type::<ReceiptStatus>()?;
 
     let output_root = PathBuf::from("./generated");
 
-    gen.swift("SharedTypes", output_root.join("swift"))
-        .expect("swift type gen failed");
-}
-
-fn register_types(gen: &mut TypeGen) -> Result<()> {
-    gen.register_type::<Request<EffectFfi>>()?;
-
-    gen.register_type::<EffectFfi>()?;
-    gen.register_type::<HttpRequest>()?;
-
-    gen.register_type::<Event>()?;
-    gen.register_type::<HttpResponse>()?;
-
-    gen.register_type::<ViewModel>()?;
-    gen.register_type::<Payment>()?;
-    gen.register_type::<PaymentStatus>()?;
-    gen.register_type::<Receipt>()?;
-    gen.register_type::<ReceiptStatus>()?;
+    gen.swift("SharedTypes", output_root.join("swift"))?;
 
     Ok(())
 }

--- a/templates/simple_counter/shared_types/build.rs
+++ b/templates/simple_counter/shared_types/build.rs
@@ -2,24 +2,23 @@ use crux_core::typegen::TypeGen;
 use {{core_name}}::Counter;
 use std::path::PathBuf;
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed=../shared");
 
     let mut gen = TypeGen::new();
 
-    gen.register_app::<Counter>().expect("register");
+    gen.register_app::<Counter>()?;
 
     let output_root = PathBuf::from("./generated");
 
-    gen.swift("SharedTypes", output_root.join("swift"))
-        .expect("swift type gen failed");
+    gen.swift("SharedTypes", output_root.join("swift"))?;
 
     gen.java(
         "com.example.simple_counter.shared_types",
         output_root.join("java"),
-    )
-    .expect("java type gen failed");
+    )?;
 
-    gen.typescript("shared_types", output_root.join("typescript"))
-        .expect("typescript type gen failed");
+    gen.typescript("shared_types", output_root.join("typescript"))?;
+
+    Ok(())
 }


### PR DESCRIPTION
Fixes #161 

Improves error handling during typegen and adds `TypeGenError::PnpmNotFound` in order to catch the more common error of not having `pnpm` installed. The error now looks like this:

```bash
cargo build
   Compiling shared_types v0.1.0 (/Users/stuartharris/src/redbadger/crux/examples/simple_counter/shared_types)
error: failed to run custom build command for `shared_types v0.1.0 (/Users/stuartharris/src/redbadger/crux/examples/simple_counter/shared_types)`

Caused by:
  process didn't exit successfully: `/Users/stuartharris/src/redbadger/crux/examples/simple_counter/target/debug/build/shared_types-8703d4b47d26cc47/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=../shared

  --- stderr
  Error: `pnpm` is needed for TypeScript type generation, but it could not be found in PATH.
  Please install it from https://pnpm.io/installation

  Caused by:
      No such file or directory (os error 2)
```