### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "crux_core"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "crux_kv"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "crux_core",
  "crux_http",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "crux_platform"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "crux_time"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "crux_time"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crux_core/CHANGELOG.md
+++ b/crux_core/CHANGELOG.md
@@ -6,6 +6,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3](https://github.com/redbadger/crux/compare/crux_core-v0.7.2...crux_core-v0.7.3) - 2024-02-02
+
+### Fixed
+- fix doc test deps
+
+### Other
+- remove Debug bound in typegen
+- update `crux_time` to not use generic response type + overall deps
+- Make rust fmt happy
+- Export crux_macros from crux_core and change docs
+- Use options helper and erase serde inside the bridge
+- Fix doctest
+- Rename a bunch of things to better reflect how they work
+- fun with erased_serde
+- Tidy doc comments
+- Better names, mod structure, and documentation with plentiful warnings
+- Fix doctests
+- Add a JSON bridge test for the pluggable Bridge serializers
+- Merge serialization traits into one
+- Initial cut of allowing bridge to use different serialization
+- Merge branch 'redbadger:master' into master
+
 ## [0.7.2](https://github.com/redbadger/crux/compare/crux_core-v0.7.1...crux_core-v0.7.2) - 2024-01-26
 
 ### Fixed

--- a/crux_core/CHANGELOG.md
+++ b/crux_core/CHANGELOG.md
@@ -1,62 +1,64 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ## [0.7.3](https://github.com/redbadger/crux/compare/crux_core-v0.7.2...crux_core-v0.7.3) - 2024-02-02
 
-### Fixed
-- fix doc test deps
+### Changes
 
-### Other
-- remove Debug bound in typegen
-- update `crux_time` to not use generic response type + overall deps
-- Make rust fmt happy
-- Export crux_macros from crux_core and change docs
-- Use options helper and erase serde inside the bridge
-- Fix doctest
-- Rename a bunch of things to better reflect how they work
-- fun with erased_serde
-- Tidy doc comments
-- Better names, mod structure, and documentation with plentiful warnings
-- Fix doctests
-- Add a JSON bridge test for the pluggable Bridge serializers
-- Merge serialization traits into one
-- Initial cut of allowing bridge to use different serialization
-- Merge branch 'redbadger:master' into master
+- Allow bring-your-own serializer/deserializer for the `Bridge`. This is not a
+  breaking change as the existing bridge interface is the same. We have
+  introduced a new `BridgeWithSerializer`, where you can plug in your own
+  serialization format (e.g. JSON), but be aware that you'll have to provide
+  your own serialization/deserialization shell-side code (in
+  TypeScript/Swift/Kotlin).
+
+- Re-exports `crux_macros` as `crux_core::macros` in order to help keep the
+  version of macros in sync with the core. Prefer importing macros as
+  `crux_core::macros`, rather than `crux_macros`
 
 ## [0.7.2](https://github.com/redbadger/crux/compare/crux_core-v0.7.1...crux_core-v0.7.2) - 2024-01-26
 
 ### Fixed
+
 - fix clippy lints
 
 ### Other
+
 - Introduce a Compose capability which allows composition of other capabilities
 - Introduce `Never` type for capabilities that don't request effects
-- Effect derive macro now allows skipping variants (to support `Never` operations)
+- Effect derive macro now allows skipping variants (to support `Never`
+  operations)
 - Make render capability is now Clone to suport composition
 - remove uuid unused wasm-bindgen feature flag
 
 ## [0.7.1](https://github.com/redbadger/crux/compare/crux_core-v0.7.0...crux_core-v0.7.1) - 2024-01-11
 
 ### Other
+
 - update deps for Rust, Web, iOS and Android
 - update examples to crux_core 0.7
 
 ## [0.7.0](https://github.com/redbadger/crux/compare/crux_core-v0.6.5...crux_core-v0.7.0) - 2023-12-03
 
 ### Fixed
+
 - fix doc tests
 
 ### Other
+
 - improve typegen error handling
 
 ## [0.6.5](https://github.com/redbadger/crux/compare/crux_core-v0.6.4...crux_core-v0.6.5) - 2023-11-29
 
 ### Other
+
 - root deps
 - rustfmt
 - full error message
@@ -64,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.4](https://github.com/redbadger/crux/compare/crux_core-v0.6.3...crux_core-v0.6.4) - 2023-10-25
 
 ### Other
+
 - update deps
 - update leptos examples to remove Scope
 - deps + tweaks

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_core"
 description = "Cross-platform app development in Rust"
-version = "0.7.2"
+version = "0.7.3"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true
@@ -20,7 +20,7 @@ all-features = true
 anyhow.workspace = true
 bincode = "1.3.3"
 crossbeam-channel = "0.5.11"
-crux_macros = { version = "0.3.6", path = "../crux_macros" }
+crux_macros = { version = "0.3.7", path = "../crux_macros" }
 derive_more = "0.99.17"
 erased-serde = "0.4"
 futures = "0.3.30"

--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -1,161 +1,63 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ## [0.5.1](https://github.com/redbadger/crux/compare/crux_http-v0.5.0...crux_http-v0.5.1) - 2024-02-02
 
-### Fixed
-- fix doc test deps
-- fix clippy lints
-- fix macro to trace Effect
-- fix features on http-types
+### Changed
 
-### Other
-- update `crux_time` to not use generic response type + overall deps
-- Merge branch 'master' into byo-serialization
-- Make rust fmt happy
-- Export crux_macros from crux_core and change docs
-- remove http_types default features from crux_http
-- More human readable change logs
-- release
-- Capabilities don't need to be clone
-- Clone less, to lead by example
-- Prefer IntoFuture as the main RequestBuilder async API
-- Doc comment
-- Remove irrelevant comment
-- Add async API to crux_http
-- update Rust deps
-- release
-- update deps for Rust, Web, iOS and Android
-- release
-- release
-- root deps
-- release
-- versions for compatibility with semver checks
-- update deps
-- deps + tweaks
-- deps
-- deps
-- deps
-- capability doc tests
-- deps
-- deps, http 0.4.1, time 0.1.4
-- :ok(), clone() to Time cap, +tweaks
-- crux_core v0.4.0
-- added json() builder methods and fixed up examples
-- add builders for HttpRequest and HttpResponse
-- add response headers to http capability protocol
-- update deps, iOS and Android examples
-- deps
-- implement derive macro for Capability trait
-- into_effects(), effects() and effects_mut()
-- Update.effects as Iterator
-- update deps
-- v0.6.0
-- Merge branch 'master' into bincode
-- http_v0.3.1
-- v0.5.0
-- remove unneeded feature in crux_hhtp
-- docs and doctests
-- split out export derive macro
-- http typegen test WIP
-- deps
-- version bumps
-- Fix crux_http tests for the new API, amend HttpRequests in examples
-- update http with shell tests
-- Change Request from a tuple struct to a normal struct
-- Rename Step to Request, change crux_core module structure
-- Fix crux_http tests, extend testing support to work with steps
-- Change Step to be easier to consume in Rust shells
-- crux_http module update: added HTTPRequest body to protocol.rs
-- deps
-- Rename rustdoc::missing_doc_code_examples lint
-- deps
-- Add support for HTTP request headers
-- prep for 0.3 release
-- update deps
-- some typos
-- rename core fn names
-- deps
-- add MSRV
-- deps
-- Don't default to HTTP 1.1 in test responses
-- Attribute surf in the crux_http README
-- Remove crux_http::Http::send_
-- Remove crux_http::protocol::HttpMethod
-- Don't re-export the protocol types from crux_http.
-- Write a quick unit test of crux_http::Client
-- Remove crux_http::Config docstrings.
-- Update crux_http::Request docstrings
-- Update ResponseAsync doctests
-- Fix the Response doctests
-- Update the examples to use new HTTP capability
-- Fix some more doctests
-- Reinstate redirect middleware
-- Fix docstrings for crux_http::RequestBuilder
-- More doc tests
-- Start on fixing the documentation
-- Fix some CI problems
-- Clean up a ton of warnings
-- Merge remote-tracking branch 'origin/master' into steal-an-http-api
-- workspace deps
-- Add & use Capability::Operation associated type
-- move macros dep in caps to dev
-- simplify tests by naming better
-- ability to specify Event type name
-- update uniffi and other deps
-- Merge branch 'master' into counter-example
-- Merge branch 'master' into counter-example
-- Merge branch 'master' into testing-effects-with-async
-- example test for http cap using tester + clippy fixes
-- First pass of capability test helping funtimes
-- Merge remote-tracking branch 'origin/master' into graeme-just-going-all-in-on-async
-- remove Default bounds from App impl in tests
-- use macro in tests + capability fields can be private
-- and update tests
-- stronger typing inside http cap
-- extract kv cap and write test
-- extract http capability into own crate
+- Depends on a fork of `http_types` that will compile for the
+  `wasm32-unknown-emscripten` target.
 
 ## [0.5.0](https://github.com/redbadger/crux/compare/crux_http-v0.4.6...crux_http-v0.5.0) - 2024-01-30
 
 ### Fixed
+
 - fix doc test deps
 
 ### Other
+
 - remove http_types default features from crux_http
 - More human readable change logs
 
 ## [0.4.6](https://github.com/redbadger/crux/compare/crux_http-v0.4.5...crux_http-v0.4.6) - 2024-01-26
 
 ### Fixed
+
 - fix clippy lints
 
 ### Other
+
 - Add async API support
 
 ## [0.4.5](https://github.com/redbadger/crux/compare/crux_http-v0.4.4...crux_http-v0.4.5) - 2024-01-11
 
 ### Other
+
 - update deps for Rust, Web, iOS and Android
 
 ## [0.4.4](https://github.com/redbadger/crux/compare/crux_http-v0.4.3...crux_http-v0.4.4) - 2023-12-03
 
 ### Other
+
 - updated the following local packages: crux_core, crux_core
 
 ## [0.4.3](https://github.com/redbadger/crux/compare/crux_http-v0.4.2...crux_http-v0.4.3) - 2023-11-29
 
 ### Other
+
 - root deps
 
 ## [0.4.2](https://github.com/redbadger/crux/compare/crux_http-v0.4.1...crux_http-v0.4.2) - 2023-10-25
 
 ### Other
+
 - versions for compatibility with semver checks
 - update deps
 - deps + tweaks

--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -6,6 +6,121 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/redbadger/crux/compare/crux_http-v0.5.0...crux_http-v0.5.1) - 2024-02-02
+
+### Fixed
+- fix doc test deps
+- fix clippy lints
+- fix macro to trace Effect
+- fix features on http-types
+
+### Other
+- update `crux_time` to not use generic response type + overall deps
+- Merge branch 'master' into byo-serialization
+- Make rust fmt happy
+- Export crux_macros from crux_core and change docs
+- remove http_types default features from crux_http
+- More human readable change logs
+- release
+- Capabilities don't need to be clone
+- Clone less, to lead by example
+- Prefer IntoFuture as the main RequestBuilder async API
+- Doc comment
+- Remove irrelevant comment
+- Add async API to crux_http
+- update Rust deps
+- release
+- update deps for Rust, Web, iOS and Android
+- release
+- release
+- root deps
+- release
+- versions for compatibility with semver checks
+- update deps
+- deps + tweaks
+- deps
+- deps
+- deps
+- capability doc tests
+- deps
+- deps, http 0.4.1, time 0.1.4
+- :ok(), clone() to Time cap, +tweaks
+- crux_core v0.4.0
+- added json() builder methods and fixed up examples
+- add builders for HttpRequest and HttpResponse
+- add response headers to http capability protocol
+- update deps, iOS and Android examples
+- deps
+- implement derive macro for Capability trait
+- into_effects(), effects() and effects_mut()
+- Update.effects as Iterator
+- update deps
+- v0.6.0
+- Merge branch 'master' into bincode
+- http_v0.3.1
+- v0.5.0
+- remove unneeded feature in crux_hhtp
+- docs and doctests
+- split out export derive macro
+- http typegen test WIP
+- deps
+- version bumps
+- Fix crux_http tests for the new API, amend HttpRequests in examples
+- update http with shell tests
+- Change Request from a tuple struct to a normal struct
+- Rename Step to Request, change crux_core module structure
+- Fix crux_http tests, extend testing support to work with steps
+- Change Step to be easier to consume in Rust shells
+- crux_http module update: added HTTPRequest body to protocol.rs
+- deps
+- Rename rustdoc::missing_doc_code_examples lint
+- deps
+- Add support for HTTP request headers
+- prep for 0.3 release
+- update deps
+- some typos
+- rename core fn names
+- deps
+- add MSRV
+- deps
+- Don't default to HTTP 1.1 in test responses
+- Attribute surf in the crux_http README
+- Remove crux_http::Http::send_
+- Remove crux_http::protocol::HttpMethod
+- Don't re-export the protocol types from crux_http.
+- Write a quick unit test of crux_http::Client
+- Remove crux_http::Config docstrings.
+- Update crux_http::Request docstrings
+- Update ResponseAsync doctests
+- Fix the Response doctests
+- Update the examples to use new HTTP capability
+- Fix some more doctests
+- Reinstate redirect middleware
+- Fix docstrings for crux_http::RequestBuilder
+- More doc tests
+- Start on fixing the documentation
+- Fix some CI problems
+- Clean up a ton of warnings
+- Merge remote-tracking branch 'origin/master' into steal-an-http-api
+- workspace deps
+- Add & use Capability::Operation associated type
+- move macros dep in caps to dev
+- simplify tests by naming better
+- ability to specify Event type name
+- update uniffi and other deps
+- Merge branch 'master' into counter-example
+- Merge branch 'master' into counter-example
+- Merge branch 'master' into testing-effects-with-async
+- example test for http cap using tester + clippy fixes
+- First pass of capability test helping funtimes
+- Merge remote-tracking branch 'origin/master' into graeme-just-going-all-in-on-async
+- remove Default bounds from App impl in tests
+- use macro in tests + capability fields can be private
+- and update tests
+- stronger typing inside http cap
+- extract kv cap and write test
+- extract http capability into own crate
+
 ## [0.5.0](https://github.com/redbadger/crux/compare/crux_http-v0.4.6...crux_http-v0.5.0) - 2024-01-30
 
 ### Fixed

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_http"
 description = "HTTP capability for use with crux_core"
