### PR TITLE
Better error handling for crux_http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
+ "thiserror",
  "url",
 ]
 

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -20,6 +20,7 @@ http-types = { package = "http-types-red-badger-temporary-fork", version = "2.12
 pin-project-lite = "0.2.13"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0.113"
+thiserror = "1.0.56"
 url = "2.5.0"
 
 [dev-dependencies]

--- a/crux_http/src/error.rs
+++ b/crux_http/src/error.rs
@@ -1,22 +1,26 @@
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub struct Error {
-    message: String,
-    code: Option<crate::http::StatusCode>,
+use serde::{Deserialize, Serialize};
+use thiserror::Error as ThisError;
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, ThisError, Debug)]
+pub enum Error {
+    #[error("HTTP error {0}")]
+    Http(HttpError),
+    #[error("JSON serialisation error: {0}")]
+    Json(String),
+    #[error("URL parse error: {0}")]
+    Url(String),
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(code) = self.code {
-            write!(f, "{}: {}", code, self.message)
-        } else {
-            write!(f, "{}", self.message)
-        }
-    }
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, ThisError)]
+#[error("{code}: {message}")]
+pub struct HttpError {
+    pub message: String,
+    pub code: crate::http::StatusCode,
 }
 
-impl Error {
-    pub fn new(code: Option<crate::http::StatusCode>, message: impl Into<String>) -> Self {
-        Error {
+impl HttpError {
+    pub fn new(code: crate::http::StatusCode, message: impl Into<String>) -> Self {
+        Self {
             message: message.into(),
             code,
         }
@@ -25,28 +29,22 @@ impl Error {
 
 impl From<crate::http::Error> for Error {
     fn from(e: crate::http::Error) -> Self {
-        Error {
+        Error::Http(HttpError {
             message: e.to_string(),
-            code: Some(e.status()),
-        }
+            code: e.status(),
+        })
     }
 }
 
 impl From<serde_json::Error> for Error {
     fn from(e: serde_json::Error) -> Self {
-        Error {
-            message: e.to_string(),
-            code: None,
-        }
+        Error::Json(e.to_string())
     }
 }
 
 impl From<url::ParseError> for Error {
     fn from(e: url::ParseError) -> Self {
-        Error {
-            message: e.to_string(),
-            code: None,
-        }
+        Error::Url(e.to_string())
     }
 }
 
@@ -56,10 +54,10 @@ mod tests {
 
     #[test]
     fn test_error_display() {
-        let error = Error::new(Some(crate::http::StatusCode::BadRequest), "Bad Request");
-        assert_eq!(error.to_string(), "400: Bad Request");
-
-        let error = Error::new(None, "internal server error");
-        assert_eq!(error.to_string(), "internal server error");
+        let error = Error::Http(HttpError::new(
+            crate::http::StatusCode::BadRequest,
+            "Bad Request",
+        ));
+        assert_eq!(error.to_string(), "HTTP error 400: Bad Request");
     }
 }

--- a/crux_http/src/error.rs
+++ b/crux_http/src/error.rs
@@ -16,13 +16,19 @@ pub enum Error {
 pub struct HttpError {
     pub message: String,
     pub code: crate::http::StatusCode,
+    pub body: Option<Vec<u8>>,
 }
 
 impl HttpError {
-    pub fn new(code: crate::http::StatusCode, message: impl Into<String>) -> Self {
+    pub fn new(
+        code: crate::http::StatusCode,
+        message: impl Into<String>,
+        body: Option<Vec<u8>>,
+    ) -> Self {
         Self {
             message: message.into(),
             code,
+            body,
         }
     }
 }
@@ -32,6 +38,7 @@ impl From<crate::http::Error> for Error {
         Error::Http(HttpError {
             message: e.to_string(),
             code: e.status(),
+            body: None,
         })
     }
 }
@@ -57,6 +64,7 @@ mod tests {
         let error = Error::Http(HttpError::new(
             crate::http::StatusCode::BadRequest,
             "Bad Request",
+            None,
         ));
         assert_eq!(error.to_string(), "HTTP error 400: Bad Request");
     }

--- a/crux_http/src/request_builder.rs
+++ b/crux_http/src/request_builder.rs
@@ -385,14 +385,8 @@ where
                 }
             };
 
-            // Note: doing an unwrap here, but since we're reading bytes from
-            // a prepopulated buffer there should be no way for this to fail
-            // currently.
-            let resp = Response::<Vec<u8>>::new(resp).await.unwrap();
-
-            // Turn the response into the final result
-            let resp = resp
-                .error_for_status()
+            let resp = Response::<Vec<u8>>::new(resp)
+                .await
                 .and_then(|r| self.expectation.decode(r));
 
             capability.context.update_app(make_event(resp));

--- a/crux_http/src/request_builder.rs
+++ b/crux_http/src/request_builder.rs
@@ -390,9 +390,12 @@ where
             // currently.
             let resp = Response::<Vec<u8>>::new(resp).await.unwrap();
 
-            capability
-                .context
-                .update_app(make_event(self.expectation.decode(resp)));
+            // Turn the response into the final result
+            let resp = resp
+                .error_for_status()
+                .and_then(|r| self.expectation.decode(r));
+
+            capability.context.update_app(make_event(resp));
         });
     }
 

--- a/crux_http/src/response/response.rs
+++ b/crux_http/src/response/response.rs
@@ -1,8 +1,11 @@
 use super::{decode::decode_body, new_headers};
-use crate::http::{
-    self,
-    headers::{self, HeaderName, HeaderValues, ToHeaderValues},
-    Mime, StatusCode, Version,
+use crate::{
+    error::HttpError,
+    http::{
+        self,
+        headers::{self, HeaderName, HeaderValues, ToHeaderValues},
+        Mime, StatusCode, Version,
+    },
 };
 
 use http::{headers::CONTENT_TYPE, Headers};
@@ -198,7 +201,7 @@ impl Response<Vec<u8>> {
     pub fn body_bytes(&mut self) -> crate::Result<Vec<u8>> {
         self.body
             .take()
-            .ok_or_else(|| crate::Error::new(Some(self.status()), "Body had no bytes"))
+            .ok_or_else(|| crate::Error::Http(HttpError::new(self.status(), "Body had no bytes")))
     }
 
     /// Reads the entire response body into a string.

--- a/crux_http/src/response/response.rs
+++ b/crux_http/src/response/response.rs
@@ -52,6 +52,19 @@ impl<Body> Response<Body> {
         self.status
     }
 
+    /// Consume the response and return a success if the status code is a 2xx, or 3xx,
+    /// and an error otherwise.
+    pub fn error_for_status(self) -> crate::Result<Response<Body>> {
+        if self.status.is_client_error() || self.status.is_server_error() {
+            return Err(crate::Error::Http(HttpError::new(
+                self.status,
+                self.status.to_string(),
+            )));
+        }
+
+        Ok(self)
+    }
+
     /// Get the HTTP protocol version.
     ///
     /// # Examples


### PR DESCRIPTION
This should allow apps to handle HTTP errors better and provide special error handling for bad requests, unauthorized requests and other common situations that can be handled gracefully.

There are two changes
* A nicer error type which is easier to work with
* When using the event returning API, response status in the 4xx and 5xx range is considered an `Err` not an `Ok`