### PR TITLE
Capability runtime documentation

### DIFF
--- a/crux_core/src/bridge/mod.rs
+++ b/crux_core/src/bridge/mod.rs
@@ -15,6 +15,8 @@ pub use request_serde::ResolveSerialized;
 /// Request for a side-effect passed from the Core to the Shell. The `uuid` links
 /// the `Request` with the corresponding call to [`Core::resolve`] to pass the data back
 /// to the [`App::update`] function (wrapped in the event provided to the capability originating the effect).
+// used in docs/internals/bridge.md
+// ANCHOR: request
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Request<Eff>
 where
@@ -23,6 +25,7 @@ where
     pub uuid: Vec<u8>,
     pub effect: Eff,
 }
+// ANCHOR_END: request
 
 /// Bridge is a core wrapper presenting the same interface as the [`Core`] but in a
 /// serialized form, using bincode as the serialization format.
@@ -70,7 +73,10 @@ where
     ///
     /// The `output` is serialized capability output. It will be deserialized by the core.
     /// The `uuid` MUST match the `uuid` of the effect that triggered it, else the core will panic.
+    // used in docs/internals/bridge.md
+    // ANCHOR: handle_response_sig
     pub fn handle_response(&self, uuid: &[u8], output: &[u8]) -> Vec<u8>
+    // ANCHOR_END: handle_response_sig
     where
         A::Event: for<'a> Deserialize<'a>,
     {
@@ -114,6 +120,8 @@ where
 /// does not have a corresponding type generation support - you will need
 /// to write deserialization code on the shell side yourself, or generate
 /// it using separate tooling.
+// used in docs/internals/bridge.md
+// ANCHOR: bridge_with_serializer
 pub struct BridgeWithSerializer<Eff, A>
 where
     Eff: Effect,
@@ -122,6 +130,7 @@ where
     core: Core<Eff, A>,
     registry: ResolveRegistry,
 }
+// ANCHOR_END: bridge_with_serializer
 
 impl<Eff, A> BridgeWithSerializer<Eff, A>
 where

--- a/crux_core/src/bridge/registry.rs
+++ b/crux_core/src/bridge/registry.rs
@@ -26,6 +26,8 @@ impl ResolveRegistry {
     ///
     /// The `effect` will be serialized into its FFI counterpart before being stored
     /// and wrapped in a [`Request`].
+    // used in docs/internals/bridge.md
+    // ANCHOR: register
     pub fn register<Eff>(&self, effect: Eff) -> Request<Eff::Ffi>
     where
         Eff: Effect,
@@ -43,6 +45,7 @@ impl ResolveRegistry {
             effect,
         }
     }
+    // ANCHOR_END: register
 
     /// Resume a previously registered effect. This may fail, either because UUID wasn't
     /// found or because this effect was not expected to be resumed again.

--- a/crux_core/src/bridge/request_serde.rs
+++ b/crux_core/src/bridge/request_serde.rs
@@ -4,6 +4,8 @@ use crate::{
     Request,
 };
 
+// used in docs/internals/bridge.md
+// ANCHOR: resolve_serialized
 type ResolveOnceSerialized = Box<dyn FnOnce(&mut dyn erased_serde::Deserializer) + Send>;
 type ResolveManySerialized =
     Box<dyn Fn(&mut dyn erased_serde::Deserializer) -> Result<(), ()> + Send>;
@@ -19,6 +21,7 @@ pub enum ResolveSerialized {
     Once(ResolveOnceSerialized),
     Many(ResolveManySerialized),
 }
+// ANCHOR_END: resolve_serialized
 
 impl ResolveSerialized {
     pub(crate) fn resolve(

--- a/crux_core/src/capability/mod.rs
+++ b/crux_core/src/capability/mod.rs
@@ -396,6 +396,8 @@ where
 /// # }
 /// ```
 ///
+// used in docs/internals/runtime.md
+// ANCHOR: capability_context
 pub struct CapabilityContext<Op, Event>
 where
     Op: Operation,
@@ -411,6 +413,7 @@ where
     app_channel: Sender<Event>,
     spawner: executor::Spawner,
 }
+// ANCHOR_END: capability_context
 
 /// Initial version of capability Context which has not yet been specialized to a chosen capability
 pub struct ProtoContext<Eff, Event> {

--- a/crux_core/src/capability/shell_request.rs
+++ b/crux_core/src/capability/shell_request.rs
@@ -69,6 +69,8 @@ where
         // from shared_state -> send_request -> request -> shared_state
         let callback_shared_state = Arc::downgrade(&shared_state);
 
+        // used in docs/internals/runtime.md
+        // ANCHOR: resolve
         let request = Request::resolves_once(operation, move |result| {
             let Some(shared_state) = callback_shared_state.upgrade() else {
                 // The ShellRequest was dropped before we were called, so just
@@ -85,6 +87,7 @@ where
                 waker.wake()
             }
         });
+        // ANCHOR_END: resolve
 
         // Send the request on the next poll of the ShellRequest future
         let send_req_context = self.clone();

--- a/crux_core/src/core/effect.rs
+++ b/crux_core/src/core/effect.rs
@@ -5,6 +5,8 @@ use crate::bridge::ResolveSerialized;
 /// Implemented automatically with the Effect macro from `crux_macros`.
 /// This is used by the [`Bridge`](crate::bridge::Bridge) to serialize effects going across the
 /// FFI boundary.
+// used in docs/internals/bridge.md
+// ANCHOR: effect
 pub trait Effect: Send + 'static {
     /// Ffi is an enum with variants corresponding to the Effect variants
     /// but instead of carrying a `Request<Op>` they carry the `Op` directly
@@ -18,3 +20,4 @@ pub trait Effect: Send + 'static {
     /// the [`Bridge`](crate::bridge::Bridge)
     fn serialize(self) -> (Self::Ffi, ResolveSerialized);
 }
+// ANCHOR_END: effect

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -21,6 +21,8 @@ use crate::{App, WithContext};
 ///
 /// The result of the capability's work can then be sent back to the core using [`Core::resolve`], passing
 /// in the request and the corresponding capability output type.
+// used in docs/internals/runtime.md
+// ANCHOR: core
 pub struct Core<Ef, A>
 where
     A: App,
@@ -32,6 +34,7 @@ where
     capability_events: Receiver<A::Event>,
     app: A,
 }
+// ANCHOR_END: core
 
 impl<Ef, A> Core<Ef, A>
 where
@@ -65,6 +68,8 @@ where
 
     /// Run the app's `update` function with a given `event`, returning a vector of
     /// effect requests.
+    // used in docs/internals/runtime.md
+    // ANCHOR: process_event
     pub fn process_event(&self, event: A::Event) -> Vec<Ef> {
         let mut model = self.model.write().expect("Model RwLock was poisoned.");
 
@@ -72,12 +77,15 @@ where
 
         self.process()
     }
+    // ANCHOR_END: process_event
 
     /// Resolve an effect `request` for operation `Op` with the corresponding result.
     ///
     /// Note that the `request` is borrowed mutably. When a request that is expected to
     /// only be resolved once is passed in, it will be consumed and changed to a request
     /// which can no longer be resolved.
+    // used in docs/internals/runtime.md
+    // ANCHOR: resolve
     pub fn resolve<Op>(&self, request: &mut Request<Op>, result: Op::Output) -> Vec<Ef>
     where
         Op: Operation,
@@ -87,7 +95,10 @@ where
 
         self.process()
     }
+    // ANCHOR_END: resolve
 
+    // used in docs/internals/runtime.md
+    // ANCHOR: process
     pub(crate) fn process(&self) -> Vec<Ef> {
         self.executor.run_all();
 
@@ -101,6 +112,7 @@ where
 
         self.requests.drain().collect()
     }
