### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.4.6"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/redbadger/crux/compare/crux_http-v0.4.6...crux_http-v0.5.0) - 2024-01-30
+
+### Fixed
+- fix doc test deps
+
+### Other
+- remove http_types default features from crux_http
+- More human readable change logs
+
 ## [0.4.6](https://github.com/redbadger/crux/compare/crux_http-v0.4.5...crux_http-v0.4.6) - 2024-01-26
 
 ### Fixed

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_http"
 description = "HTTP capability for use with crux_core"
-version = "0.4.6"
+version = "0.5.0"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `crux_http`: 0.4.6 -> 0.5.0 (⚠️ API breaking changes)

### ⚠️ `crux_http` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.28.0/src/lints/inherent_method_missing.ron

Failed in:
  Request::body_file, previously in file /private/var/folders/vj/_19mcln57qz5j75lqqjtxc540000gn/T/.tmpDZPqgc/crux_http/src/request.rs:331
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `crux_http`
<blockquote>

## [0.5.0](https://github.com/redbadger/crux/compare/crux_http-v0.4.6...crux_http-v0.5.0) - 2024-01-30

### Fixed
- fix doc test deps

### Other
- remove http_types default features from crux_http
- More human readable change logs
</blockquote>


---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).