-version = "0.5.0"
+version = "0.5.1"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true

--- a/crux_kv/CHANGELOG.md
+++ b/crux_kv/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/redbadger/crux/compare/crux_kv-v0.1.8...crux_kv-v0.1.9) - 2024-02-02
+
+### Fixed
+- fix doc test deps
+
+### Other
+- Make rust fmt happy
+- Export crux_macros from crux_core and change docs
+- More human readable change logs
+
 ## [0.1.8](https://github.com/redbadger/crux/compare/crux_kv-v0.1.7...crux_kv-v0.1.8) - 2024-01-26
 
 ### Other

--- a/crux_kv/Cargo.toml
+++ b/crux_kv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_kv"
 description = "Key-Value capability for use with crux_core"
-version = "0.1.8"
+version = "0.1.9"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true

--- a/crux_macros/CHANGELOG.md
+++ b/crux_macros/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7](https://github.com/redbadger/crux/compare/crux_macros-v0.3.6...crux_macros-v0.3.7) - 2024-02-02
+
+### Fixed
+- fix doc test deps
+
+### Other
+- update `crux_time` to not use generic response type + overall deps
+- Export crux_macros from crux_core and change docs
+- Rename a bunch of things to better reflect how they work
+- fun with erased_serde
+- Better names, mod structure, and documentation with plentiful warnings
+- Merge serialization traits into one
+- Initial cut of allowing bridge to use different serialization
+
 ## [0.3.6](https://github.com/redbadger/crux/compare/crux_macros-v0.3.5...crux_macros-v0.3.6) - 2024-01-26
 
 ### Other

--- a/crux_macros/CHANGELOG.md
+++ b/crux_macros/CHANGELOG.md
@@ -1,47 +1,48 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ## [0.3.7](https://github.com/redbadger/crux/compare/crux_macros-v0.3.6...crux_macros-v0.3.7) - 2024-02-02
 
-### Fixed
-- fix doc test deps
+### Changed
 
-### Other
-- update `crux_time` to not use generic response type + overall deps
-- Export crux_macros from crux_core and change docs
-- Rename a bunch of things to better reflect how they work
-- fun with erased_serde
-- Better names, mod structure, and documentation with plentiful warnings
-- Merge serialization traits into one
-- Initial cut of allowing bridge to use different serialization
+- Only works with `crux_core` 0.7.3 or later.
+- You should now import the macros from `crux_core::macros` rather than from
+  this crate directly. This should avoid compatibility issues between the core
+  and the macros in the future.
 
 ## [0.3.6](https://github.com/redbadger/crux/compare/crux_macros-v0.3.5...crux_macros-v0.3.6) - 2024-01-26
 
 ### Other
+
 - darling default
 - unimplemented rather than todo
 - docs for effect macro
-- effect derive macro allows skipping  variants (e.g. for Never operations)
+- effect derive macro allows skipping variants (e.g. for Never operations)
 - update Rust deps
 
 ## [0.3.5](https://github.com/redbadger/crux/compare/crux_macros-v0.3.4...crux_macros-v0.3.5) - 2024-01-11
 
 ### Other
+
 - update deps for Rust, Web, iOS and Android
 
 ## [0.3.4](https://github.com/redbadger/crux/compare/crux_macros-v0.3.3...crux_macros-v0.3.4) - 2023-11-29
 
 ### Other
+
 - root deps
 
 ## [0.3.3](https://github.com/redbadger/crux/compare/crux_macros-v0.3.2...crux_macros-v0.3.3) - 2023-10-25
 
 ### Other
+
 - update deps
 - update leptos examples to remove Scope
 - deps + tweaks

--- a/crux_macros/Cargo.toml
+++ b/crux_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_macros"
 description = "Macros for use with crux_core"
-version = "0.3.6"
+version = "0.3.7"
 authors.workspace = true
 repository.workspace = true
 edition.workspace = true

--- a/crux_platform/CHANGELOG.md
+++ b/crux_platform/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/redbadger/crux/compare/crux_platform-v0.1.7...crux_platform-v0.1.8) - 2024-02-02
+
+### Fixed
+- fix doc test deps
+
+### Other
+- Export crux_macros from crux_core and change docs
+
 ## [0.1.7](https://github.com/redbadger/crux/compare/crux_platform-v0.1.6...crux_platform-v0.1.7) - 2024-01-11
 
 ### Other

