### PR TITLE
Release crux_http 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/redbadger/crux/compare/crux_http-v0.6.0...crux_http-v0.7.0) - 2024-02-21
+
+### Breaking changes
+- **The protocol between shell and core has changed. Core now expects a `HttpResult` rather than a `HttpResponse`**
+
 ## [0.6.0](https://github.com/redbadger/crux/compare/crux_http-v0.5.1...crux_http-v0.6.0) - 2024-02-06
 
 ### Breaking changes

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_http"
 description = "HTTP capability for use with crux_core"
-version = "0.6.0"
+version = "0.7.0"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
New version of crux_http

## Breaking changes

- **The protocol between shell and core has changed. Core now expects a `HttpResult` rather than a `HttpResponse`**, see #204 for details
