### PR TITLE
Instant and Duration subscriptions for `crux_time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,9 +218,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -450,6 +450,7 @@ dependencies = [
  "chrono",
  "crux_core",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -1617,18 +1618,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,12 +120,12 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28243a43d821d11341ab73c80bed182dc015c514b951616cf79bd4af39af0c3"
+checksum = "136d4d23bcc79e27423727b36823d86233aad06dfea531837b038394d11e9928"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.2.0",
+ "event-listener 5.3.0",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -139,14 +139,14 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "bae"
@@ -200,15 +200,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -250,19 +250,19 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.0",
+ "strsim 0.11.1",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -279,9 +279,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "concurrent-queue"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -366,7 +366,7 @@ dependencies = [
  "anyhow",
  "assert_fs",
  "assert_matches",
- "async-channel 2.2.0",
+ "async-channel 2.2.1",
  "bincode",
  "crossbeam-channel",
  "crux_http",
@@ -430,7 +430,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -450,6 +450,7 @@ dependencies = [
  "chrono",
  "crux_core",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 
@@ -474,7 +475,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -485,7 +486,7 @@ checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -506,7 +507,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -516,7 +517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -591,9 +592,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5fb89194fa3cad959b833185b3063ba881dbfc7030680b314250779fb4cc91"
+checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -602,11 +603,11 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feedafcaa9b749175d5ac357452a9d41ea2911da598fde46ce1fe02c37751291"
+checksum = "332f51cb23d20b0de8458b86580878211da09bcd4503cb579c225b3d124cabb3"
 dependencies = [
- "event-listener 5.2.0",
+ "event-listener 5.3.0",
  "pin-project-lite",
 ]
 
@@ -711,7 +712,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -774,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -980,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -1044,7 +1045,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1058,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "num-traits"
@@ -1150,7 +1151,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1200,12 +1201,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.16"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
 dependencies = [
  "proc-macro2",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1240,18 +1241,18 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0530d13d87d1f549b66a3e8d0c688952abe5994e204ed62615baaf25dc029c"
+checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
 dependencies = [
  "bitflags",
  "memchr",
@@ -1261,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-escape"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d8f9aa0e3cbcfaf8bf00300004ee3b72f74770f9cbac93f6928771f613276b"
+checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
 
 [[package]]
 name = "quote"
@@ -1361,7 +1362,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
 ]
 
 [[package]]
@@ -1386,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rustc_version"
@@ -1401,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags",
  "errno",
@@ -1435,9 +1436,9 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
@@ -1469,20 +1470,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -1562,9 +1563,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -1579,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1633,7 +1634,7 @@ checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1674,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap",
  "serde",
@@ -1723,9 +1724,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "url"
@@ -1751,7 +1752,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom 0.2.14",
  "serde",
  "wasm-bindgen",
 ]
@@ -1811,7 +1812,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -1833,7 +1834,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1845,35 +1846,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1895,13 +1874,14 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -1910,51 +1890,57 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]

--- a/crux_time/Cargo.toml
+++ b/crux_time/Cargo.toml
@@ -14,5 +14,8 @@ rust-version.workspace = true
 anyhow.workspace = true
 crux_core = { version = "0.7", path = "../crux_core" }
 serde = { workspace = true, features = ["derive"] }
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = "0.4.38", features = ["serde"], optional = true }
 thiserror = "1.0.59"
+
+[dev-dependencies]
+serde_json = "1.0.116"

--- a/crux_time/Cargo.toml
+++ b/crux_time/Cargo.toml
@@ -14,4 +14,5 @@ rust-version.workspace = true
 anyhow.workspace = true
 crux_core = { version = "0.7", path = "../crux_core" }
 serde = { workspace = true, features = ["derive"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4.38", features = ["serde"] }
+thiserror = "1.0.59"

--- a/crux_time/src/duration.rs
+++ b/crux_time/src/duration.rs
@@ -20,7 +20,8 @@ impl Duration {
 
     /// Create a new `Duration` from the given number of seconds.
     ///
-    /// Returns `None` if the number of seconds would overflow when converted to nanoseconds.
+    /// Errors with [`TimeError::InvalidDuration`] if the number of seconds
+    /// would overflow when converted to nanoseconds.
     pub fn from_secs(seconds: u64) -> TimeResult<Self> {
         let nanos = seconds
             .checked_mul(NANOS_PER_SEC as u64)

--- a/crux_time/src/duration.rs
+++ b/crux_time/src/duration.rs
@@ -1,0 +1,73 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{error::TimeResult, TimeError};
+
+/// The number of nanoseconds in seconds.
+pub(crate) const NANOS_PER_SEC: u32 = 1_000_000_000;
+
+/// Represents a duration of time, internally stored as nanoseconds
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Duration {
+    nanos: u64,
+}
+
+impl Duration {
+    /// Create a new `Duration` from the given number of nanoseconds.
+    pub fn new(nanos: u64) -> Self {
+        Self { nanos }
+    }
+
+    /// Create a new `Duration` from the given number of seconds.
+    ///
+    /// Returns `None` if the number of seconds would overflow when converted to nanoseconds.
+    pub fn from_secs(seconds: u64) -> TimeResult<Self> {
+        let nanos = seconds
+            .checked_mul(NANOS_PER_SEC as u64)
+            .ok_or(TimeError::InvalidDuration)?;
+        Ok(Self { nanos })
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl TryFrom<chrono::TimeDelta> for Duration {
+    type Error = TimeError;
+
+    fn try_from(value: chrono::TimeDelta) -> Result<Self, Self::Error> {
+        let nanos = value.num_nanoseconds().ok_or(TimeError::InvalidDuration)? as u64;
+        Ok(Self { nanos })
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl TryFrom<Duration> for chrono::TimeDelta {
+    type Error = TimeError;
+
+    fn try_from(value: Duration) -> Result<Self, Self::Error> {
+        let nanos = value
+            .nanos
+            .try_into()
+            .map_err(|_| TimeError::InvalidDuration)?;
+        Ok(chrono::TimeDelta::nanoseconds(nanos))
+    }
+}
+
+#[cfg(feature = "chrono")]
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn duration_to_timedelta() {
+        let duration = Duration::new(1_000_000_000);
+        let chrono_duration: chrono::TimeDelta = duration.try_into().unwrap();
+        assert_eq!(chrono_duration.num_nanoseconds().unwrap(), 1_000_000_000);
+    }
+
+    #[test]
+    fn timedelta_to_duration() {
+        let chrono_duration = chrono::TimeDelta::nanoseconds(1_000_000_000);
+        let duration: Duration = chrono_duration.try_into().unwrap();
+        assert_eq!(duration.nanos, 1_000_000_000);
+    }
+}

--- a/crux_time/src/error.rs
+++ b/crux_time/src/error.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+pub type TimeResult<T> = Result<T, TimeError>;
+
+/// Error type for time operations
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Error)]
+#[serde(rename_all = "camelCase")]
+pub enum TimeError {
+    #[error("invalid time")]
+    InvalidTime,
+    #[error("invalid Duration")]
+    InvalidDuration,
+    #[error("invalid Instant")]
+    InvalidInstant,
+}

--- a/crux_time/src/instant.rs
+++ b/crux_time/src/instant.rs
@@ -13,6 +13,13 @@ pub struct Instant {
     pub nanos: u32,
 }
 
+/// Create a new `Instant` from the given number of seconds and nanoseconds.
+///
+/// - seconds: number of seconds since the Unix epoch (1970-01-01T00:00:00Z)
+/// - nanos: number of nanoseconds since the last second
+///
+/// Errors with [`TimeError::InvalidDuration`] if the number of seconds
+/// would overflow when converted to nanoseconds.
 impl Instant {
     pub fn new(seconds: u64, nanos: u32) -> TimeResult<Self> {
         if nanos >= NANOS_PER_SEC {

--- a/crux_time/src/instant.rs
+++ b/crux_time/src/instant.rs
@@ -54,6 +54,24 @@ impl TryFrom<chrono::DateTime<chrono::Utc>> for Instant {
     }
 }
 
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn new_instant() {
+        let instant = Instant::new(1_000_000_000, 10).unwrap();
+        assert_eq!(instant.seconds, 1_000_000_000);
+        assert_eq!(instant.nanos, 10);
+    }
+
+    #[test]
+    fn new_instant_invalid_nanos() {
+        let instant = Instant::new(1_000_000_000, 1_000_000_000);
+        assert_eq!(instant.unwrap_err(), TimeError::InvalidInstant);
+    }
+}
+
 #[cfg(feature = "chrono")]
 #[cfg(test)]
 mod chrono_test {

--- a/crux_time/src/instant.rs
+++ b/crux_time/src/instant.rs
@@ -1,0 +1,72 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{duration::NANOS_PER_SEC, error::TimeResult, TimeError};
+
+/// Represents a point in time (UTC):
+///
+/// - seconds: number of seconds since the Unix epoch (1970-01-01T00:00:00Z)
+/// - nanos: number of nanoseconds since the last second
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Instant {
+    pub seconds: u64,
+    pub nanos: u32,
+}
+
+impl Instant {
+    pub fn new(seconds: u64, nanos: u32) -> TimeResult<Self> {
+        if nanos >= NANOS_PER_SEC {
+            return Err(TimeError::InvalidInstant);
+        }
+        Ok(Self { seconds, nanos })
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl TryFrom<Instant> for chrono::DateTime<chrono::Utc> {
+    type Error = TimeError;
+
+    fn try_from(time: Instant) -> Result<Self, Self::Error> {
+        let seconds = i64::try_from(time.seconds).map_err(|_| TimeError::InvalidInstant)?;
+        chrono::DateTime::<chrono::Utc>::from_timestamp(seconds, time.nanos)
+            .ok_or(TimeError::InvalidInstant)
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl TryFrom<chrono::DateTime<chrono::Utc>> for Instant {
+    type Error = TimeError;
+
+    fn try_from(time: chrono::DateTime<chrono::Utc>) -> Result<Self, Self::Error> {
+        let seconds = time
+            .timestamp()
+            .try_into()
+            .map_err(|_| TimeError::InvalidTime)?;
+        let nanos = time.timestamp_subsec_nanos();
+        Ok(Instant { seconds, nanos })
+    }
+}
+
+#[cfg(feature = "chrono")]
+#[cfg(test)]
+mod chrono_test {
+    use chrono::{DateTime, TimeZone, Utc};
+
+    use super::*;
+
+    #[test]
+    fn instant_to_datetime_utc() {
+        let instant = Instant::new(1_000_000_000, 10).unwrap();
+        let chrono_time: DateTime<Utc> = instant.try_into().unwrap();
+        assert_eq!(chrono_time.timestamp(), 1_000_000_000);
+        assert_eq!(chrono_time.timestamp_subsec_nanos(), 10);
+    }
+
+    #[test]
+    fn datetime_utc_to_instant() {
+        let chrono_time: DateTime<Utc> = Utc.timestamp_opt(1_000_000_000, 10).unwrap();
+        let instant: Instant = chrono_time.try_into().unwrap();
+        assert_eq!(instant.seconds, 1_000_000_000);
+        assert_eq!(instant.nanos, 10);
+    }
+}

--- a/crux_time/src/lib.rs
+++ b/crux_time/src/lib.rs
@@ -5,24 +5,74 @@
 //! interface to do so.
 //!
 //! This is still work in progress and as such very basic.
+
 use chrono::{DateTime, Utc};
-use crux_core::capability::{CapabilityContext, Operation};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crux_core::capability::{CapabilityContext, Operation};
+
+/// Error type for time operations
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Error)]
+pub enum TimeError {
+    #[error("invalid time")]
+    InvalidTime,
+}
+
+/// Represents a point in time:
+///
+/// - seconds: number of seconds since the Unix epoch (1970-01-01T00:00:00Z)
+/// - sub_nanos: number of nanoseconds since the last second
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Instant {
+    pub seconds: u64,
+    pub sub_nanos: u32,
+}
+
+impl TryFrom<Instant> for DateTime<Utc> {
+    type Error = TimeError;
+
+    fn try_from(time: Instant) -> Result<Self, Self::Error> {
+        let seconds = i64::try_from(time.seconds).map_err(|_| TimeError::InvalidTime)?;
+        DateTime::<Utc>::from_timestamp(seconds, time.sub_nanos).ok_or(TimeError::InvalidTime)
+    }
+}
+
+impl TryFrom<DateTime<Utc>> for Instant {
+    type Error = TimeError;
+
+    fn try_from(time: DateTime<Utc>) -> Result<Self, Self::Error> {
+        let seconds = time.timestamp();
+        let sub_nanos = time.timestamp_subsec_nanos();
+        Ok(Instant {
+            seconds: seconds.try_into().map_err(|_| TimeError::InvalidTime)?,
+            sub_nanos,
+        })
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TimeRequest;
+pub enum TimeRequest {
+    Now,
+    SubscribeInstant(Instant),
+    SubscribeDuration(u64),
+}
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TimeResponse(pub String);
+pub enum TimeResponse {
+    Now(Instant),
+    InstantArrived,
+    DurationElapsed,
+}
 
 impl Operation for TimeRequest {
     type Output = TimeResponse;
 }
 
-/// The Time capability API. Uses the `chrono` crate's timezone aware representation
-/// of the current date and time.
+/// The Time capability API
 ///
-/// The time value serializes as an RFC3339 string across the FFI boundary.
+/// This capability provides access to the current time and allows the app to subscribe to
+/// notifications when a specific instant has arrived or a duration has elapsed.
 #[derive(crux_core::macros::Capability)]
 pub struct Time<Ev> {
     context: CapabilityContext<TimeRequest, Ev>,
@@ -44,33 +94,73 @@ where
         Self { context }
     }
 
-    /// Request current time, which will be passed to the app as `chrono::DateTime<Utc>`
+    /// Request current time, which will be passed to the app as a [`TimeResponse`] containing an [`Instant`]
     /// wrapped in the event produced by the `callback`.
     pub fn now<F>(&self, callback: F)
     where
-        F: Fn(DateTime<Utc>) -> Ev + Send + Sync + 'static,
+        F: Fn(TimeResponse) -> Ev + Send + Sync + 'static,
     {
         self.context.spawn({
             let context = self.context.clone();
             async move {
-                let response = context.request_from_shell(TimeRequest).await;
-                let response = response
-                    .0
-                    .parse::<DateTime<Utc>>()
-                    .expect("invalid time format");
-                context.update_app(callback(response));
+                context.update_app(callback(context.request_from_shell(TimeRequest::Now).await));
             }
         });
     }
 
-    /// Request current time, which will be returned as `chrono::DateTime<Utc>`.
+    /// Request current time, which will be passed to the app as a [`TimeResponse`] containing an [`Instant`]
     /// This is an async call to use with [`crux_core::compose::Compose`].
-    pub async fn now_async(&self) -> DateTime<Utc> {
+    pub async fn now_async(&self) -> TimeResponse {
+        self.context.request_from_shell(TimeRequest::Now).await
+    }
+
+    /// Subscribe to receive a notification when the specified [`Instant`] has arrived.
+    pub fn subscribe_instant<F>(&self, instant: Instant, callback: F)
+    where
+        F: Fn(TimeResponse) -> Ev + Send + Sync + 'static,
+    {
+        self.context.spawn({
+            let context = self.context.clone();
+            async move {
+                context.update_app(callback(
+                    context
+                        .request_from_shell(TimeRequest::SubscribeInstant(instant))
+                        .await,
+                ));
+            }
+        });
+    }
+
+    /// Subscribe to receive a notification when the specified [`Instant`] has arrived.
+    /// This is an async call to use with [`crux_core::compose::Compose`].
+    pub async fn subscribe_instant_async(&self, instant: Instant) -> TimeResponse {
         self.context
-            .request_from_shell(TimeRequest)
+            .request_from_shell(TimeRequest::SubscribeInstant(instant))
             .await
-            .0
-            .parse::<DateTime<Utc>>()
-            .expect("invalid time format")
+    }
+
+    /// Subscribe to receive a notification when the specified duration has elapsed.
+    pub fn subscribe_duration<F>(&self, duration: u64, callback: F)
+    where
+        F: Fn(TimeResponse) -> Ev + Send + Sync + 'static,
+    {
+        self.context.spawn({
+            let context = self.context.clone();
+            async move {
+                context.update_app(callback(
+                    context
+                        .request_from_shell(TimeRequest::SubscribeDuration(duration))
+                        .await,
+                ));
+            }
+        });
+    }
+
+    /// Subscribe to receive a notification when the specified duration has elapsed.
+    /// This is an async call to use with [`crux_core::compose::Compose`].
+    pub async fn subscribe_duration_async(&self, duration: u64) -> TimeResponse {
+        self.context
+            .request_from_shell(TimeRequest::SubscribeDuration(duration))
+            .await
     }
 }

--- a/crux_time/tests/time_test.rs
+++ b/crux_time/tests/time_test.rs
@@ -74,7 +74,7 @@ mod shared {
                     let pending = model.debounce.start();
 
                     caps.time.subscribe_duration(
-                        crux_time::Duration::from_secs(1).expect("valid duration"),
+                        crux_time::Duration::from_millis(300).expect("valid duration"),
                         event_with_user_info(pending, Event::DurationElapsed),
                     );
                 }

--- a/crux_time/tests/time_test.rs
+++ b/crux_time/tests/time_test.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "chrono")]
 mod shared {
     use chrono::{DateTime, Utc};
     use crux_core::macros::Effect;
@@ -25,7 +26,7 @@ mod shared {
 
     impl Debounce {
         fn start(&mut self) -> usize {
-            self.pending += 1;
+            self.pending = self.pending.wrapping_add(1);
             self.pending
         }
 
@@ -71,8 +72,9 @@ mod shared {
                 }
                 Event::StartDebounce => {
                     let pending = model.debounce.start();
+
                     caps.time.subscribe_duration(
-                        1_000_000_000, // nano seconds
+                        crux_time::Duration::from_secs(1).expect("valid duration"),
                         event_with_user_info(pending, Event::DurationElapsed),
                     );
                 }
@@ -113,6 +115,7 @@ mod shared {
     }
 }
 
+#[cfg(feature = "chrono")]
 mod shell {
     use super::shared::{App, Effect, Event};
     use chrono::{DateTime, Utc};
@@ -159,6 +162,7 @@ mod shell {
     }
 }
 
+#[cfg(feature = "chrono")]
 mod tests {
     use crate::{
         shared::{App, Effect, Event, Model},

--- a/crux_time/tests/time_test.rs
+++ b/crux_time/tests/time_test.rs
@@ -73,7 +73,7 @@ mod shared {
                 Event::StartDebounce => {
                     let pending = model.debounce.start();
 
-                    caps.time.subscribe_duration(
+                    caps.time.notify_after(
                         crux_time::Duration::from_millis(300).expect("valid duration"),
                         event_with_user_info(pending, Event::DurationElapsed),
                     );

--- a/crux_time/tests/time_test.rs
+++ b/crux_time/tests/time_test.rs
@@ -1,7 +1,8 @@
 mod shared {
+    use chrono::{DateTime, Utc};
     use crux_core::macros::Effect;
     use crux_core::render::Render;
-    use crux_time::Time;
+    use crux_time::{Time, TimeResponse};
     use serde::{Deserialize, Serialize};
 
     #[derive(Default)]
@@ -11,12 +12,33 @@ mod shared {
     pub enum Event {
         Get,
         GetAsync,
-        Set(chrono::DateTime<chrono::Utc>),
+        Set(TimeResponse),
+
+        StartDebounce,
+        DurationElapsed(usize, TimeResponse),
     }
 
-    #[derive(Default, Serialize, Deserialize)]
+    #[derive(Default)]
+    struct Debounce {
+        pending: usize,
+    }
+
+    impl Debounce {
+        fn start(&mut self) -> usize {
+            self.pending += 1;
+            self.pending
+        }
+
+        fn resolve(&mut self, pending: usize) -> bool {
+            self.pending == pending
+        }
+    }
+
+    #[derive(Default)]
     pub struct Model {
         pub time: String,
+        debounce: Debounce,
+        pub debounce_complete: bool,
     }
 
     #[derive(Serialize, Deserialize, Default)]
@@ -41,8 +63,26 @@ mod shared {
                     }
                 }),
                 Event::Set(time) => {
-                    model.time = time.to_rfc3339();
-                    caps.render.render()
+                    if let TimeResponse::Now(time) = time {
+                        let time: DateTime<Utc> = time.try_into().unwrap();
+                        model.time = time.to_rfc3339();
+                        caps.render.render()
+                    }
+                }
+                Event::StartDebounce => {
+                    let pending = model.debounce.start();
+                    caps.time.subscribe_duration(
+                        1_000_000_000, // nano seconds
+                        event_with_user_info(pending, Event::DurationElapsed),
+                    );
+                }
+                Event::DurationElapsed(pending, TimeResponse::DurationElapsed) => {
+                    if model.debounce.resolve(pending) {
+                        model.debounce_complete = true;
+                    }
+                }
+                Event::DurationElapsed(_, _) => {
+                    panic!("Unexpected debounce event")
                 }
             }
         }
@@ -61,16 +101,27 @@ mod shared {
         #[effect(skip)]
         pub compose: crux_core::compose::Compose<Event>,
     }
+
+    /// Helper to create an event with additional user info captured
+    /// this is effectively partially applying the event constructor
+    pub fn event_with_user_info<E, F, U, T>(user_info: U, make_event: F) -> impl Fn(T) -> E
+    where
+        F: Fn(U, T) -> E,
+        U: Clone,
+    {
+        move |response| make_event(user_info.clone(), response)
+    }
 }
 
 mod shell {
     use super::shared::{App, Effect, Event};
+    use chrono::{DateTime, Utc};
     use crux_core::{Core, Request};
-    use crux_time::{TimeRequest, TimeResponse};
+    use crux_time::{Instant, TimeRequest, TimeResponse};
     use std::collections::VecDeque;
 
     pub enum Outcome {
-        Time(Request<TimeRequest>, String),
+        Time(Request<TimeRequest>, Instant),
     }
 
     enum CoreMessage {
@@ -89,16 +140,18 @@ mod shell {
             let effs = match msg {
                 Some(CoreMessage::Event(m)) => core.process_event(m),
                 Some(CoreMessage::Response(Outcome::Time(mut request, result))) => {
-                    core.resolve(&mut request, TimeResponse(result))
+                    core.resolve(&mut request, TimeResponse::Now(result))
                 }
                 _ => vec![],
             };
 
             for effect in effs {
                 if let Effect::Time(request) = effect {
+                    let time: DateTime<Utc> =
+                        "2022-12-01T01:47:12.746202562+00:00".parse().unwrap();
                     queue.push_back(CoreMessage::Response(Outcome::Time(
                         request,
-                        "2022-12-01T01:47:12.746202562+00:00".to_string(),
+                        time.try_into().unwrap(),
                     )));
                 }
             }
@@ -111,6 +164,7 @@ mod tests {
         shared::{App, Effect, Event, Model},
         shell::run,
     };
+    use chrono::{DateTime, Utc};
     use crux_core::{testing::AppTester, Core};
     use crux_time::TimeResponse;
 
@@ -135,13 +189,58 @@ mod tests {
             panic!("Expected Time effect");
         };
 
-        let now = "2022-12-01T01:47:12.746202562+00:00".to_string();
-        let response = TimeResponse(now);
+        let now: DateTime<Utc> = "2022-12-01T01:47:12.746202562+00:00".parse().unwrap();
+        let response = TimeResponse::Now(now.try_into().unwrap());
         let update = app.resolve(&mut request, response).unwrap();
 
         let event = update.events.into_iter().next().unwrap();
         app.update(event, &mut model);
 
         assert_eq!(app.view(&model).time, "2022-12-01T01:47:12.746202562+00:00");
+    }
+
+    #[test]
+    pub fn test_debounce_timer() {
+        let app = AppTester::<App, _>::default();
+        let mut model = Model::default();
+
+        let update1 = app.update(Event::StartDebounce, &mut model);
+        let update2 = app.update(Event::StartDebounce, &mut model);
+
+        let Effect::Time(mut request1) = update1.into_effects().next().unwrap() else {
+            panic!("Expected Time effect");
+        };
+
+        // resolve and run loop
+        app.update(
+            app.resolve(&mut request1, TimeResponse::DurationElapsed)
+                .unwrap()
+                .events
+                .into_iter()
+                .next()
+                .unwrap(),
+            &mut model,
+        );
+
+        // resolving the first debounce should not set the debounce_complete flag
+        assert!(!model.debounce_complete);
+
+        let Effect::Time(mut request2) = update2.into_effects().next().unwrap() else {
+            panic!("Expected Time effect");
+        };
+
+        // resolve and run loop
+        app.update(
+            app.resolve(&mut request2, TimeResponse::DurationElapsed)
+                .unwrap()
+                .events
+                .into_iter()
+                .next()
+                .unwrap(),
+            &mut model,
+        );
+
+        // resolving the second debounce should set the debounce_complete flag
+        assert!(model.debounce_complete);
     }
 }


### PR DESCRIPTION
Updates `crux_time` capability to be more closely aligned with [`wasi-clocks`](https://github.com/WebAssembly/wasi-clocks/).

- [x] update `now` to return an `Instant`, which represents a UTC point in time (number of seconds since the epoch and number of nanoseconds since the last second).
- [x] add `subscribe_duration` and its async counterpart. The shell side of the capability responds when the requested duration has elapsed.
- [x] add `subscribe_instant` and its async counterpart. The shell side of the capability responds when the requested instant has arrived.
- [x] Add a test that demonstrates a debounce based on `subscribe_duration`