--- a/crux_platform/Cargo.toml
+++ b/crux_platform/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_platform"
 description = "Platform capability for use with crux_core"
-version = "0.1.7"
+version = "0.1.8"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true

--- a/crux_time/CHANGELOG.md
+++ b/crux_time/CHANGELOG.md
@@ -1,17 +1,27 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.2.1](https://github.com/redbadger/crux/compare/crux_time-v0.2.0...crux_time-v0.2.1) - 2024-02-02
+## [0.3.0](https://github.com/redbadger/crux/compare/crux_time-v0.2.0...crux_time-v0.3.0) - 2024-02-02
+
+### Breaking change
+
+- Output type is now `TimeResponse(String)` (again) instead of
+  `TimeResponse(chrono::DateTime<Utc>)`, in order to avoid typegen problems
+  (lack of support for generic types).
 
 ### Fixed
+
 - fix doc test deps
 
 ### Other
+
 - TimeResponse(String) and fix up cat_facts examples
 - update `crux_time` to not use generic response type + overall deps
 - Export crux_macros from crux_core and change docs
@@ -20,28 +30,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.0](https://github.com/redbadger/crux/compare/crux_time-v0.1.8...crux_time-v0.2.0) - 2024-01-26
 
 ### Breaking change
+
 - Move to using `chrono::DateTime<Utc>` as representation
-- The main method is now called `now` instead of `get` and has a different return type
+- The main method is now called `now` instead of `get` and has a different
+  return type
 
 ### Other
+
 - Add async API to crux_time
 
 ## [0.1.8](https://github.com/redbadger/crux/compare/crux_time-v0.1.7...crux_time-v0.1.8) - 2024-01-11
 
 ### Other
+
 - update Cargo.toml dependencies
 
 ## [0.1.7](https://github.com/redbadger/crux/compare/crux_time-v0.1.6...crux_time-v0.1.7) - 2023-12-03
 
 ### Other
+
 - updated the following local packages: crux_core
 
 ## [0.1.6](https://github.com/redbadger/crux/compare/crux_time-v0.1.5...crux_time-v0.1.6) - 2023-11-29
 
 ### Other
+
 - update dependencies
 
 ## [0.1.5](https://github.com/redbadger/crux/compare/crux_time-v0.1.4...crux_time-v0.1.5) - 2023-10-25
 
 ### Other
+
 - versions for compatibility with semver checks

--- a/crux_time/CHANGELOG.md
+++ b/crux_time/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/redbadger/crux/compare/crux_time-v0.2.0...crux_time-v0.2.1) - 2024-02-02
+
+### Fixed
+- fix doc test deps
+
+### Other
+- TimeResponse(String) and fix up cat_facts examples
+- update `crux_time` to not use generic response type + overall deps
+- Export crux_macros from crux_core and change docs
+- More human readable change logs
+
 ## [0.2.0](https://github.com/redbadger/crux/compare/crux_time-v0.1.8...crux_time-v0.2.0) - 2024-01-26
 
 ### Breaking change

