### PR TITLE
remove uuid unused wasm-bindgen feature flag

### DIFF
--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0.111"
 serde-generate = { version = "0.25.1", optional = true }
 serde-reflection = { version = "0.3.6", optional = true }
 thiserror = "1.0.56"
-uuid = { version = "1.6.1", features = ["v4", "wasm-bindgen", "js", "serde"] }
+uuid = { version = "1.6.1", features = ["v4", "js", "serde"] }
 wasm-bindgen = "0.2.89"
 
 [dev-dependencies]

--- a/examples/cat_facts/shared/Cargo.toml
+++ b/examples/cat_facts/shared/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0.111"
 thiserror = "1.0.56"
 uniffi = "0.25.3"
 url = "2.5.0"
-uuid = { version = "1.6.1", features = ["v4", "wasm-bindgen", "js"] }
+uuid = { version = "1.6.1", features = ["v4", "js"] }
 wasm-bindgen = "0.2.89"
 
 [dev-dependencies]

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.66"
 [workspace.dependencies]
 anyhow = "1.0.79"
 serde = "1.0.195"
-uuid = { version = "1.6.1", features = ["v4", "wasm-bindgen", "js", "serde"] }
+uuid = { version = "1.6.1", features = ["v4", "js", "serde"] }
 
 [workspace.metadata.bin]
 cargo-xcode = { version = "=1.7.0" }


### PR DESCRIPTION
`uuid` 1.7.0 has dropped the wasm-bindgen feature flag making it incompatible with previous versions (<= 1.6.1). 

The response from `uuid` maintainers:

> Thanks for pointing this out! The `wasm-bindgen` dependency was never meant to be public. It was only a Cargo limitation that made it so. Packages should instead use the js feature...