### PR TITLE
`crux_http` to use form of `http-types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,8 +875,7 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 [[package]]
 name = "http-types"
 version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+source = "git+https://github.com/redbadger/http-types.git?branch=v2.x.x-backports#c8eb9f241e39c55e88a46b5e5152794497519dd3"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -17,7 +17,7 @@ crux_core = { version = "0.7", path = "../crux_core" }
 crux_macros = { version = "0.3", path = "../crux_macros" }
 derive_builder = "0.13.0"
 futures-util = "0.3"
-http-types = { version = "2.12", default-features = false }
+http-types = { git = "https://github.com/redbadger/http-types.git", branch = "v2.x.x-backports", default-features = false }
 pin-project-lite = "0.2.13"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0.111"


### PR DESCRIPTION
The published `http-types` crate uses 128bit `trace_id`, which doesn't compile for `wasm32-unknown-emscripten`.

See https://github.com/http-rs/http-types/pull/522