### PR TITLE
crux_http: Allow non-HTTP errors to be represented by shell

### DIFF
--- a/crux_http/src/client.rs
+++ b/crux_http/src/client.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use crate::http::{Method, Url};
 use crate::middleware::{Middleware, Next};
-use crate::protocol::{EffectSender, ProtocolRequestBuilder};
+use crate::protocol::{EffectSender, HttpResult, ProtocolRequestBuilder};
 use crate::{Config, Request, RequestBuilder, ResponseAsync, Result};
 
 /// An HTTP client, capable of sending `Request`s
@@ -113,7 +113,10 @@ impl Client {
         let next = Next::new(&mw_stack, &|req, client| {
             Box::pin(async move {
                 let req = req.into_protocol_request().await.unwrap();
-                Ok(client.effect_sender.send(req).await.into())
+                match client.effect_sender.send(req).await {
+                    HttpResult::Ok(res) => Ok(res.into()),
+                    HttpResult::Err(e) => Err(e),
+                }
             })
         });
 

--- a/crux_http/src/error.rs
+++ b/crux_http/src/error.rs
@@ -9,6 +9,10 @@ pub enum Error {
     Json(String),
     #[error("URL parse error: {0}")]
     Url(String),
+    #[error("IO error: {0}")]
+    Io(String),
+    #[error("Timeout")]
+    Timeout,
 }
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, ThisError)]

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -117,13 +117,19 @@ impl HttpResponseBuilder {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub enum HttpResult {
+    Ok(HttpResponse),
+    Err(crate::Error),
+}
+
 impl crux_core::capability::Operation for HttpRequest {
-    type Output = HttpResponse;
+    type Output = HttpResult;
 }
 
 #[async_trait]
 pub(crate) trait EffectSender {
-    async fn send(&self, effect: HttpRequest) -> HttpResponse;
+    async fn send(&self, effect: HttpRequest) -> HttpResult;
 }
 
 #[async_trait]
@@ -131,7 +137,7 @@ impl<Ev> EffectSender for crux_core::capability::CapabilityContext<HttpRequest, 
 where
     Ev: 'static,
 {
-    async fn send(&self, effect: HttpRequest) -> HttpResponse {
+    async fn send(&self, effect: HttpRequest) -> HttpResult {
         crux_core::capability::CapabilityContext::request_from_shell(self, effect).await
     }
 }

--- a/crux_http/src/testing/fake_shell.rs
+++ b/crux_http/src/testing/fake_shell.rs
@@ -5,7 +5,7 @@ use std::{
 
 use async_trait::async_trait;
 
-use crate::protocol::{EffectSender, HttpRequest, HttpResponse};
+use crate::protocol::{EffectSender, HttpRequest, HttpResponse, HttpResult};
 
 /// FakeShell implements EffectSender for use in our internal tests.
 #[derive(Clone, Default)]
@@ -36,12 +36,15 @@ impl FakeShell {
 
 #[async_trait]
 impl EffectSender for FakeShell {
-    async fn send(&self, effect: HttpRequest) -> HttpResponse {
+    async fn send(&self, effect: HttpRequest) -> HttpResult {
         let mut inner = self.inner.lock().unwrap();
         inner.requests_received.push(effect);
-        inner
-            .responses_to_provide
-            .pop_back()
-            .expect("test tried to send an unexpected HttpRequest")
+
+        HttpResult::Ok(
+            inner
+                .responses_to_provide
+                .pop_back()
+                .expect("test tried to send an unexpected HttpRequest"),
+        )
     }
 }

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -85,7 +85,7 @@ mod shell {
     use super::shared::{App, Effect, Event};
     use anyhow::Result;
     use crux_core::Core;
-    use crux_http::protocol::{HttpRequest, HttpResponse};
+    use crux_http::protocol::{HttpRequest, HttpResponse, HttpResult};
     use std::collections::VecDeque;
 
     enum Task {
@@ -115,7 +115,10 @@ mod shell {
                         received.push(http_request.clone());
                         let response = HttpResponse::ok().json("Hello").build();
 
-                        enqueue_effects(&mut queue, core.resolve(&mut request, response));
+                        enqueue_effects(
+                            &mut queue,
+                            core.resolve(&mut request, HttpResult::Ok(response)),
+                        );
                     }
                 },
             };

--- a/crux_http/tests/with_tester.rs
+++ b/crux_http/tests/with_tester.rs
@@ -136,7 +136,7 @@ mod tests {
 
     use crate::shared::{App, Effect, Event, Model};
     use crux_core::testing::AppTester;
-    use crux_http::protocol::{HttpRequest, HttpResponse};
+    use crux_http::protocol::{HttpRequest, HttpResponse, HttpResult};
 
     #[test]
     fn get() {
@@ -158,11 +158,13 @@ mod tests {
         let update = app
             .resolve(
                 request,
-                HttpResponse::ok()
-                    .json("hello")
-                    .header("my_header", "my_value1")
-                    .header("my_header", "my_value2")
-                    .build(),
+                HttpResult::Ok(
+                    HttpResponse::ok()
+                        .json("hello")
+                        .header("my_header", "my_value1")
+                        .header("my_header", "my_value2")
+                        .build(),
+                ),
             )
             .expect("Resolves successfully");
 
@@ -199,7 +201,10 @@ mod tests {
         );
 
         let update = app
-            .resolve(request, HttpResponse::ok().json("The Body").build())
+            .resolve(
+                request,
+                HttpResult::Ok(HttpResponse::ok().json("The Body").build()),
+            )
             .expect("Resolves successfully");
 
         let actual = update.events;
@@ -224,7 +229,10 @@ mod tests {
         );
 
         let mut update = app
-            .resolve(request, HttpResponse::ok().body("secret_place").build())
+            .resolve(
+                request,
+                HttpResult::Ok(HttpResponse::ok().body("secret_place").build()),
+            )
             .expect("Resolves successfully");
 
         assert!(update.events.is_empty());
@@ -238,7 +246,7 @@ mod tests {
         );
 
         let update = app
-            .resolve(request, HttpResponse::status(201).build())
+            .resolve(request, HttpResult::Ok(HttpResponse::status(201).build()))
             .expect("Resolves successfully");
 
         let actual = update.events.clone();
@@ -273,7 +281,10 @@ mod tests {
 
         // Resolve second request first, should not matter
         let update = app
-            .resolve(request_two, HttpResponse::ok().body("one").build())
+            .resolve(
+                request_two,
+                HttpResult::Ok(HttpResponse::ok().body("one").build()),
+            )
             .expect("Resolves successfully");
 
         // Nothing happens yet
@@ -281,7 +292,10 @@ mod tests {
         assert!(update.events.is_empty());
 
         let update = app
-            .resolve(request_one, HttpResponse::ok().body("one").build())
+            .resolve(
+                request_one,
+                HttpResult::Ok(HttpResponse::ok().body("one").build()),
+            )
             .expect("Resolves successfully");
 
         let actual = update.events.clone();


### PR DESCRIPTION
Introduce `HttpResult` to the shell protocol, to allow the shell to signal an error other than a HTTP error - currently these are IO and Timeout (there may be more to come).