--- a/crux_time/Cargo.toml
+++ b/crux_time/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_time"
 description = "Time capability for use with crux_core"
-version = "0.2.0"
+version = "0.2.1"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true

--- a/crux_time/Cargo.toml
+++ b/crux_time/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_time"
 description = "Time capability for use with crux_core"
-version = "0.2.1"
+version = "0.3.0"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true

--- a/examples/cat_facts/Cargo.toml
+++ b/examples/cat_facts/Cargo.toml
@@ -12,12 +12,12 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 anyhow = "1.0.79"
-crux_core = { version = "0.7", path="../../crux_core" }
-crux_http = { version = "0.5", path="../../crux_http" }
-crux_kv = { version = "0.1", path="../../crux_kv" }
-crux_macros = { version = "0.3", path="../../crux_macros" }
-crux_platform = { version = "0.1", path="../../crux_platform" }
-crux_time = { version = "0.2", path="../../crux_time" }
+crux_core = { version = "0.7", path = "../../crux_core" }
+crux_http = { version = "0.5", path = "../../crux_http" }
+crux_kv = { version = "0.1", path = "../../crux_kv" }
+crux_macros = { version = "0.3", path = "../../crux_macros" }
+crux_platform = { version = "0.1", path = "../../crux_platform" }
+crux_time = { version = "0.3", path = "../../crux_time" }
 serde = "1.0.196"
 
 [workspace.metadata.bin]


### PR DESCRIPTION
## 🤖 New release
* `crux_core`: 0.7.2 -> 0.7.3 (✓ API compatible changes)
* `crux_macros`: 0.3.6 -> 0.3.7
* `crux_http`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `crux_time`: 0.2.0 -> 0.3.0 (API BREAKING CHANGE)
* `crux_kv`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `crux_platform`: 0.1.7 -> 0.1.8 (✓ API compatible changes)