+    // ANCHOR_END: process
 
     /// Get the current state of the app's view model.
     pub fn view(&self) -> A::ViewModel {

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -84,11 +84,13 @@ where
     /// Note that the `request` is borrowed mutably. When a request that is expected to
     /// only be resolved once is passed in, it will be consumed and changed to a request
     /// which can no longer be resolved.
-    // used in docs/internals/runtime.md
+    // used in docs/internals/runtime.md and docs/internals/bridge.md
     // ANCHOR: resolve
+    // ANCHOR: resolve_sig
     pub fn resolve<Op>(&self, request: &mut Request<Op>, result: Op::Output) -> Vec<Ef>
     where
         Op: Operation,
+        // ANCHOR_END: resolve_sig
     {
         let resolve_result = request.resolve(result);
         debug_assert!(resolve_result.is_ok());

--- a/crux_core/src/core/resolve.rs
+++ b/crux_core/src/core/resolve.rs
@@ -5,11 +5,14 @@ type ResolveMany<Out> = Box<dyn Fn(Out) -> Result<(), ()> + Send>;
 
 /// Resolve is a callback used to resolve an effect request and continue
 /// one of the capability Tasks running on the executor.
+// used in docs/internals/runtime.md
+// ANCHOR: resolve
 pub(crate) enum Resolve<Out> {
     Never,
     Once(ResolveOnce<Out>),
     Many(ResolveMany<Out>),
 }
+// ANCHOR_END: resolve
 
 impl<Out> Resolve<Out> {
     pub fn resolve(&mut self, output: Out) -> Result<(), ResolveError> {

--- a/crux_core/src/core/resolve.rs
+++ b/crux_core/src/core/resolve.rs
@@ -1,12 +1,12 @@
 use thiserror::Error;
 
+// ANCHOR: resolve
 type ResolveOnce<Out> = Box<dyn FnOnce(Out) + Send>;
 type ResolveMany<Out> = Box<dyn Fn(Out) -> Result<(), ()> + Send>;
 
 /// Resolve is a callback used to resolve an effect request and continue
 /// one of the capability Tasks running on the executor.
 // used in docs/internals/runtime.md
-// ANCHOR: resolve
 pub(crate) enum Resolve<Out> {
     Never,
     Once(ResolveOnce<Out>),

--- a/crux_core/src/core/resolve.rs
+++ b/crux_core/src/core/resolve.rs
@@ -1,12 +1,12 @@
 use thiserror::Error;
 
+// used in docs/internals/runtime.md
 // ANCHOR: resolve
 type ResolveOnce<Out> = Box<dyn FnOnce(Out) + Send>;
 type ResolveMany<Out> = Box<dyn Fn(Out) -> Result<(), ()> + Send>;
 
 /// Resolve is a callback used to resolve an effect request and continue
 /// one of the capability Tasks running on the executor.
-// used in docs/internals/runtime.md
 pub(crate) enum Resolve<Out> {
     Never,
     Once(ResolveOnce<Out>),

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -32,8 +32,7 @@
 
 # Internals
 
-1. [Capability runtime](./internals/runtime.md)
-1. [Effect handling](./internals/effect.md)
-1. [FFI interface](./internals/uniffi.md)
-1. [Serialization](./internals/serialization.md)
+1. [Capability runtime and Effects](./internals/runtime.md)
+1. [FFI bridge](./internals/bridge.md)
+1. [The Effect type](./internals/effect.md)
 1. [Type generation](./internals/typegen.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -27,8 +27,7 @@
 1. [Capabilities](./guide/capabilities.md)
    1. [Capability APIs](./guide/capability_apis.md)
 1. [Testing](./guide/testing.md)
-1. [Core API](./guide/core_api.md)
-1. [Message interface between core and shell](./guide/message_interface.md)
+1. [Interface between core and shell](./guide/message_interface.md)
 1. [Composable Applications](./guide/composing.md)
 
 # Internals

--- a/docs/src/guide/core_api.md
+++ b/docs/src/guide/core_api.md
@@ -1,5 +1,0 @@
-# Core API
-
-```admonish info
-Coming soon.
-```

--- a/docs/src/internals/bridge.md
+++ b/docs/src/internals/bridge.md
@@ -1,0 +1,161 @@
+# FFI bridge
+
+In the previous chapter, we saw how the capability runtime facilitates the
+orchestration of effect processing by the shell. We looked at the simpler
+scenario where the shell was built in Rust. Now we'll extend this to the more
+common scenario where the shell is written in a different language and the
+core APIs are called over an FFI, passing events, requests and responses back
+and forth serialised as bytes.
+
+## The FFI bridge
+
+The FFI bridge has two key parts, the serialisation part converting from typed
+effect requests to serializable types, and the FFI implementation itself, facilitated by [UniFFI](https://github.com/mozilla/uniffi-rs).
+
+The serialisation part is the `Bridge` type, defined in the `bridge` module of
+`crux_core`. It is a wrapper for the `Core` with its own definition of
+`Request`. Its API is very similar to the `Core` API - it has an identical set
+of methods, but their type signatures are different.
+
+For example, here is `Core::resolve`
+
+```rust,no_run,noplayground
+{{#include ../../../crux_core/src/core/mod.rs:81:83}}
+```
+
+and here's its counterpart, `Bridge::handle_response`
+
+```rust,no_run,noplayground
+{{#include ../../../crux_core/src/bridge/mod.rs:73}}
+```
+
+where the core expects to be given a `Request<Op>` to resolve, the bridge
+expects a `uuid` - a unique identifier of the request being resolved.
+
+This makes sense - the `Request`s include callback closures working with the
+capability runtime, they can't be easily serialised and sent back and forth
+acros the language boundary. Instead, the bridge "parks" them in a registry, to
+be picked up later. Like in a coat in a theatre cloakroom, the registry returns
+a unique number under which the request is stored.
+
+The implementation of the serialization/deserialization process is slightly
+complicated by the fact that Crux allows you to supply your own serializer and
+deserializaer should you need to, so the actual bridge implementation does not
+work on bytes but on serializers. The `Bridge` type used in examples and all
+the documentation is a default implementation, which uses bincode
+serialization, which is also supported by the [type generation
+subsystem](./typegen.md).
+
+We won't go into the detial of working with Serde and the [`erased_serde`](https://docs.rs/erased-serde/) crate to make all the serialization happen without leaking deserialzation lifetimes out of the bridge. You can read the implemantation of `BridgeWithSerializer` if you're interested in the gory details. For our purposes, the type definition will suffice.
+
+```rust,no_run,noplayground
+{{#include ../../../crux_core/src/bridge/mod.rs:117:124}}
+```
+
+The bridge holds an instance of the `Core` and a `ResolveRegistry` to store the
+effect requests in.
+
+The processing of the update loop is quite similar to the Core update loop:
+
+- When a serialized event arrives, it is deserialized and passed to the `Core`'s `process_event`
+- When a request response arrives, the uuid is forwarded to the `ResolveRegistry`'s `resume` method, and the `Core`'s `process` method is called to run the capability runtime
+
+You may remember that both these calls return effect requests. The remaining step is to store these in the registry, using the registry's `register` method,
+exchanging the core `Request` for a bridge variant, which looks like this:
+
+```rust,no_run,noplayground
+{{#include ../../../crux_core/src/bridge/mod.rs:18:25}}
+```
+
+Unlike the core request, this does nto include any closures or other difficult data, and is fully serializable.
+
+## ResolveRegistry
+
+It is worth pausing for a second on the resolve registry. There is one tricky
+problem to solve here - storing the generic `Request`s in a single store. We
+get around this by making the `register` method generic and asking the effect
+to "serialize" itself.
+
+```rust,no_run,noplayground
+{{#include ../../../crux_core/src/bridge/registry.rs:29:45}}
+```
+
+this is named based on our intent, not really based on what actually happens.
+The method comes from an `Effect` trait:
+
+```rust,no_run,noplayground
+{{#include ../../../crux_core/src/core/effect.rs:5:20}}
+```
+
+Like the `Effect` type which implements this trait, the implementation is macro
+generated, based on the Capabilities used by your application. We will look at
+how this works in the [`Effect type`](./effect.md) chapter.
+
+The type signature of the method gives us a hint though - it converts the
+normal `Effect` into an serializable counterpart, and somethig
+of a `ResolveSerialized` type. This is stored in the registry under a randomly
+generated uuid, and the effect and the uuid are return as the bridge version of
+a `Request`.
+
+The definition of the `ResolveSerialized` type is a little bit convoluted:
+
+```rust,no_run,noplayground
+{{#include ../../../crux_core/src/bridge/request_serde.rs:7:21}}
+```
+
+but the gist of it is that it is a mirror of the `Resolve` type we already know,
+except it takes a Deserializer. More about this serialization trickery in the next chapter.
+
+## FFI interface
+
+The final piece of the puzzle is the FFI interface itself. All it does is expose
+the bridge API we've seen above.
+
+```admonish note
+You will see that this part, alongside the type generation, is a fairly
+complicated mixture of various existing tools and libraries, which has
+a number of rough edges. It is likely that we will explore replacing this
+part of Crux with a tailor made FFI bridge in the future. If/when we do, we will
+do our best to provide a smooth migration path.
+```
+
+Here's a typical app's shared crate `src/lib.rs` file:
+
+```rust,no_run,noplayground
+{{#include ../../../examples/bridge_echo/shared/src/lib.rs}}
+```
+
+Ignore the TODO, we will get to that eventually, promise. There are two forms
+of FFI going on - the `wasm_bindgen` annotations on the three functions,
+exposing them when built as webassembly, and also the line saying
+
+```rust,no_run,noplayground
+uniffi::include_scaffolding!("shared");
+```
+
+which refers to the `shared.udl` file in the same folder
+
+```
+{{#include ../../../examples/bridge_echo/shared/src/shared.udl}}
+```
+
+This is UniFFI's interface definition used to generate the scaffolding for the
+FFI interface - both the externally callable functions in the `shared` library,
+and their counterparts in the "foreign" languages (like Swift or Kotlin).
+
+The scaffolding is built in the `build.rs` script of the crate
+
+```rust,no_run,noplayground
+{{#include ../../../examples/bridge_echo/shared/build.rs}}
+```
+
+The foreign language code is built by an aditional binary target for the same crate, in `src/bin/uniffi-bindgen.rs`
+
+```rust,no_run,noplayground
+{{#include ../../../examples/bridge_echo/shared/src/bin/uniffi-bindgen.rs}}
+```
+
+this builds a CLI which can be used as part of the build process for clients
+of the library to generate the code.
+
+The details of this process are well documented [in UniFFI's tutorial](https://mozilla.github.io/uniffi-rs/Getting_started.html)

--- a/docs/src/internals/bridge.md
+++ b/docs/src/internals/bridge.md
@@ -1,21 +1,12 @@
 # FFI bridge
 
-In the previous chapter, we saw how the capability runtime facilitates the
-orchestration of effect processing by the shell. We looked at the simpler
-scenario where the shell was built in Rust. Now we'll extend this to the more
-common scenario where the shell is written in a different language and the
-core APIs are called over an FFI, passing events, requests and responses back
-and forth serialised as bytes.
+In the previous chapter, we saw how the capability runtime facilitates the orchestration of effect processing by the shell. We looked at the simpler scenario where the shell was built in Rust. Now we'll extend this to the more common scenario where the shell is written in a different language and the core APIs are called over an FFI, passing events, requests and responses back and forth serialised as bytes.
 
 ## The FFI bridge
 
-The FFI bridge has two key parts, the serialisation part converting from typed
-effect requests to serializable types, and the FFI implementation itself, facilitated by [UniFFI](https://github.com/mozilla/uniffi-rs).
+The FFI bridge has two key parts, the serialisation part converting from typed effect requests to serializable types, and the FFI implementation itself, facilitated by [UniFFI](https://github.com/mozilla/uniffi-rs).
 
-The serialisation part is the `Bridge` type, defined in the `bridge` module of
-`crux_core`. It is a wrapper for the `Core` with its own definition of
-`Request`. Its API is very similar to the `Core` API - it has an identical set
-of methods, but their type signatures are different.
+The serialisation part is the `Bridge` type, defined in the `bridge` module of `crux_core`. It is a wrapper for the `Core` with its own definition of `Request`. Its API is very similar to the `Core` API - it has an identical set of methods, but their type signatures are different.
 
 For example, here is `Core::resolve`
 
@@ -29,39 +20,26 @@ and here's its counterpart, `Bridge::handle_response`
 {{#include ../../../crux_core/src/bridge/mod.rs:handle_response_sig}}
 ```
 
-where the core expects to be given a `Request<Op>` to resolve, the bridge
-expects a `uuid` - a unique identifier of the request being resolved.
+where the core expects to be given a `Request<Op>` to resolve, the bridge expects a `uuid` - a unique identifier of the request being resolved.
 
-This makes sense - the `Request`s include callback closures working with the
-capability runtime, they can't be easily serialised and sent back and forth
-acros the language boundary. Instead, the bridge "parks" them in a registry, to
-be picked up later. Like in a coat in a theatre cloakroom, the registry returns
-a unique number under which the request is stored.
+This makes sense - the `Request`s include callback closures working with the capability runtime, they can't be easily serialised and sent back and forth across the language boundary. Instead, the bridge "parks" them in a registry, to be picked up later. Like in a coat in a theatre cloakroom, the registry returns a unique number under which the request is stored.
 
-The implementation of the serialization/deserialization process is slightly
-complicated by the fact that Crux allows you to supply your own serializer and
-deserializaer should you need to, so the actual bridge implementation does not
-work on bytes but on serializers. The `Bridge` type used in examples and all
-the documentation is a default implementation, which uses bincode
-serialization, which is also supported by the [type generation
-subsystem](./typegen.md).
+The implementation of the serialization/deserialization process is slightly complicated by the fact that Crux allows you to supply your own serializer and deserializaer should you need to, so the actual bridge implementation does not work on bytes but on serializers. The `Bridge` type used in examples and all the documentation is a default implementation, which uses bincode serialization, which is also supported by the [type generation subsystem](./typegen.md).
 
-We won't go into the detial of working with Serde and the [`erased_serde`](https://docs.rs/erased-serde/) crate to make all the serialization happen without leaking deserialzation lifetimes out of the bridge. You can read the implemantation of `BridgeWithSerializer` if you're interested in the gory details. For our purposes, the type definition will suffice.
+We won't go into the detail of working with Serde and the [`erased_serde`](https://docs.rs/erased-serde/) crate to make all the serialization happen without leaking deserialzation lifetimes out of the bridge. You can read the implemantation of `BridgeWithSerializer` if you're interested in the gory details. For our purposes, the type definition will suffice.
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/bridge/mod.rs:bridge_with_serializer}}
 ```
 
-The bridge holds an instance of the `Core` and a `ResolveRegistry` to store the
-effect requests in.
+The bridge holds an instance of the `Core` and a `ResolveRegistry` to store the effect requests in.
 
 The processing of the update loop is quite similar to the Core update loop:
 
 - When a serialized event arrives, it is deserialized and passed to the `Core`'s `process_event`
 - When a request response arrives, the uuid is forwarded to the `ResolveRegistry`'s `resume` method, and the `Core`'s `process` method is called to run the capability runtime
 
-You may remember that both these calls return effect requests. The remaining step is to store these in the registry, using the registry's `register` method,
-exchanging the core `Request` for a bridge variant, which looks like this:
+You may remember that both these calls return effect requests. The remaining step is to store these in the registry, using the registry's `register` method, exchanging the core `Request` for a bridge variant, which looks like this:
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/bridge/mod.rs:request}}
@@ -71,31 +49,21 @@ Unlike the core request, this does nto include any closures or other difficult d
 
 ## ResolveRegistry
 
-It is worth pausing for a second on the resolve registry. There is one tricky
-problem to solve here - storing the generic `Request`s in a single store. We
-get around this by making the `register` method generic and asking the effect
-to "serialize" itself.
+It is worth pausing for a second on the resolve registry. There is one tricky problem to solve here - storing the generic `Request`s in a single store. We get around this by making the `register` method generic and asking the effect to "serialize" itself.
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/bridge/registry.rs:register}}
 ```
 
-this is named based on our intent, not really based on what actually happens.
-The method comes from an `Effect` trait:
+this is named based on our intent, not really based on what actually happens. The method comes from an `Effect` trait:
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/core/effect.rs:effect}}
 ```
 
-Like the `Effect` type which implements this trait, the implementation is macro
-generated, based on the Capabilities used by your application. We will look at
-how this works in the [`Effect type`](./effect.md) chapter.
+Like the `Effect` type which implements this trait, the implementation is macro generated, based on the Capabilities used by your application. We will look at how this works in the [`Effect type`](./effect.md) chapter.
 
-The type signature of the method gives us a hint though - it converts the
-normal `Effect` into an serializable counterpart, and somethig
-of a `ResolveSerialized` type. This is stored in the registry under a randomly
-generated uuid, and the effect and the uuid are return as the bridge version of
-a `Request`.
+The type signature of the method gives us a hint though - it converts the normal `Effect` into an serializable counterpart, and something of a `ResolveSerialized` type. This is stored in the registry under a randomly generated uuid, and the effect and the uuid are return as the bridge version of a `Request`.
 
 The definition of the `ResolveSerialized` type is a little bit convoluted:
 
@@ -103,13 +71,11 @@ The definition of the `ResolveSerialized` type is a little bit convoluted:
 {{#include ../../../crux_core/src/bridge/request_serde.rs:resolve_serialized}}
 ```
 
-but the gist of it is that it is a mirror of the `Resolve` type we already know,
-except it takes a Deserializer. More about this serialization trickery in the next chapter.
+but the gist of it is that it is a mirror of the `Resolve` type we already know, except it takes a Deserializer. More about this serialization trickery in the next chapter.
 
 ## FFI interface
 
-The final piece of the puzzle is the FFI interface itself. All it does is expose
-the bridge API we've seen above.
+The final piece of the puzzle is the FFI interface itself. All it does is expose the bridge API we've seen above.
 
 ```admonish note
 You will see that this part, alongside the type generation, is a fairly
@@ -125,9 +91,7 @@ Here's a typical app's shared crate `src/lib.rs` file:
 {{#include ../../../examples/bridge_echo/shared/src/lib.rs}}
 ```
 
-Ignore the TODO, we will get to that eventually, promise. There are two forms
-of FFI going on - the `wasm_bindgen` annotations on the three functions,
-exposing them when built as webassembly, and also the line saying
+Ignore the TODO, we will get to that eventually, promise. There are two forms of FFI going on - the `wasm_bindgen` annotations on the three functions, exposing them when built as webassembly, and also the line saying
 
 ```rust,no_run,noplayground
 uniffi::include_scaffolding!("shared");
@@ -139,9 +103,7 @@ which refers to the `shared.udl` file in the same folder
 {{#include ../../../examples/bridge_echo/shared/src/shared.udl}}
 ```
 
-This is UniFFI's interface definition used to generate the scaffolding for the
-FFI interface - both the externally callable functions in the `shared` library,
-and their counterparts in the "foreign" languages (like Swift or Kotlin).
+This is UniFFI's interface definition used to generate the scaffolding for the FFI interface - both the externally callable functions in the `shared` library, and their counterparts in the "foreign" languages (like Swift or Kotlin).
 
 The scaffolding is built in the `build.rs` script of the crate
 
@@ -149,13 +111,12 @@ The scaffolding is built in the `build.rs` script of the crate
 {{#include ../../../examples/bridge_echo/shared/build.rs}}
 ```
 
-The foreign language code is built by an aditional binary target for the same crate, in `src/bin/uniffi-bindgen.rs`
+The foreign language code is built by an additional binary target for the same crate, in `src/bin/uniffi-bindgen.rs`
 
 ```rust,no_run,noplayground
 {{#include ../../../examples/bridge_echo/shared/src/bin/uniffi-bindgen.rs}}
 ```
 
-this builds a CLI which can be used as part of the build process for clients
-of the library to generate the code.
+this builds a CLI which can be used as part of the build process for clients of the library to generate the code.
 
 The details of this process are well documented [in UniFFI's tutorial](https://mozilla.github.io/uniffi-rs/Getting_started.html)

--- a/docs/src/internals/bridge.md
+++ b/docs/src/internals/bridge.md
@@ -1,12 +1,22 @@
 # FFI bridge
 
-In the previous chapter, we saw how the capability runtime facilitates the orchestration of effect processing by the shell. We looked at the simpler scenario where the shell was built in Rust. Now we'll extend this to the more common scenario where the shell is written in a different language and the core APIs are called over an FFI, passing events, requests and responses back and forth serialised as bytes.
+In the previous chapter, we saw how the capability runtime facilitates the
+orchestration of effect processing by the shell. We looked at the simpler
+scenario where the shell was built in Rust. Now we'll extend this to the more
+common scenario where the shell is written in a different language and the core
+APIs are called over a Foreign Function Interface, passing events, requests and
+responses back and forth, serialised as bytes.
 
 ## The FFI bridge
 
-The FFI bridge has two key parts, the serialisation part converting from typed effect requests to serializable types, and the FFI implementation itself, facilitated by [UniFFI](https://github.com/mozilla/uniffi-rs).
+The FFI bridge has two key parts, the serialisation part converting from typed
+effect requests to serializable types, and the FFI implementation itself,
+facilitated by [UniFFI](https://github.com/mozilla/uniffi-rs).
 
-The serialisation part is facilitated by the `Bridge`. It is a wrapper for the `Core` with its own definition of `Request`. Its API is very similar to the `Core` API - it has an identical set of methods, but their type signatures are different.
+The serialisation part is facilitated by the `Bridge`. It is a wrapper for the
+`Core` with its own definition of `Request`. Its API is very similar to the
+`Core` API - it has an identical set of methods, but their type signatures are
+different.
 
 For example, here is `Core::resolve`
 
@@ -20,50 +30,82 @@ and here's its counterpart, `Bridge::handle_response`
 {{#include ../../../crux_core/src/bridge/mod.rs:handle_response_sig}}
 ```
 
-where the core expects to be given a `Request<Op>` to resolve, the bridge expects a `uuid` - a unique identifier of the request being resolved.
+where the core expects to be given a `Request<Op>` to resolve, the bridge
+expects a `uuid` - a unique identifier of the request being resolved.
 
-This makes sense - the `Request`s include callback closures working with the capability runtime, they can't be easily serialised and sent back and forth across the language boundary. Instead, the bridge "parks" them in a registry, to be picked up later. Like in a theatre cloakroom, the registry returns a unique number under which the request is stored.
+This makes sense - the `Request`s include callback closures working with the
+capability runtime, they can't be easily serialised and sent back and forth
+across the language boundary. Instead, the bridge "parks" them in a registry, to
+be picked up later. Like in a theatre cloakroom, the registry returns a unique
+number under which the request is stored.
 
-The implementation of the serialization/deserialization process is slightly complicated by the fact that Crux allows you to supply your own serializer and deserializaer should you need to, so the actual bridge implementation does not work on bytes but on serializers. The `Bridge` type used in examples and all the documentation is a default implementation, which uses bincode serialization, which is also supported by the [type generation subsystem](./typegen.md).
+The implementation of the serialization/deserialization process is slightly
+complicated by the fact that Crux allows you to supply your own serializer and
+deserializer should you need to, so the actual bridge implementation does not
+work on bytes but on serializers. The `Bridge` type used in examples and all the
+documentation is a default implementation, which uses bincode serialization,
+which is also supported by the [type generation subsystem](./typegen.md).
 
-We won't go into the detail of working with Serde and the [`erased_serde`](https://docs.rs/erased-serde/) crate to make all the serialization happen without leaking deserialzation lifetimes out of the bridge. You can read the implemantation of `BridgeWithSerializer` if you're interested in the gory details. For our purposes, the type definition will suffice.
+We won't go into the detail of working with Serde and the
+[`erased_serde`](https://docs.rs/erased-serde/) crate to make all the
+serialization happen without leaking deserialization lifetimes out of the
+bridge. You can read the implementation of `BridgeWithSerializer` if you're
+interested in the gory details. For our purposes, the type definition will
+suffice.
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/bridge/mod.rs:bridge_with_serializer}}
 ```
 
-The bridge holds an instance of the `Core` and a `ResolveRegistry` to store the effect requests in.
+The bridge holds an instance of the `Core` and a `ResolveRegistry` to store the
+effect requests in.
 
 The processing of the update loop is quite similar to the Core update loop:
 
-- When a serialized event arrives, it is deserialized and passed to the `Core`'s `process_event`
-- When a request response arrives, the uuid is forwarded to the `ResolveRegistry`'s `resume` method, and the `Core`'s `process` method is called to run the capability runtime
+- When a serialized event arrives, it is deserialized and passed to the `Core`'s
+  `process_event`
+- When a request response arrives, the uuid is forwarded to the
+  `ResolveRegistry`'s `resume` method, and the `Core`'s `process` method is
+  called to run the capability runtime
 
-You may remember that both these calls return effect requests. The remaining step is to store these in the registry, using the registry's `register` method, exchanging the core `Request` for a bridge variant, which looks like this:
+You may remember that both these calls return effect requests. The remaining
+step is to store these in the registry, using the registry's `register` method,
+exchanging the core `Request` for a bridge variant, which looks like this:
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/bridge/mod.rs:request}}
 ```
 
-Unlike the core request, this does not include any closures and is fully serializable.
+Unlike the core request, this does not include any closures and is fully
+serializable.
 
 ## ResolveRegistry
 
-It is worth pausing for a second on the resolve registry. There is one tricky problem to solve here - storing the generic `Request`s in a single store. We get around this by making the `register` method generic and asking the effect to "serialize" itself.
+It is worth pausing for a second on the resolve registry. There is one tricky
+problem to solve here - storing the generic `Request`s in a single store. We get
+around this by making the `register` method generic and asking the effect to
+"serialize" itself.
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/bridge/registry.rs:register}}
 ```
 
-this is named based on our intent, not really based on what actually happens. The method comes from an `Effect` trait:
+this is named based on our intent, not really based on what actually happens.
+The method comes from an `Effect` trait:
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/core/effect.rs:effect}}
 ```
 
-Like the `Effect` type which implements this trait, the implementation is macro generated, based on the Capabilities used by your application. We will look at how this works in the [`Effect type`](./effect.md) chapter.
+Like the `Effect` type which implements this trait, the implementation is macro
+generated, based on the Capabilities used by your application. We will look at
+how this works in the [`Effect type`](./effect.md) chapter.
 
-The type signature of the method gives us a hint though - it converts the normal `Effect` into a serializable counterpart, alongside something with a `ResolveSerialized` type. This is stored in the registry under a randomly generated uuid, and the effect and the uuid are returned as the bridge version of a `Request`.
+The type signature of the method gives us a hint though - it converts the normal
+`Effect` into a serializable counterpart, alongside something with a
+`ResolveSerialized` type. This is stored in the registry under a randomly
+generated uuid, and the effect and the uuid are returned as the bridge version
+of a `Request`.
 
 The definition of the `ResolveSerialized` type is a little bit convoluted:
 
@@ -71,11 +113,14 @@ The definition of the `ResolveSerialized` type is a little bit convoluted:
 {{#include ../../../crux_core/src/bridge/request_serde.rs:resolve_serialized}}
 ```
 
-but the gist of it is that it is a mirror of the `Resolve` type we already know, except it takes a Deserializer. More about this serialization trickery in the next chapter.
+but the gist of it is that it is a mirror of the `Resolve` type we already know,
+except it takes a Deserializer. More about this serialization trickery in the
+next chapter.
 
 ## FFI interface
 
-The final piece of the puzzle is the FFI interface itself. All it does is expose the bridge API we've seen above.
+The final piece of the puzzle is the FFI interface itself. All it does is expose
+the bridge API we've seen above.
 
 ```admonish note
 You will see that this part, alongside the type generation, is a fairly
@@ -91,7 +136,9 @@ Here's a typical app's shared crate `src/lib.rs` file:
 {{#include ../../../examples/bridge_echo/shared/src/lib.rs}}
 ```
 
-Ignore the TODO, we will get to that eventually, promise. There are two forms of FFI going on - the `wasm_bindgen` annotations on the three functions, exposing them when built as webassembly, and also the line saying
+Ignore the TODO, we will get to that eventually, I promise. There are two forms
+of FFI going on - the `wasm_bindgen` annotations on the three functions,
+exposing them when built as webassembly, and also the line saying
 
 ```rust,no_run,noplayground
 uniffi::include_scaffolding!("shared");
@@ -103,7 +150,9 @@ which refers to the `shared.udl` file in the same folder
 {{#include ../../../examples/bridge_echo/shared/src/shared.udl}}
 ```
 
-This is UniFFI's interface definition used to generate the scaffolding for the FFI interface - both the externally callable functions in the `shared` library, and their counterparts in the "foreign" languages (like Swift or Kotlin).
+This is UniFFI's interface definition used to generate the scaffolding for the
+FFI interface - both the externally callable functions in the `shared` library,
+and their counterparts in the "foreign" languages (like Swift or Kotlin).
 
 The scaffolding is built in the `build.rs` script of the crate
 
@@ -111,12 +160,15 @@ The scaffolding is built in the `build.rs` script of the crate
 {{#include ../../../examples/bridge_echo/shared/build.rs}}
 ```
 
-The foreign language code is built by an additional binary target for the same crate, in `src/bin/uniffi-bindgen.rs`
+The foreign language code is built by an additional binary target for the same
+crate, in `src/bin/uniffi-bindgen.rs`
 
 ```rust,no_run,noplayground
 {{#include ../../../examples/bridge_echo/shared/src/bin/uniffi-bindgen.rs}}
 ```
 
-this builds a CLI which can be used as part of the build process for clients of the library to generate the code.
+this builds a CLI which can be used as part of the build process for clients of
+the library to generate the code.
 
-The details of this process are well documented [in UniFFI's tutorial](https://mozilla.github.io/uniffi-rs/Getting_started.html).
+The details of this process are well documented
+[in UniFFI's tutorial](https://mozilla.github.io/uniffi-rs/Getting_started.html).

--- a/docs/src/internals/bridge.md
+++ b/docs/src/internals/bridge.md
@@ -6,7 +6,7 @@ In the previous chapter, we saw how the capability runtime facilitates the orche
 
 The FFI bridge has two key parts, the serialisation part converting from typed effect requests to serializable types, and the FFI implementation itself, facilitated by [UniFFI](https://github.com/mozilla/uniffi-rs).
 
-The serialisation part is the `Bridge` type, defined in the `bridge` module of `crux_core`. It is a wrapper for the `Core` with its own definition of `Request`. Its API is very similar to the `Core` API - it has an identical set of methods, but their type signatures are different.
+The serialisation part is facilitated by the `Bridge`. It is a wrapper for the `Core` with its own definition of `Request`. Its API is very similar to the `Core` API - it has an identical set of methods, but their type signatures are different.
 
 For example, here is `Core::resolve`
 
@@ -22,7 +22,7 @@ and here's its counterpart, `Bridge::handle_response`
 
 where the core expects to be given a `Request<Op>` to resolve, the bridge expects a `uuid` - a unique identifier of the request being resolved.
 
-This makes sense - the `Request`s include callback closures working with the capability runtime, they can't be easily serialised and sent back and forth across the language boundary. Instead, the bridge "parks" them in a registry, to be picked up later. Like in a coat in a theatre cloakroom, the registry returns a unique number under which the request is stored.
+This makes sense - the `Request`s include callback closures working with the capability runtime, they can't be easily serialised and sent back and forth across the language boundary. Instead, the bridge "parks" them in a registry, to be picked up later. Like in a theatre cloakroom, the registry returns a unique number under which the request is stored.
 
 The implementation of the serialization/deserialization process is slightly complicated by the fact that Crux allows you to supply your own serializer and deserializaer should you need to, so the actual bridge implementation does not work on bytes but on serializers. The `Bridge` type used in examples and all the documentation is a default implementation, which uses bincode serialization, which is also supported by the [type generation subsystem](./typegen.md).
 
@@ -45,7 +45,7 @@ You may remember that both these calls return effect requests. The remaining ste
 {{#include ../../../crux_core/src/bridge/mod.rs:request}}
 ```
 
-Unlike the core request, this does nto include any closures or other difficult data, and is fully serializable.
+Unlike the core request, this does not include any closures and is fully serializable.
 
 ## ResolveRegistry
 
@@ -63,7 +63,7 @@ this is named based on our intent, not really based on what actually happens. Th
 
 Like the `Effect` type which implements this trait, the implementation is macro generated, based on the Capabilities used by your application. We will look at how this works in the [`Effect type`](./effect.md) chapter.
 
-The type signature of the method gives us a hint though - it converts the normal `Effect` into an serializable counterpart, and something of a `ResolveSerialized` type. This is stored in the registry under a randomly generated uuid, and the effect and the uuid are return as the bridge version of a `Request`.
+The type signature of the method gives us a hint though - it converts the normal `Effect` into a serializable counterpart, alongside something with a `ResolveSerialized` type. This is stored in the registry under a randomly generated uuid, and the effect and the uuid are returned as the bridge version of a `Request`.
 
 The definition of the `ResolveSerialized` type is a little bit convoluted:
 
@@ -79,7 +79,7 @@ The final piece of the puzzle is the FFI interface itself. All it does is expose
 
 ```admonish note
 You will see that this part, alongside the type generation, is a fairly
-complicated mixture of various existing tools and libraries, which has
+complicated constellation of various existing tools and libraries, which has
 a number of rough edges. It is likely that we will explore replacing this
 part of Crux with a tailor made FFI bridge in the future. If/when we do, we will
 do our best to provide a smooth migration path.
@@ -119,4 +119,4 @@ The foreign language code is built by an additional binary target for the same c
 
 this builds a CLI which can be used as part of the build process for clients of the library to generate the code.
 
-The details of this process are well documented [in UniFFI's tutorial](https://mozilla.github.io/uniffi-rs/Getting_started.html)
+The details of this process are well documented [in UniFFI's tutorial](https://mozilla.github.io/uniffi-rs/Getting_started.html).

--- a/docs/src/internals/bridge.md
+++ b/docs/src/internals/bridge.md
@@ -20,13 +20,13 @@ of methods, but their type signatures are different.
 For example, here is `Core::resolve`
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/core/mod.rs:81:83}}
+{{#include ../../../crux_core/src/core/mod.rs:resolve_sig}}
 ```
 
 and here's its counterpart, `Bridge::handle_response`
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/bridge/mod.rs:73}}
+{{#include ../../../crux_core/src/bridge/mod.rs:handle_response_sig}}
 ```
 
 where the core expects to be given a `Request<Op>` to resolve, the bridge
@@ -49,7 +49,7 @@ subsystem](./typegen.md).
 We won't go into the detial of working with Serde and the [`erased_serde`](https://docs.rs/erased-serde/) crate to make all the serialization happen without leaking deserialzation lifetimes out of the bridge. You can read the implemantation of `BridgeWithSerializer` if you're interested in the gory details. For our purposes, the type definition will suffice.
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/bridge/mod.rs:117:124}}
+{{#include ../../../crux_core/src/bridge/mod.rs:bridge_with_serializer}}
 ```
 
 The bridge holds an instance of the `Core` and a `ResolveRegistry` to store the
@@ -64,7 +64,7 @@ You may remember that both these calls return effect requests. The remaining ste
 exchanging the core `Request` for a bridge variant, which looks like this:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/bridge/mod.rs:18:25}}
+{{#include ../../../crux_core/src/bridge/mod.rs:request}}
 ```
 
 Unlike the core request, this does nto include any closures or other difficult data, and is fully serializable.
@@ -77,14 +77,14 @@ get around this by making the `register` method generic and asking the effect
 to "serialize" itself.
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/bridge/registry.rs:29:45}}
+{{#include ../../../crux_core/src/bridge/registry.rs:register}}
 ```
 
 this is named based on our intent, not really based on what actually happens.
 The method comes from an `Effect` trait:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/core/effect.rs:5:20}}
+{{#include ../../../crux_core/src/core/effect.rs:effect}}
 ```
 
 Like the `Effect` type which implements this trait, the implementation is macro
@@ -100,7 +100,7 @@ a `Request`.
 The definition of the `ResolveSerialized` type is a little bit convoluted:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/bridge/request_serde.rs:7:21}}
+{{#include ../../../crux_core/src/bridge/request_serde.rs:resolve_serialized}}
 ```
 
 but the gist of it is that it is a mirror of the `Resolve` type we already know,

--- a/docs/src/internals/core_api.md
+++ b/docs/src/internals/core_api.md
@@ -1,5 +1,0 @@
-# Core API
-
-```admonish info
-Coming soon.
-```

--- a/docs/src/internals/effect.md
+++ b/docs/src/internals/effect.md
@@ -1,4 +1,4 @@
-# Effects & Requests
+# The Effect type
 
 ```admonish info
 Coming soon.

--- a/docs/src/internals/runtime.md
+++ b/docs/src/internals/runtime.md
@@ -1,5 +1,158 @@
 # Capability Runtime
 
-```admonish info
-Coming soon.
+In the previous sections we focused on building applications in Crux and using
+it's public APIs to do so. In this and the following chapters, we'll look at how
+the internals of Crux work, starting with the capability runtime.
+
+The capability runtime is a set of components whose job it is to facilitate the
+processing of effects to present the two perspectives we previously mentioned:
+
+* For the core, the shell appears to be a platform with a message based system interface
+* For the shell, the core appears as a stateful library responding to events with request for side-effects
+
+There are a few chalenges to solve in order to facilitate this interface. First,
+each run of the `update` function can call several capabilities, and the effects
+produced are expected to be emitted together and processed concurrently, so the calls can't be blocking. Second, each effect requested from a capability may
+require multiple round-trips between the core and shell to conclude and we
+don't want to require a call to `update` per round trip, so we need some
+ability to "suspend" execution in capabilities while waiting for an effect to
+be fulfilled. The third challenge is dispatch - effects started in a particular
+capability, once resolved, need to continue execution in the same capability.
+
+Given this concurrency and execution suspension, an async interface seems like
+a good candidate. Capabilities request work from the shell, `.await`
+the results, and continue their work when the result has arrived. The call to
+`request_from_shell` or `stream_from_shell` translates into an effect request
+returned from the current core "transaction" (one call to `process_event`
+or `resolve`).
+
+```admonish note
+In this chapter, we will focus on the runtime and the core interface and ignore
+the serialization, bridge and FFI, and return to them in the following sections.
+The examples will assume a Rust based shell.
 ```
+
+## Async runtime
+
+One of the fairly unique aspects of Rust's async is the fact that it doesn't
+come with a bundled runtime. This is in recognition that asynchronous execution
+is useful in various different scenarios, and no one runtime can serve all of
+them. Crux takes advantage of this and brings it's own runtime, tailored to the
+execution of side-effects on top of a message based interface.
+
+For a deeper background on Rust's async architecture, we recommend... _TODO
+recommed a good source (one that describes building an executor.)_ We will
+assume you are familiar with the basic ideas and mechanics of async here.
+
+The job of an async runtime is to manage a number of tasks, each driving one
+future to completion. This management is done by an executor, which is
+responsible for scheduling the futures and `poll`ing them _at the right time_ to
+drive their execution forward. Most "grown up" runtimes will do this on a number
+of threads in a thread pool, but for Crux, we run in the context of a single
+function call (of the app's `update` function) and potentially in a webassembly
+context which is single threaded anyway, so our runtime only needs to poll all the in-flight tasks sequentially, to see if any of them need to continue.
+
+This would work, and in our case wouldn't even be that inefficient, but the
+async system is set up to avoid unnecessary polling of futures with one
+additional concept - wakers. A waker is a mechanism which can be used to signal
+the executor that something a given task is waiting on has changed, and the
+task's future should be polled, because it will be able to proceed.
+
+In our case there's a single situation which causes such a change - a result has
+arrived from the shell, for a particular effect requested earlier.
+
+So, in broad strokes, our strategy for the capability runtime is as follows:
+
+1. A capability `spawn`s a task and submits a future with some code to run
+1. The new task is scheduled to be polled next time the executor runs
+1. The executor goes through the list of ready tasks until it gets to our task and polls it
+1. The future runs to the point wher the first async call is `await`ed. In
+capabilities, this can only be a future returned from one of the calls to
+request something from the shell, or a future resulting from a composition of
+such futures (with combinators like `select` or `join`).
+1. The shell request future's first job is to create and send the request. We
+will look at the mechanics of the sending in a minute, but for now it's only
+important that this is part of the future's state, so that it can be used on
+the next poll, and that part of this request is a callback used to resolve it.
+1. The task's future is now waiting on the shell request future, and the last
+thing the task will do is poll it, to see if it can potentially continue
+straight away.
+1. The request future, as part of its poll, sees there's a request to send and
+does so. It doesn't yet have a result, so it returns a pending state to the parent future and ultimately the executor and the task is suspended.
+1. The request is passed on to the shell to resolve (as a return from `process_event` or `resolve`)
+1. Eventually, the shell has a result ready for the request and asks the core to
+resolve the request.
+1. The callback mentiond above is executed, putting the provided result onto the
+future's state, and calling the associated waker, also stored on the state, to
+wake the future up.
+1. The waker schedules the future for execution next time the executor runs, by
+putting it on the ready list.
+1. The executor runs again (asked to do so by the core `resolve` API after
+calling the callback), and polls the future.
+1. the inner future sees there is now a result available and returns a ready result, resuming the execution of the original task.
+
+The cycle may repeat a few times, but eventually the original task completes and
+is removed.
+
+This is probably a lot to take in, but the basic gist is that capability futures
+always pause on request futures, which submit requests. Resolving requests updates the state of the original future and wakes it up to continue execution.
+
+With that in mind we can look at the individual moving parts and how they
+communicate.
+
+## Spawning tasks on the executor
+
+The first step for anythning to happen is spawning a task from a capability.
+Each capability is created with a `CapabilityContext`. This is the definition:
+
+```rust,no_run,noplayground
+{{#include ../../../crux_core/src/capability/mod.rs:399:413}}
+```
+
+There are a couple sending ends of channels for requests and events, which we
+will get to soon, and also a spawner, from the executor module. The `Spawner`
+looks like this:
+
+```rust,no_run,noplayground
+{{#include ../../../crux_core/src/capability/executor.rs:17:20}}
+```
+
+also holding a sending end of a channel, this one for `Task`s. The final piece
+of the puzzle is the executor itself:
+
+```rust,no_run,noplayground
+{{#include ../../../crux_core/src/capability/executor.rs:13:15}}
+```
+
+This is the receiving end of the channel from the spawner.
+
+The executor has a single method, `run_all`:
+
+```rust,no_run,noplayground
+{{#include ../../../crux_core/src/capability/executor.rs:58:79}}
+```
+
+besides the locking and waker mechanics, the gist is quite simple - while there
+are tasks in the ready_queue, poll the future held in each one.
+
+The last interesting bit of this part is how the waker is provided to the `poll`
+call. The `waker_ref` creates a waker which, when asked to wake up, will call
+this method on the task:
+
+```rust,no_run,noplayground
+{{#include ../../../crux_core/src/capability/executor.rs:48:56}}
+```
+
+this simply enqueues the task again for processing on the next run.
+
+The only missing piece is when does the `run_all` get called, and the answer is
+in the `Core` API implementation. Both `process_event` and `resolve` call run
+all after their respective task - calling the app's `update` function, or
+resolving the given task.
+
+Now we see how the futures get executed, we can examine the flow of information
+between capabilities and the Core API calls
+
+## Requests flow from capabilities to the core
+
+TODO

--- a/docs/src/internals/runtime.md
+++ b/docs/src/internals/runtime.md
@@ -125,7 +125,7 @@ The first step for anything to happen is spawning a task from a capability.
 Each capability is created with a `CapabilityContext`. This is the definition:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/mod.rs:399:413}}
+{{#include ../../../crux_core/src/capability/mod.rs:capability_context}}
 ```
 
 There are a couple sending ends of channels for requests and events, which we
@@ -133,7 +133,7 @@ will get to soon, and also a spawner, from the executor module. The `Spawner`
 looks like this:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/executor.rs:17:20}}
+{{#include ../../../crux_core/src/capability/executor.rs:spawner}}
 ```
 
 also holding a sending end of a channel, this one for `Task`s.
@@ -143,13 +143,13 @@ end of the tasks channel, because tasks need to be able to submit themselves
 when awoken.
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/executor.rs:22:26}}
+{{#include ../../../crux_core/src/capability/executor.rs:task}}
 ```
 
 Tasks are spawned by the Spawner as follows:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/executor.rs:34:46}}
+{{#include ../../../crux_core/src/capability/executor.rs:spawning}}
 ```
 
 after constructing a task, it is submitted using the task sender.
@@ -157,7 +157,7 @@ after constructing a task, it is submitted using the task sender.
 The final piece of the puzzle is the executor itself:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/executor.rs:13:15}}
+{{#include ../../../crux_core/src/capability/executor.rs:executor}}
 ```
 
 This is the receiving end of the channel from the spawner.
@@ -165,7 +165,7 @@ This is the receiving end of the channel from the spawner.
 The executor has a single method, `run_all`:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/executor.rs:58:79}}
+{{#include ../../../crux_core/src/capability/executor.rs:run_all}}
 ```
 
 besides the locking and waker mechanics, the gist is quite simple - while there
@@ -176,7 +176,7 @@ call. The `waker_ref` creates a waker which, when asked to wake up, will call
 this method on the task:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/executor.rs:48:56}}
+{{#include ../../../crux_core/src/capability/executor.rs:arc_wake}}
 ```
 
 this is where the task resubmits itself for processing on the next run.
@@ -226,7 +226,7 @@ the capabilities and the core of crux. As you can see, the requests expected are
 Looking at the core itself, we see their `Receiver` ends.
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/core/mod.rs:24:34}}
+{{#include ../../../crux_core/src/core/mod.rs:core}}
 ```
 
 One detail to note is that the receiving end of the requests channel is a
@@ -244,19 +244,19 @@ capability runtime.
 Here is `process_event`:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/core/mod.rs:68:74}}
+{{#include ../../../crux_core/src/core/mod.rs:process_event}}
 ```
 
 and here is `resolve`:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/core/mod.rs:81:89}}
+{{#include ../../../crux_core/src/core/mod.rs:resolve}}
 ```
 
 The interesting things happen in the common `process` method:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/core/mod.rs:91:103}}
+{{#include ../../../crux_core/src/core/mod.rs:process}}
 ```
 
 First, we run all ready tasks in the executor. There can be new tasks ready
@@ -277,14 +277,14 @@ is ultimately just a callback carried by the request, but for additional type
 safety, it is tagged by the expected number of resolutions
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/core/resolve.rs:3:12}}
+{{#include ../../../crux_core/src/core/resolve.rs:resolve}}
 ```
 
 We've already mentioned the resolve function itself briefly, but for
-completeness, here's an example:
+completeness, here's an example from `request_from_shell`:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/shell_request.rs:72:87}}
+{{#include ../../../crux_core/src/capability/shell_request.rs:resolve}}
 ```
 
 Bar the locking and sharing mechanics, all it does is update the state of the

--- a/docs/src/internals/runtime.md
+++ b/docs/src/internals/runtime.md
@@ -1,15 +1,34 @@
 # Capability Runtime
 
-In the previous sections we focused on building applications in Crux and using it's public APIs to do so. In this and the following chapters, we'll look at how the internals of Crux work, starting with the capability runtime.
+In the previous sections we focused on building applications in Crux and using
+its public APIs to do so. In this and the following chapters, we'll look at how
+the internals of Crux work, starting with the capability runtime.
 
-The capability runtime is a set of components whose job it is to facilitate the processing of effects to present the two perspectives we previously mentioned:
+The capability runtime is a set of components whose job it is to facilitate the
+processing of effects to present the two perspectives we previously mentioned:
 
-- For the core, the shell appears to be a platform with a message based system interface
-- For the shell, the core appears as a stateful library responding to events with request for side-effects
+- For the core, the shell appears to be a platform with a message based system
+  interface
+- For the shell, the core appears as a stateful library responding to events
+  with request for side-effects
 
-There are a few challenges to solve in order to facilitate this interface. First, each run of the `update` function can call several capabilities, and the requested effects are expected to be emitted together and processed concurrently, so the calls can't be blocking. Second, each effect requested from a capability may require multiple round-trips between the core and shell to conclude and we don't want to require a call to `update` per round trip, so we need some ability to "suspend" execution in capabilities while waiting for an effect to be fulfilled. The ability to suspend effects introduces a new challenge - effects started in a particular capability and suspended, once resolved, need to continue execution in the same capability.
+There are a few challenges to solve in order to facilitate this interface.
+First, each run of the `update` function can call several capabilities, and the
+requested effects are expected to be emitted together and processed
+concurrently, so the calls can't be blocking. Second, each effect requested from
+a capability may require multiple round-trips between the core and shell to
+conclude and we don't want to require a call to `update` per round trip, so we
+need some ability to "suspend" execution in capabilities while waiting for an
+effect to be fulfilled. The ability to suspend effects introduces a new
+challenge - effects started in a particular capability and suspended, once
+resolved, need to continue execution in the same capability.
 
-Given this concurrency and execution suspension, an async interface seems like a good candidate. Capabilities request work from the shell, `.await` the results, and continue their work when the result has arrived. The call to `request_from_shell` or `stream_from_shell` translates into an effect request returned from the current core "transaction" (one call to `process_event` or `resolve`).
+Given this concurrency and execution suspension, an async interface seems like a
+good candidate. Capabilities request work from the shell, `.await` the results,
+and continue their work when the result has arrived. The call to
+`request_from_shell` or `stream_from_shell` translates into an effect request
+returned from the current core "transaction" (one call to `process_event` or
+`resolve`).
 
 ```admonish note
 In this chapter, we will focus on the runtime and the core interface and ignore
@@ -19,15 +38,37 @@ The examples will assume a Rust based shell.
 
 ## Async runtime
 
-One of the fairly unique aspects of Rust's async is the fact that it doesn't come with a bundled runtime. This is recognising that asynchronous execution is useful in various different scenarios, and no one runtime can serve all of them. Crux takes advantage of this and brings it's own runtime, tailored to the execution of side-effects on top of a message based interface.
+One of the fairly unique aspects of Rust's async is the fact that it doesn't
+come with a bundled runtime. This is recognising that asynchronous execution is
+useful in various different scenarios, and no one runtime can serve all of them.
+Crux takes advantage of this and brings its own runtime, tailored to the
+execution of side-effects on top of a message based interface.
 
-For a deeper background on Rust's async architecture, we recommend the [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/) book, especially the chapter about [executing futures and tasks](https://rust-lang.github.io/async-book/02_execution/01_chapter.html). We will assume you are familiar with the basic ideas and mechanics of async here.
+For a deeper background on Rust's async architecture, we recommend the
+[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/)
+book, especially the chapter about
+[executing futures and tasks](https://rust-lang.github.io/async-book/02_execution/01_chapter.html).
+We will assume you are familiar with the basic ideas and mechanics of async
+here.
 
-The job of an async runtime is to manage a number of tasks, each driving one future to completion. This management is done by an executor, which is responsible for scheduling the futures and `poll`ing them _at the right time_ to drive their execution forward. Most "grown up" runtimes will do this on a number of threads in a thread pool, but in Crux, we run in the context of a single function call (of the app's `update` function) and potentially in a webassembly context which is single threaded anyway, so our baby runtime only needs to poll all the tasks sequentially, to see if any of them need to continue.
+The job of an async runtime is to manage a number of tasks, each driving one
+future to completion. This management is done by an executor, which is
+responsible for scheduling the futures and `poll`ing them _at the right time_ to
+drive their execution forward. Most "grown up" runtimes will do this on a number
+of threads in a thread pool, but in Crux, we run in the context of a single
+function call (of the app's `update` function) and potentially in a webassembly
+context which is single threaded anyway, so our baby runtime only needs to poll
+all the tasks sequentially, to see if any of them need to continue.
 
-Polling all the tasks would work, and in our case wouldn't even be that inefficient, but the async system is set up to avoid unnecessary polling of futures with one additional concept - wakers. A waker is a mechanism which can be used to signal to the executor that something that a given task is waiting on has changed, and the task's future should be polled, because it will be able to proceed. This is how "at the right time" from the above paragraph is decided.
+Polling all the tasks would work, and in our case wouldn't even be that
+inefficient, but the async system is set up to avoid unnecessary polling of
+futures with one additional concept - wakers. A waker is a mechanism which can
+be used to signal to the executor that something that a given task is waiting on
+has changed, and the task's future should be polled, because it will be able to
+proceed. This is how "at the right time" from the above paragraph is decided.
 
-In our case there's a single situation which causes such a change - a result has arrived from the shell, for a particular effect requested earlier.
+In our case there's a single situation which causes such a change - a result has
+arrived from the shell, for a particular effect requested earlier.
 
 ```admonish warning
 This is a strong assumption Crux makes, and can lead to unexpected behaviour
@@ -35,7 +76,8 @@ when futures with different wakers are submitted onto the runtime. Trying to do
 so will either simply not work on some platforms where the given type of waker
 (e.g. network I/O) is not available, or the futures will eventually proceed,
 but only when one of the Crux core APIs are called, because that's when the
-executor runs, as we will see below
+executor runs, as we will see below. Instead, implement your async work in
+a separate capability (see the [capabilities](../guide/capability_apis.md) chapter).
 ```
 
 ## One effect's life cycle
@@ -44,31 +86,57 @@ So, step by step, our strategy for the capabilities to handle effects is:
 
 1. A capability `spawn`s a task and submits a future with some code to run
 1. The new task is scheduled to be polled next time the executor runs
-1. The executor goes through the list of ready tasks until it gets to our task and polls it
-1. The future runs to the point where the first async call is `await`ed. In capabilities, this _should_ only be a future returned from one of the calls to request something from the shell, or a future resulting from a composition of such futures (through async method calls or combinators like `select` or `join`).
-1. The shell request future's first step is to create the request and prepare it to be sent. We will look at the mechanics of the sending shortly, but for now it's only important that part of this request is a callback used to resolve it.
-1. The request future, as part of the first poll by the executor, sends the request to be handed to the shell. As there is no result from the shell yet, it returns a pending state and the task is suspended.
-1. The request is passed on to the shell to resolve (as a return value from `process_event` or `resolve`)
-1. Eventually, the shell has a result ready for the request and asks the core to `resolve` the request.
-1. The request callback mentioned above is executed, puts the provided result in the future's mutable state, and calls the future's waker, also stored in the future's state, to wake the future up. The waker enqueues the future for processing on th executor.
-1. The executor runs again (asked to do so by the core's `resolve` API after calling the callback), and polls the awoken future.
-1. the future sees there is now a result available and continues the execution of the original task until a further await or until completion.
+1. The executor goes through the list of ready tasks until it gets to our task
+   and polls it
+1. The future runs to the point where the first async call is `await`ed. In
+   capabilities, this _should_ only be a future returned from one of the calls
+   to request something from the shell, or a future resulting from a composition
+   of such futures (through async method calls or combinators like `select` or
+   `join`).
+1. The shell request future's first step is to create the request and prepare it
+   to be sent. We will look at the mechanics of the sending shortly, but for now
+   it's only important that part of this request is a callback used to resolve
+   it.
+1. The request future, as part of the first poll by the executor, sends the
+   request to be handed to the shell. As there is no result from the shell yet,
+   it returns a pending state and the task is suspended.
+1. The request is passed on to the shell to resolve (as a return value from
+   `process_event` or `resolve`)
+1. Eventually, the shell has a result ready for the request and asks the core to
+   `resolve` the request.
+1. The request callback mentioned above is executed, puts the provided result in
+   the future's mutable state, and calls the future's waker, also stored in the
+   future's state, to wake the future up. The waker enqueues the future for
+   processing on the executor.
+1. The executor runs again (asked to do so by the core's `resolve` API after
+   calling the callback), and polls the awoken future.
+1. the future sees there is now a result available and continues the execution
+   of the original task until a further await or until completion.
 
-The cycle may repeat a few times, depending on the capability implementation, but eventually the original task completes and is removed.
+The cycle may repeat a few times, depending on the capability implementation,
+but eventually the original task completes and is removed.
 
-This is probably a lot to take in, but the basic gist is that capability futures (the ones submitted to `spawn`) always pause on request futures (the ones returned from `request_from_shell` et al.), which submit requests. Resolving requests updates the state of the original future and wakes it up to continue execution.
+This is probably a lot to take in, but the basic gist is that capability futures
+(the ones submitted to `spawn`) always pause on request futures (the ones
+returned from `request_from_shell` et al.), which submit requests. Resolving
+requests updates the state of the original future and wakes it up to continue
+execution.
 
-With that in mind we can look at the individual moving parts and how they communicate.
+With that in mind we can look at the individual moving parts and how they
+communicate.
 
 ## Spawning tasks on the executor
 
-The first step for anything to happen is spawning a task from a capability. Each capability is created with a `CapabilityContext`. This is the definition:
+The first step for anything to happen is spawning a task from a capability. Each
+capability is created with a `CapabilityContext`. This is the definition:
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/capability/mod.rs:capability_context}}
 ```
 
-There are a couple sending ends of channels for requests and events, which we will get to soon, and also a spawner, from the executor module. The `Spawner` looks like this:
+There are a couple of sending ends of channels for requests and events, which we
+will get to soon, and also a spawner, from the executor module. The `Spawner`
+looks like this:
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/capability/executor.rs:spawner}}
@@ -76,7 +144,9 @@ There are a couple sending ends of channels for requests and events, which we wi
 
 also holding a sending end of a channel, this one for `Task`s.
 
-Tasks are a fairly simple data structure, holding a future and another sending end of the tasks channel, because tasks need to be able to submit themselves when awoken.
+Tasks are a fairly simple data structure, holding a future and another sending
+end of the tasks channel, because tasks need to be able to submit themselves
+when awoken.
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/capability/executor.rs:task}}
@@ -104,9 +174,12 @@ The executor has a single method, `run_all`:
 {{#include ../../../crux_core/src/capability/executor.rs:run_all}}
 ```
 
-besides the locking and waker mechanics, the gist is quite simple - while there are tasks in the ready_queue, poll the future held in each one.
+besides the locking and waker mechanics, the gist is quite simple - while there
+are tasks in the ready_queue, poll the future held in each one.
 
-The last interesting bit of this part is how the waker is provided to the `poll` call. The `waker_ref` creates a waker which, when asked to wake up, will call this method on the task:
+The last interesting bit of this part is how the waker is provided to the `poll`
+call. The `waker_ref` creates a waker which, when asked to wake up, will call
+this method on the task:
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/capability/executor.rs:arc_wake}}
@@ -114,19 +187,48 @@ The last interesting bit of this part is how the waker is provided to the `poll`
 
 this is where the task resubmits itself for processing on the next run.
 
-While there are a lot of moving pieces involved, the basic mechanics are relatively straightforward - tasks are submitted either by the spawner, or the futures awoken by arriving responses to the requests they submitted. The queue of tasks is processed whenever `run_all` is called on the executor. This happens in the `Core` API implementation. Both `process_event` and `resolve` call `run_all` after their respective task - calling the app's `update` function, or resolving the given task.
+While there are a lot of moving pieces involved, the basic mechanics are
+relatively straightforward - tasks are submitted either by the spawner, or the
+futures awoken by arriving responses to the requests they submitted. The queue
+of tasks is processed whenever `run_all` is called on the executor. This happens
+in the `Core` API implementation. Both `process_event` and `resolve` call
+`run_all` after their respective task - calling the app's `update` function, or
+resolving the given task.
 
-Now we know how the futures get executed, suspended and resumed, we can examine the flow of information between capabilities and the Core API calls layered on top.
+Now we know how the futures get executed, suspended and resumed, we can examine
+the flow of information between capabilities and the Core API calls layered on
+top.
 
 ## Requests flow from capabilities to the shell
 
-The key to understanding how the effects get processed and executed is to name all the various pieces of information, and discuss how they are wrapped in each other.
+The key to understanding how the effects get processed and executed is to name
+all the various pieces of information, and discuss how they are wrapped in each
+other.
 
-The basic inner piece of the effect request is an _operation_. This is the intent which the capability is submitting to the shell. Each operation has an associated _output_ value, with which the operation request can be resolved. There are multiple capabilities in each app, and in order for the shell to easily tell which capability's effect it needs to handle, we wrap the operation in an _effect_. The `Effect` type is a generated enum based on the app's set of capabilities, with one variant per capability. It allows us to multiplex (or type erase) the different typed operations into a single type, which can be `match`ed on to process the operations.
+The basic inner piece of the effect request is an _operation_. This is the
+intent which the capability is submitting to the shell. Each operation has an
+associated _output_ value, with which the operation request can be resolved.
+There are multiple capabilities in each app, and in order for the shell to
+easily tell which capability's effect it needs to handle, we wrap the operation
+in an _effect_. The `Effect` type is a generated enum based on the app's set of
+capabilities, with one variant per capability. It allows us to multiplex (or
+type erase) the different typed operations into a single type, which can be
+`match`ed on to process the operations.
 
-Finally, the effect is wrapped in a _request_ which carries the effect, and an associated _resolve_ callback to which the output will eventually be given. We discussed this callback in the previous section - its job is to update the paused future's state and resume it. The request is the value passed to the shell, and used as both the description of the effect intent, and the "token" used to resolve it.
+Finally, the effect is wrapped in a _request_ which carries the effect, and an
+associated _resolve_ callback to which the output will eventually be given. We
+discussed this callback in the previous section - its job is to update the
+paused future's state and resume it. The request is the value passed to the
+shell, and used as both the description of the effect intent, and the "token"
+used to resolve it.
 
-Now we can look at how all this wrapping is facilitated. Recall from the previous section that each capability has access to a `CapabilityContext`, which holds a sending end of two channels, one for events - the `app_channel` and one for requests - the `shell_channel`, whose type is `Sender<Request<Op>>`. These channels serve both as thread synchronisation and queueing mechanism between the capabilities and the core of crux. As you can see, the requests expected are typed for the capability's operation type.
+Now we can look at how all this wrapping is facilitated. Recall from the
+previous section that each capability has access to a `CapabilityContext`, which
+holds a sending end of two channels, one for events - the `app_channel` and one
+for requests - the `shell_channel`, whose type is `Sender<Request<Op>>`. These
+channels serve both as thread synchronisation and queueing mechanism between the
+capabilities and the core of crux. As you can see, the requests expected are
+typed for the capability's operation type.
 
 Looking at the core itself, we see their `Receiver` ends.
 
@@ -134,11 +236,18 @@ Looking at the core itself, we see their `Receiver` ends.
 {{#include ../../../crux_core/src/core/mod.rs:core}}
 ```
 
-One detail to note is that the receiving end of the requests channel is a `Receiver<Ef>`. The channel has an additional feature - it can map between the input types and output types, and, in this case, serve as a multiplexer, wrapping the operation in the corresponding Effect variant. Each sending end is specialised for the respective capability, but the receiving end gets an already wrapped `Effect`.
+One detail to note is that the receiving end of the requests channel is a
+`Receiver<Ef>`. The channel has an additional feature - it can map between the
+input types and output types, and, in this case, serve as a multiplexer,
+wrapping the operation in the corresponding Effect variant. Each sending end is
+specialised for the respective capability, but the receiving end gets an already
+wrapped `Effect`.
 
 ## A single update cycle
 
-To piece all these things together, lets look at processing a single call from the shell. Both `process_event` and `resolve` share a common step advancing the capability runtime.
+To piece all these things together, lets look at processing a single call from
+the shell. Both `process_event` and `resolve` share a common step advancing the
+capability runtime.
 
 Here is `process_event`:
 
@@ -158,26 +267,39 @@ The interesting things happen in the common `process` method:
 {{#include ../../../crux_core/src/core/mod.rs:process}}
 ```
 
-First, we run all ready tasks in the executor. There can be new tasks ready because we just ran the app's update function (which may have spawned some task via capability calls) or resolved some effects (which woke up their suspended futures).
+First, we run all ready tasks in the executor. There can be new tasks ready
+because we just ran the app's update function (which may have spawned some task
+via capability calls) or resolved some effects (which woke up their suspended
+futures).
 
-Next, we drain the events channel (where events are submitted from capabilities by `context.update_app`) and one by one, send them to the `update` function, running the executor after each one.
+Next, we drain the events channel (where events are submitted from capabilities
+by `context.update_app`) and one by one, send them to the `update` function,
+running the executor after each one.
 
-Finally, we collect all of the effect requests submitted in the process and return them to the shell.
+Finally, we collect all of the effect requests submitted in the process and
+return them to the shell.
 
 ## Resolving requests
 
-We've now seen everything other than the mechanics of resolving requests. This is ultimately just a callback carried by the request, but for additional type safety, it is tagged by the expected number of resolutions
+We've now seen everything other than the mechanics of resolving requests. This
+is ultimately just a callback carried by the request, but for additional type
+safety, it is tagged by the expected number of resolutions
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/core/resolve.rs:resolve}}
 ```
 
-We've already mentioned the resolve function itself briefly, but for completeness, here's an example from `request_from_shell`:
+We've already mentioned the resolve function itself briefly, but for
+completeness, here's an example from `request_from_shell`:
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/capability/shell_request.rs:resolve}}
 ```
 
-Bar the locking and sharing mechanics, all it does is update the state of the future (`shared_state`) and then calls `wake` on the future's waker to schedule it on the executor.
+Bar the locking and sharing mechanics, all it does is update the state of the
+future (`shared_state`) and then calls `wake` on the future's waker to schedule
+it on the executor.
 
-In the next chapter, we will look at how this process changes when Crux is used via an FFI interface where requests and responses need to be serialised in order to pass across the language boundary.
+In the next chapter, we will look at how this process changes when Crux is used
+via an FFI interface where requests and responses need to be serialised in order
+to pass across the language boundary.

--- a/docs/src/internals/runtime.md
+++ b/docs/src/internals/runtime.md
@@ -1,32 +1,15 @@
 # Capability Runtime
 
-In the previous sections we focused on building applications in Crux and using
-it's public APIs to do so. In this and the following chapters, we'll look at how
-the internals of Crux work, starting with the capability runtime.
+In the previous sections we focused on building applications in Crux and using it's public APIs to do so. In this and the following chapters, we'll look at how the internals of Crux work, starting with the capability runtime.
 
-The capability runtime is a set of components whose job it is to facilitate the
-processing of effects to present the two perspectives we previously mentioned:
+The capability runtime is a set of components whose job it is to facilitate the processing of effects to present the two perspectives we previously mentioned:
 
-- For the core, the shell appears to be a platform with a message based system
-  interface
-- For the shell, the core appears as a stateful library responding to events
-  with request for side-effects
+- For the core, the shell appears to be a platform with a message based system interface
+- For the shell, the core appears as a stateful library responding to events with request for side-effects
 
-There are a few chalenges to solve in order to facilitate this interface. First,
-each run of the `update` function can call several capabilities, and the
-requested effects are expected to be emitted together and processed
-concurrently, so the calls can't be blocking. Second, each effect requested
-from a capability may require multiple round-trips between the core and shell
-to conclude and we don't want to require a call to `update` per round trip, so
-we need some ability to "suspend" execution in capabilities while waiting for
-an effect to be fulfilled. The ability to suspend effects introduces a new challenge - effects started in a particular capability and suspended, once resolved, need to continue execution in the same capability.
+There are a few challenges to solve in order to facilitate this interface. First, each run of the `update` function can call several capabilities, and the requested effects are expected to be emitted together and processed concurrently, so the calls can't be blocking. Second, each effect requested from a capability may require multiple round-trips between the core and shell to conclude and we don't want to require a call to `update` per round trip, so we need some ability to "suspend" execution in capabilities while waiting for an effect to be fulfilled. The ability to suspend effects introduces a new challenge - effects started in a particular capability and suspended, once resolved, need to continue execution in the same capability.
 
-Given this concurrency and execution suspension, an async interface seems like
-a good candidate. Capabilities request work from the shell, `.await`
-the results, and continue their work when the result has arrived. The call to
-`request_from_shell` or `stream_from_shell` translates into an effect request
-returned from the current core "transaction" (one call to `process_event`
-or `resolve`).
+Given this concurrency and execution suspension, an async interface seems like a good candidate. Capabilities request work from the shell, `.await` the results, and continue their work when the result has arrived. The call to `request_from_shell` or `stream_from_shell` translates into an effect request returned from the current core "transaction" (one call to `process_event` or `resolve`).
 
 ```admonish note
 In this chapter, we will focus on the runtime and the core interface and ignore
@@ -36,36 +19,15 @@ The examples will assume a Rust based shell.
 
 ## Async runtime
 
-One of the fairly unique aspects of Rust's async is the fact that it doesn't
-come with a bundled runtime. This is recognising that asynchronous execution
-is useful in various different scenarios, and no one runtime can serve all of
-them. Crux takes advantage of this and brings it's own runtime, tailored to the
-execution of side-effects on top of a message based interface.
+One of the fairly unique aspects of Rust's async is the fact that it doesn't come with a bundled runtime. This is recognising that asynchronous execution is useful in various different scenarios, and no one runtime can serve all of them. Crux takes advantage of this and brings it's own runtime, tailored to the execution of side-effects on top of a message based interface.
 
-For a deeper background on Rust's async architecture, we recommend the
-[Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/)
-book, especially the chapter about [executing futured and
-tasks](https://rust-lang.github.io/async-book/02_execution/01_chapter.html) We
-will assume you are familiar with the basic ideas and mechanics of async here.
+For a deeper background on Rust's async architecture, we recommend the [Asynchronous Programming in Rust](https://rust-lang.github.io/async-book/) book, especially the chapter about [executing futured and tasks](https://rust-lang.github.io/async-book/02_execution/01_chapter.html) We will assume you are familiar with the basic ideas and mechanics of async here.
 
-The job of an async runtime is to manage a number of tasks, each driving one
-future to completion. This management is done by an executor, which is
-responsible for scheduling the futures and `poll`ing them _at the right time_ to
-drive their execution forward. Most "grown up" runtimes will do this on a number
-of threads in a thread pool, but for Crux, we run in the context of a single
-function call (of the app's `update` function) and potentially in a webassembly
-context which is single threaded anyway, so our baby runtime only needs to poll
-all the tasks sequentially, to see if any of them need to continue.
+The job of an async runtime is to manage a number of tasks, each driving one future to completion. This management is done by an executor, which is responsible for scheduling the futures and `poll`ing them _at the right time_ to drive their execution forward. Most "grown up" runtimes will do this on a number of threads in a thread pool, but for Crux, we run in the context of a single function call (of the app's `update` function) and potentially in a webassembly context which is single threaded anyway, so our baby runtime only needs to poll all the tasks sequentially, to see if any of them need to continue.
 
-Polling all the tasks would work, and in our case wouldn't even be that
-inefficient, but the async system is set up to avoid unnecessary polling of
-futures with one additional concept - wakers. A waker is a mechanism which can
-be used to signal to the executor that something a given task is waiting on has
-changed, and the task's future should be polled, because it will be able to
-proceed. This is how "at the right time" from the above paragraph is decided.
+Polling all the tasks would work, and in our case wouldn't even be that inefficient, but the async system is set up to avoid unnecessary polling of futures with one additional concept - wakers. A waker is a mechanism which can be used to signal to the executor that something a given task is waiting on has changed, and the task's future should be polled, because it will be able to proceed. This is how "at the right time" from the above paragraph is decided.
 
-In our case there's a single situation which causes such a change - a result has
-arrived from the shell, for a particular effect requested earlier.
+In our case there's a single situation which causes such a change - a result has arrived from the shell, for a particular effect requested earlier.
 
 ```admonish warning
 This is a strong assumption Crux makes, and can lead to unexpected behaviour
@@ -82,55 +44,31 @@ So, step by step, our strategy for the capabilities to handle effects is:
 
 1. A capability `spawn`s a task and submits a future with some code to run
 1. The new task is scheduled to be polled next time the executor runs
-1. The executor goes through the list of ready tasks until it gets to our task
-   and polls it
-1. The future runs to the point where the first async call is `await`ed. In
-   capabilities, this _should_ only be a future returned from one of the calls
-   to request something from the shell, or a future resulting from a
-   composition of such futures (through async method calls or combinators like
-   `select` or `join`).
-1. The shell request future's first step is to create the request and prepare
-   it to be sent. We will look at the mechanics of the sending in a minute, but
-   for now it's only important that part of this request is a callback used to
-   resolve it.
-1. The request future, as part of the first poll by the executor, sends the
-   request to be handed to the shell. As there is no result from the shell yet, it returns a pending state and the task is suspended.
-1. The request is passed on to the shell to resolve (as a return from
-   `process_event` or `resolve`)
-1. Eventually, the shell has a result ready for the request and asks the core to
-   `resolve` the request.
-1. The request callback mentiond above is executed, and puts the provided result
-   in the future's mutable state, and calls the future's waker, also stored in
-   the future's state, to wake the future up. The waker enqueues the future for
-   processing on th executor.
-1. The executor runs again (asked to do so by the core's `resolve` API after
-   calling the callback), and polls the awoken future.
-1. the future sees there is now a result available and continues the execution
-   of the original task until a furher await or until completion.
+1. The executor goes through the list of ready tasks until it gets to our task and polls it
+1. The future runs to the point where the first async call is `await`ed. In capabilities, this _should_ only be a future returned from one of the calls to request something from the shell, or a future resulting from a composition of such futures (through async method calls or combinators like `select` or `join`).
+1. The shell request future's first step is to create the request and prepare it to be sent. We will look at the mechanics of the sending in a minute, but for now it's only important that part of this request is a callback used to resolve it.
+1. The request future, as part of the first poll by the executor, sends the request to be handed to the shell. As there is no result from the shell yet, it returns a pending state and the task is suspended.
+1. The request is passed on to the shell to resolve (as a return from `process_event` or `resolve`)
+1. Eventually, the shell has a result ready for the request and asks the core to `resolve` the request.
+1. The request callback mentioned above is executed, and puts the provided result in the future's mutable state, and calls the future's waker, also stored in the future's state, to wake the future up. The waker enqueues the future for processing on th executor.
+1. The executor runs again (asked to do so by the core's `resolve` API after calling the callback), and polls the awoken future.
+1. the future sees there is now a result available and continues the execution of the original task until a further await or until completion.
 
 The cycle may repeat a few times, depending on the capability implementation, but eventually the original task completes and is removed.
 
-This is probably a lot to take in, but the basic gist is that capability futures
-(the ones submitted to `spawn`) always pause on request futures (the ones
-returned from `request_from_shell` et al.), which submit requests. Resolving
-requests updates the state of the original future and wakes it up to continue
-execution.
+This is probably a lot to take in, but the basic gist is that capability futures (the ones submitted to `spawn`) always pause on request futures (the ones returned from `request_from_shell` et al.), which submit requests. Resolving requests updates the state of the original future and wakes it up to continue execution.
 
-With that in mind we can look at the individual moving parts and how they
-communicate.
+With that in mind we can look at the individual moving parts and how they communicate.
 
 ## Spawning tasks on the executor
 
-The first step for anything to happen is spawning a task from a capability.
-Each capability is created with a `CapabilityContext`. This is the definition:
+The first step for anything to happen is spawning a task from a capability. Each capability is created with a `CapabilityContext`. This is the definition:
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/capability/mod.rs:capability_context}}
 ```
 
-There are a couple sending ends of channels for requests and events, which we
-will get to soon, and also a spawner, from the executor module. The `Spawner`
-looks like this:
+There are a couple sending ends of channels for requests and events, which we will get to soon, and also a spawner, from the executor module. The `Spawner` looks like this:
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/capability/executor.rs:spawner}}
@@ -138,9 +76,7 @@ looks like this:
 
 also holding a sending end of a channel, this one for `Task`s.
 
-Tasks are a fairly simple data structure, holding a future and another sending
-end of the tasks channel, because tasks need to be able to submit themselves
-when awoken.
+Tasks are a fairly simple data structure, holding a future and another sending end of the tasks channel, because tasks need to be able to submit themselves when awoken.
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/capability/executor.rs:task}}
@@ -168,12 +104,9 @@ The executor has a single method, `run_all`:
 {{#include ../../../crux_core/src/capability/executor.rs:run_all}}
 ```
 
-besides the locking and waker mechanics, the gist is quite simple - while there
-are tasks in the ready_queue, poll the future held in each one.
+besides the locking and waker mechanics, the gist is quite simple - while there are tasks in the ready_queue, poll the future held in each one.
 
-The last interesting bit of this part is how the waker is provided to the `poll`
-call. The `waker_ref` creates a waker which, when asked to wake up, will call
-this method on the task:
+The last interesting bit of this part is how the waker is provided to the `poll` call. The `waker_ref` creates a waker which, when asked to wake up, will call this method on the task:
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/capability/executor.rs:arc_wake}}
@@ -181,47 +114,19 @@ this method on the task:
 
 this is where the task resubmits itself for processing on the next run.
 
-While there are a lot of moving pieces involved, the basic mechanics are
-relatively straightforward - tasks are submitted either by the spawner, or the
-futures awoken by arriving responses to the requests they submitted. The queue
-of tasks is processed whenever `run_all` is called on the executor. This
-happenes in the `Core` API implementation. Both `process_event` and `resolve`
-call `run_all` after their respective task - calling the app's `update`
-function, or resolving the given task.
+While there are a lot of moving pieces involved, the basic mechanics are relatively straightforward - tasks are submitted either by the spawner, or the futures awoken by arriving responses to the requests they submitted. The queue of tasks is processed whenever `run_all` is called on the executor. This happens in the `Core` API implementation. Both `process_event` and `resolve` call `run_all` after their respective task - calling the app's `update` function, or resolving the given task.
 
-Now we know how the futures get executed, suspended and resumed, we can examine
-the flow of information between capabilities and the Core API calls layered on
-top.
+Now we know how the futures get executed, suspended and resumed, we can examine the flow of information between capabilities and the Core API calls layered on top.
 
 ## Requests flow from capabilities to the shell
 
-The key to understanding how the effects get processed and executed is to name
-all the various pieces of information, and discuss how they are wrapped in each
-other.
+The key to understanding how the effects get processed and executed is to name all the various pieces of information, and discuss how they are wrapped in each other.
 
-The basic inner piece of the effect request is an _operation_. This is the
-intent which the capability is submitting to the shell. Each operation has an
-associated _output_ value, with which the operation request can be resolved.
-There are multiple capabilities in each app, and in order for the shell to
-easily tell which capability's effect it needs to handle, we wrap the
-operation in an _effect_. The `Effect` type is a generated enum serving this
-purpose. It allows us to multiplex (or type erase) the different typed
-operations into a single type, which can be `match`ed on to process the
-operations.
+The basic inner piece of the effect request is an _operation_. This is the intent which the capability is submitting to the shell. Each operation has an associated _output_ value, with which the operation request can be resolved. There are multiple capabilities in each app, and in order for the shell to easily tell which capability's effect it needs to handle, we wrap the operation in an _effect_. The `Effect` type is a generated enum serving this purpose. It allows us to multiplex (or type erase) the different typed operations into a single type, which can be `match`ed on to process the operations.
 
-Finally, the effect is wrapped in a _request_ which carries the effect, and an
-associated _resolve_ callback to which the output will eventually be given. We
-discussed this callback in the previous section - its job is to update the
-paused future's state and resume it. The request is the value passed to the
-shell, and used as both the description of the effect, and the "token" used to
-resolve it.
+Finally, the effect is wrapped in a _request_ which carries the effect, and an associated _resolve_ callback to which the output will eventually be given. We discussed this callback in the previous section - its job is to update the paused future's state and resume it. The request is the value passed to the shell, and used as both the description of the effect, and the "token" used to resolve it.
 
-Now we can look at how all this wrapping is facilitated. Recall from the
-previous section that each capability has access to a `CapabilityContext`, which
-holds a sending end of two channels, one for events - the `app_channel` and one
-for requests - the `shell_channel`, whos type is `Sender<Request<Op>>`. These
-channels serve both as thread synchronisation and queueing mechanism between
-the capabilities and the core of crux. As you can see, the requests expected are typed for the capability's operation type.
+Now we can look at how all this wrapping is facilitated. Recall from the previous section that each capability has access to a `CapabilityContext`, which holds a sending end of two channels, one for events - the `app_channel` and one for requests - the `shell_channel`, whose type is `Sender<Request<Op>>`. These channels serve both as thread synchronisation and queueing mechanism between the capabilities and the core of crux. As you can see, the requests expected are typed for the capability's operation type.
 
 Looking at the core itself, we see their `Receiver` ends.
 
@@ -229,17 +134,11 @@ Looking at the core itself, we see their `Receiver` ends.
 {{#include ../../../crux_core/src/core/mod.rs:core}}
 ```
 
-One detail to note is that the receiving end of the requests channel is a
-`Receiver<Ef>`. The channel has an additional feature - it can map between the
-input types and output types, and, in this case, serve as a multiplexer. Each
-sending end is specialised for the respective capability, but the receiving end
-gets already wrapped `Effect`.
+One detail to note is that the receiving end of the requests channel is a `Receiver<Ef>`. The channel has an additional feature - it can map between the input types and output types, and, in this case, serve as a multiplexer. Each sending end is specialised for the respective capability, but the receiving end gets already wrapped `Effect`.
 
 ## A single update cycle
 
-To piece all these things together, lets look at processing a single call from
-the shell. Both `process_event` and `resolve` share a common step advancing the
-capability runtime.
+To piece all these things together, lets look at processing a single call from the shell. Both `process_event` and `resolve` share a common step advancing the capability runtime.
 
 Here is `process_event`:
 
@@ -259,38 +158,26 @@ The interesting things happen in the common `process` method:
 {{#include ../../../crux_core/src/core/mod.rs:process}}
 ```
 
-First, we run all ready tasks in the executor. There can be new tasks ready
-because we just ran the app's update function (which may have spawned some task
-via capability calls) or resolved some effects (which woke up their suspended
-futures).
+First, we run all ready tasks in the executor. There can be new tasks ready because we just ran the app's update function (which may have spawned some task via capability calls) or resolved some effects (which woke up their suspended futures).
 
-Next, we drain the events channel (where events are submited from capabilities
-by `context.update_app`) and one by one, send them to the `update` function,
-running the executor after each one.
+Next, we drain the events channel (where events are submitted from capabilities by `context.update_app`) and one by one, send them to the `update` function, running the executor after each one.
 
 Finally, we collect all of the effects submitted in the process and return them to the shell.
 
 ## Resolving requests
 
-We've now seen everything other than the mechanics of resolving requests. This
-is ultimately just a callback carried by the request, but for additional type
-safety, it is tagged by the expected number of resolutions
+We've now seen everything other than the mechanics of resolving requests. This is ultimately just a callback carried by the request, but for additional type safety, it is tagged by the expected number of resolutions
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/core/resolve.rs:resolve}}
 ```
 
-We've already mentioned the resolve function itself briefly, but for
-completeness, here's an example from `request_from_shell`:
+We've already mentioned the resolve function itself briefly, but for completeness, here's an example from `request_from_shell`:
 
 ```rust,no_run,noplayground
 {{#include ../../../crux_core/src/capability/shell_request.rs:resolve}}
 ```
 
-Bar the locking and sharing mechanics, all it does is update the state of the
-future (`shared_state`) and then calls `wake` on the future's waker to schedule
-it on the executor.
+Bar the locking and sharing mechanics, all it does is update the state of the future (`shared_state`) and then calls `wake` on the future's waker to schedule it on the executor.
 
-In the next chapter, we will look at how this process changes when Crux is used
-via an FFI interface where requests and responses need to be serialised in order
-to pass across the language boundary.
+In the next chapter, we will look at how this process changes when Crux is used via an FFI interface where requests and responses need to be serialised in order to pass across the language boundary.

--- a/docs/src/internals/serialization.md
+++ b/docs/src/internals/serialization.md
@@ -1,5 +1,0 @@
-# Serialization
-
-```admonish info
-Coming soon.
-```

--- a/docs/src/internals/uniffi.md
+++ b/docs/src/internals/uniffi.md
@@ -1,5 +1,0 @@
-# FFI interface
-
-```admonish info
-Coming soon.
-```


### PR DESCRIPTION
This is the beginning of the internals section of the docs.

I'm aiming to cover the capability runtime, Operations, Requests, and the serialisation in the bridge. The Effect derive macro and typegen are probably a separate docs PR.

## To do 
- [x] make the included code references stable using [anchors](https://rust-lang.github.io/mdBook/format/mdbook.html#including-portions-of-a-file)
- [x] re-read and spellcheck