### PR TITLE
Simplify app-facing API of crux_kv

### DIFF
--- a/examples/cat_facts/Cargo.lock
+++ b/examples/cat_facts/Cargo.lock
@@ -431,8 +431,6 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 [[package]]
 name = "crux_core"
 version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db554a7b76b00437e79f4a732db8d096bb3d1bb85f6543f2d52e2dbe752b9df"
 dependencies = [
  "anyhow",
  "bincode",
@@ -453,8 +451,6 @@ dependencies = [
 [[package]]
 name = "crux_http"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a4dbfdbff69fe1e76d5667514afb52fab334878f8727f5790133490d1911e6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -472,8 +468,6 @@ dependencies = [
 [[package]]
 name = "crux_kv"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe6ac4054e5732860616d6b6c1b5baf6851357f16045c24a2b1e9f4f916b71a"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -484,8 +478,6 @@ dependencies = [
 [[package]]
 name = "crux_macros"
 version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cbfd17dc6f5f03e077b76a554a451ec432614933057fd8687a3bf9f8c9b527"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -497,8 +489,6 @@ dependencies = [
 [[package]]
 name = "crux_platform"
 version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c27e8f0931f2c4eddce533a94c9114565c24a4f06d8d30ffad9901d5b21246f"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -508,8 +498,6 @@ dependencies = [
 [[package]]
 name = "crux_time"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeeb184c3a04ab47a079910a63cd26cdbf121bfc656e94f193f6309ac958f424"
 dependencies = [
  "anyhow",
  "chrono",

--- a/examples/cat_facts/Cargo.toml
+++ b/examples/cat_facts/Cargo.toml
@@ -12,16 +12,16 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 anyhow = "1.0.83"
-crux_core = "0.7"
-crux_http = "0.9"
-crux_kv = "0.2"
-crux_platform = "0.1"
-crux_time = { version = "0.4", features = ["chrono"] }
-# crux_core = { path = "../../crux_core" }
-# crux_http = { path = "../../crux_http" }
-# crux_kv = { path = "../../crux_kv" }
-# crux_platform = { path = "../../crux_platform" }
-# crux_time = { path = "../../crux_time", features = ["chrono"] }
+# crux_core = "0.7"
+# crux_http = "0.9"
+# crux_kv = "0.2"
+# crux_platform = "0.1"
+# crux_time = { version = "0.4", features = ["chrono"] }
+crux_core = { path = "../../crux_core" }
+crux_http = { path = "../../crux_http" }
+crux_kv = { path = "../../crux_kv" }
+crux_platform = { path = "../../crux_platform" }
+crux_time = { path = "../../crux_time", features = ["chrono"] }
 serde = "1.0.201"
 
 [workspace.metadata.bin]

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 pub use crux_core::App;
 use crux_core::{render::Render, Capability};
 use crux_http::Http;
-use crux_kv::{KeyValue, KeyValueResponse, KeyValueResult};
+use crux_kv::{error::KeyValueError, KeyValue};
 use crux_platform::Platform;
 use crux_time::{Time, TimeResponse};
 
@@ -71,7 +71,7 @@ pub enum Event {
     #[serde(skip)]
     Platform(platform::Event),
     #[serde(skip)]
-    SetState(KeyValueResult), // receive the data to restore state with
+    SetState(Result<Vec<u8>, KeyValueError>), // receive the data to restore state with
     #[serde(skip)]
     CurrentTime(TimeResponse),
     #[serde(skip)]
@@ -180,15 +180,13 @@ impl App for CatFacts {
             Event::Restore => {
                 caps.key_value.get(KEY.to_string(), Event::SetState);
             }
-            Event::SetState(KeyValueResult::Ok { response }) => {
-                if let KeyValueResponse::Get { value } = response {
-                    if let Ok(m) = serde_json::from_slice::<Model>(&value) {
-                        *model = m;
-                        caps.render.render();
-                    };
+            Event::SetState(Ok(value)) => {
+                if let Ok(m) = serde_json::from_slice::<Model>(&value) {
+                    *model = m;
+                    caps.render.render();
                 };
             }
-            Event::SetState(KeyValueResult::Err { .. }) => {
+            Event::SetState(Err(_)) => {
                 // handle error
             }
             Event::None => {}

--- a/examples/notes/Cargo.lock
+++ b/examples/notes/Cargo.lock
@@ -307,8 +307,6 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 [[package]]
 name = "crux_core"
 version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db554a7b76b00437e79f4a732db8d096bb3d1bb85f6543f2d52e2dbe752b9df"
 dependencies = [
  "anyhow",
  "bincode",
@@ -329,8 +327,6 @@ dependencies = [
 [[package]]
 name = "crux_kv"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe6ac4054e5732860616d6b6c1b5baf6851357f16045c24a2b1e9f4f916b71a"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -341,8 +337,6 @@ dependencies = [
 [[package]]
 name = "crux_macros"
 version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cbfd17dc6f5f03e077b76a554a451ec432614933057fd8687a3bf9f8c9b527"
 dependencies = [
  "darling",
  "proc-macro-error",

--- a/examples/notes/Cargo.toml
+++ b/examples/notes/Cargo.toml
@@ -12,8 +12,10 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 anyhow = "1.0"
-crux_core = "0.7"
-crux_kv = "0.2"
+# crux_core = "0.7"
+# crux_kv = "0.2"
+crux_core = { path = "../../crux_core" }
+crux_kv = { path = "../../crux_kv" }
 serde = "1.0"
 
 [workspace.metadata.bin]

--- a/examples/notes/shared/src/app.rs
+++ b/examples/notes/shared/src/app.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 
 use automerge::Change;
 use crux_core::{render::Render, App};
-use crux_kv::{KeyValue, KeyValueResult};
+use crux_kv::{error::KeyValueError, KeyValue};
 use serde::{Deserialize, Serialize};
 
 use crate::capabilities::{
@@ -21,6 +21,7 @@ pub struct NoteEditor;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Event {
+    // events from the shell
     Open,
     Insert(String),
     Replace(usize, usize, String),
@@ -30,8 +31,12 @@ pub enum Event {
     Delete,
     ReceiveChanges(Vec<u8>),
     EditTimer(TimerOutput),
-    Written(KeyValueResult),
-    Load(KeyValueResult),
+
+    // events local to the core
+    #[serde(skip)]
+    Written(Result<Vec<u8>, KeyValueError>),
+    #[serde(skip)]
+    Load(Result<Vec<u8>, KeyValueError>),
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -221,21 +226,19 @@ impl App for NoteEditor {
                 // FIXME assuming successful write
             }
             Event::Open => caps.key_value.get("note".to_string(), Event::Load),
-            Event::Load(KeyValueResult::Ok { response }) => {
-                if let crux_kv::KeyValueResponse::Get { value } = response {
-                    if value.is_empty() {
-                        model.note = Note::new();
+            Event::Load(Ok(value)) => {
+                if value.is_empty() {
+                    model.note = Note::new();
 
-                        caps.key_value
-                            .set("note".to_string(), model.note.save(), Event::Written);
-                    } else {
-                        model.note = Note::load(&value);
-                    }
-                    caps.pub_sub.subscribe(Event::ReceiveChanges);
-                    caps.render.render();
-                };
+                    caps.key_value
+                        .set("note".to_string(), model.note.save(), Event::Written);
+                } else {
+                    model.note = Note::load(&value);
+                }
+                caps.pub_sub.subscribe(Event::ReceiveChanges);
+                caps.render.render();
             }
-            Event::Load(KeyValueResult::Err { .. }) => {
+            Event::Load(Err(_)) => {
                 // FIXME handle error
             }
         }
@@ -537,7 +540,7 @@ mod editing_tests {
 mod save_load_tests {
     use assert_let_bind::assert_let;
     use crux_core::{assert_effect, testing::AppTester};
-    use crux_kv::{KeyValueOperation, KeyValueResponse};
+    use crux_kv::{KeyValueOperation, KeyValueResponse, KeyValueResult};
 
     use crate::capabilities::timer::{TimerOperation, TimerOutput};
 
@@ -759,7 +762,6 @@ mod sync_tests {
     use std::collections::VecDeque;
 
     use crux_core::{testing::AppTester, Request};
-    use crux_kv::KeyValueResponse;
 
     use crate::capabilities::pub_sub::{Message, PubSubOperation};
 
@@ -847,14 +849,8 @@ mod sync_tests {
         let mut alice = Peer::new();
         let mut bob = Peer::new();
 
-        alice.update(Event::Load(KeyValueResult::Ok {
-            response: KeyValueResponse::Get {
-                value: note.clone(),
-            },
-        }));
-        bob.update(Event::Load(KeyValueResult::Ok {
-            response: KeyValueResponse::Get { value: note },
-        }));
+        alice.update(Event::Load(Ok(note.clone())));
+        bob.update(Event::Load(Ok(note)));
 
         (alice, bob)
     }


### PR DESCRIPTION
This should make crux_kv a bit more idiomatic to use from inside the core. It no longer forces the user to deal with receiving a response to the wrong operation (which shouldn't happen anyway so is largely just boilerplate), and also works on standard `Results` rather than the FFI protocol result.

I've only changed the capability and its tests, haven't done examples in case people are violently opposed to this 🙂 