### PR TITLE
crux_http: Restrict exported error variants

### DIFF
--- a/crux_http/README.md
+++ b/crux_http/README.md
@@ -1,10 +1,24 @@
 # Crux HTTP capability
 
+[![Crate version](https://img.shields.io/crates/v/crux_http.svg)](https://crates.io/crates/crux_http)
+[![Docs](https://img.shields.io/badge/docs.rs-crux_http-green)](https://docs.rs/crux_http/)
+
 This crate contains the `Http` capability, which can be used to ask the Shell to make an HTTP request.
 
 For an example of how to use the capability, see the [integration test](./tests/with_shell.rs).
 
 The code for this was largely copied from [`surf`](https://github.com/http-rs/surf) with some modifications made to fit into the crux paradigm.
+
+## Getting Started
+
+Add `crux_http` as a dependency.
+
+Additionally, if using crux type generation, include this line in your shared
+types generation script (e.g. `shared_types/build.rs`):
+
+```rust
+gen.register_type::<HttpError>()?;
+```
 
 ## About Crux Capabilities
 

--- a/crux_http/src/lib.rs
+++ b/crux_http/src/lib.rs
@@ -26,7 +26,7 @@ pub use http_types::{self as http};
 
 pub use self::{
     config::Config,
-    error::Error,
+    error::HttpError,
     request::Request,
     request_builder::RequestBuilder,
     response::{Response, ResponseAsync},
@@ -34,7 +34,7 @@ pub use self::{
 
 use client::Client;
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = std::result::Result<T, HttpError>;
 
 /// The Http capability API.
 #[derive(Capability)]

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -120,7 +120,7 @@ impl HttpResponseBuilder {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum HttpResult {
     Ok(HttpResponse),
-    Err(crate::Error),
+    Err(crate::HttpError),
 }
 
 impl crux_core::capability::Operation for HttpRequest {

--- a/crux_http/src/request_builder.rs
+++ b/crux_http/src/request_builder.rs
@@ -7,7 +7,7 @@ use crate::{
         Body, Method, Mime, Url,
     },
 };
-use crate::{Client, Error, Request, Response, ResponseAsync, Result};
+use crate::{Client, HttpError, Request, Response, ResponseAsync, Result};
 
 use futures_util::future::BoxFuture;
 use http_types::convert::DeserializeOwned;
@@ -250,7 +250,7 @@ where
     ///     .send(Event::ReceiveResponse)
     /// # }
     /// ```
-    pub fn query(mut self, query: &impl Serialize) -> std::result::Result<Self, Error> {
+    pub fn query(mut self, query: &impl Serialize) -> std::result::Result<Self, HttpError> {
         self.req.as_mut().unwrap().set_query(query)?;
 
         Ok(self)

--- a/crux_http/src/response/response.rs
+++ b/crux_http/src/response/response.rs
@@ -1,6 +1,6 @@
 use super::{decode::decode_body, new_headers};
 use crate::{
-    error::HttpError,
+    error::HttpErrorHttp,
     http::{
         self,
         headers::{self, HeaderName, HeaderValues, ToHeaderValues},
@@ -31,7 +31,7 @@ impl<Body> Response<Body> {
         let status = res.status();
 
         if status.is_client_error() || status.is_server_error() {
-            return Err(crate::Error::Http(HttpError::new(
+            return Err(crate::HttpError::Http(HttpErrorHttp::new(
                 status,
                 status.to_string(),
                 Some(body),
@@ -209,7 +209,7 @@ impl Response<Vec<u8>> {
     /// ```
     pub fn body_bytes(&mut self) -> crate::Result<Vec<u8>> {
         self.body.take().ok_or_else(|| {
-            crate::Error::Http(HttpError::new(self.status(), "Body had no bytes", None))
+            crate::HttpError::Http(HttpErrorHttp::new(self.status(), "Body had no bytes", None))
         })
     }
 
@@ -287,7 +287,7 @@ impl Response<Vec<u8>> {
     /// ```
     pub fn body_json<T: DeserializeOwned>(&mut self) -> crate::Result<T> {
         let body_bytes = self.body_bytes()?;
-        serde_json::from_slice(&body_bytes).map_err(crate::Error::from)
+        serde_json::from_slice(&body_bytes).map_err(crate::HttpError::from)
     }
 }
 

--- a/crux_http/src/response/response_async.rs
+++ b/crux_http/src/response/response_async.rs
@@ -285,7 +285,7 @@ impl ResponseAsync {
     /// ```
     pub async fn body_json<T: DeserializeOwned>(&mut self) -> crate::Result<T> {
         let body_bytes = self.body_bytes().await?;
-        serde_json::from_slice(&body_bytes).map_err(crate::Error::from)
+        serde_json::from_slice(&body_bytes).map_err(crate::HttpError::from)
     }
 
     /// Reads and deserialized the entire request body from form encoding.

--- a/crux_http/tests/with_tester.rs
+++ b/crux_http/tests/with_tester.rs
@@ -325,7 +325,7 @@ mod tests {
         let update = app
             .resolve(
                 request,
-                HttpResult::Err(crux_http::Error::Io(
+                HttpResult::Err(crux_http::HttpError::Io(
                     "Socket shenanigans prevented the request".to_string(),
                 )),
             )
@@ -333,7 +333,7 @@ mod tests {
 
         let actual = update.events.clone();
 
-        let Event::Set(Err(crux_http::Error::Io(error))) = &actual[0] else {
+        let Event::Set(Err(crux_http::HttpError::Io(error))) = &actual[0] else {
             panic!("Expected original error back")
         };
 


### PR DESCRIPTION
This avoids a type generation problem due to custom deserializer on `http::StatusCode`. 

The change also makes semantic sense - the shell-side of the capability should not be generating HTTP errors and JSON errors anyway, as that is done by the core side of it.

Even with this change, the type tracing is no longer able to find all the relevant types, and an additional line is required in the `build.rs` file in `shared_types`:

```rust
gen.register_type::<HttpError>()?;
```
