### PR TITLE
`crux_kv` capability list keys

### DIFF
--- a/crux_kv/src/error.rs
+++ b/crux_kv/src/error.rs
@@ -9,6 +9,8 @@ pub enum KeyValueError {
     Io { message: String },
     #[error("timeout")]
     Timeout,
+    #[error("cursor not found")]
+    CursorNotFound,
     #[error("other error: {message}")]
     Other { message: String },
 }

--- a/crux_kv/src/lib.rs
+++ b/crux_kv/src/lib.rs
@@ -21,6 +21,13 @@ pub enum KeyValueOperation {
     Delete { key: String },
     /// Test if a key exists
     Exists { key: String },
+    // List keys that start with a prefix, starting at the cursor
+    ListKeys {
+        /// The prefix to list keys for, or an empty string to list all keys
+        prefix: String,
+        /// The cursor to start listing from, or 0 to start from the beginning
+        cursor: u64,
+    },
 }
 
 /// The result of an operation on the store.
@@ -47,6 +54,12 @@ pub enum KeyValueResponse {
     /// Response to a `KeyValueOperation::Exists`,
     /// returning whether the key is present in the store
     Exists { is_present: bool },
+    /// Response to a `KeyValueOperation::ListKeys`,
+    /// returning a list of keys that start with the prefix, and a cursor to continue listing
+    /// if there are more keys
+    ///
+    /// Note: the cursor is 0 if there are no more keys
+    ListKeys { keys: Vec<String>, cursor: u64 },
 }
 
 impl Operation for KeyValueOperation {
@@ -75,7 +88,7 @@ where
     }
 
     /// Read a value under `key`, will dispatch the event with a
-    /// `KeyValueOutput::Get(KeyValueResult<Option<Vec<u8>>>)` as payload
+    /// `KeyValueResult::Get { value: Vec<u8> }` as payload
     pub fn get<F>(&self, key: String, make_event: F)
     where
         F: FnOnce(Result<Vec<u8>, KeyValueError>) -> Ev + Send + Sync + 'static,
@@ -103,7 +116,7 @@ where
     /// Set `key` to be the provided `value`. Typically the bytes would be
     /// a value serialized/deserialized by the app.
     ///
-    /// Will dispatch the event with a `KeyValueOutput::Set { result: KeyValueResult<()> }` as payload
+    /// Will dispatch the event with a `KeyValueResult::Set { previous: Vec<u8> }` as payload
     pub fn set<F>(&self, key: String, value: Vec<u8>, make_event: F)
     where
         F: FnOnce(Result<Vec<u8>, KeyValueError>) -> Ev + Send + Sync + 'static,
@@ -129,7 +142,7 @@ where
     }
 
     /// Remove a `key` and its value, will dispatch the event with a
-    /// `KeyValueOutput::Delete(KeyValueResult<()>)` as payload
+    /// `KeyValueResult::Delete { previous: Vec<u8> }` as payload
     pub fn delete<F>(&self, key: String, make_event: F)
     where
         F: Fn(Result<Vec<u8>, KeyValueError>) -> Ev + Send + Sync + 'static,
@@ -153,7 +166,7 @@ where
     }
 
     /// Check to see if a `key` exists, will dispatch the event with a
-    /// `KeyValueOutput::Exists(KeyValueResult<bool>)` as payload
+    /// `KeyValueResult::Exists { is_present: bool }` as payload
     pub fn exists<F>(&self, key: String, make_event: F)
     where
         F: Fn(Result<bool, KeyValueError>) -> Ev + Send + Sync + 'static,
@@ -174,6 +187,35 @@ where
             .request_from_shell(KeyValueOperation::Exists { key })
             .await
             .unwrap_exists()
+    }
+
+    /// List keys that start with the provided `prefix`, starting from the provided `cursor`.
+    /// Will dispatch the event with a `KeyValueResult::ListKeys { keys: Vec<String>, cursor: u64 }`
+    /// as payload.
+    pub fn list_keys<F>(&self, prefix: String, cursor: u64, make_event: F)
+    where
+        F: Fn(Result<(Vec<String>, u64), KeyValueError>) -> Ev + Send + Sync + 'static,
+    {
+        let context = self.context.clone();
+        let this = self.clone();
+
+        self.context.spawn(async move {
+            let response = this.list_keys_async(prefix, cursor).await;
+            context.update_app(make_event(response))
+        });
+    }
+
+    /// List keys that start with the provided `prefix`, starting from the provided `cursor`,
+    /// while in an async context. This is used together with [`crux_core::compose::Compose`].
+    pub async fn list_keys_async(
+        &self,
+        prefix: String,
+        cursor: u64,
+    ) -> Result<(Vec<String>, u64), KeyValueError> {
+        self.context
+            .request_from_shell(KeyValueOperation::ListKeys { prefix, cursor })
+            .await
+            .unwrap_list_keys()
     }
 }
 
@@ -213,6 +255,18 @@ impl KeyValueResult {
             KeyValueResult::Ok { response } => match response {
                 KeyValueResponse::Exists { is_present } => Ok(is_present),
                 _ => panic!("attempt to convert KeyValueResponse other than Exists to bool"),
+            },
+            KeyValueResult::Err { error } => Err(error.clone()),
+        }
+    }
+
+    fn unwrap_list_keys(self) -> Result<(Vec<String>, u64), KeyValueError> {
+        match self {
+            KeyValueResult::Ok { response } => match response {
+                KeyValueResponse::ListKeys { keys, cursor } => Ok((keys, cursor)),
+                _ => panic!(
+                    "attempt to convert KeyValueResponse other than ListKeys to (Vec<String>, u64)"
+                ),
             },
             KeyValueResult::Err { error } => Err(error.clone()),
         }

--- a/crux_kv/src/tests.rs
+++ b/crux_kv/src/tests.rs
@@ -285,7 +285,7 @@ fn test_list_keys() {
             KeyValueResult::Ok {
                 response: KeyValueResponse::ListKeys {
                     keys: vec!["test:1".to_string(), "test:2".to_string()],
-                    cursor: 2,
+                    next_cursor: 2,
                 },
             },
         )

--- a/crux_kv/src/tests.rs
+++ b/crux_kv/src/tests.rs
@@ -13,16 +13,20 @@ pub enum Event {
     Set,
     Delete,
     Exists,
+    ListKeys,
     GetThenSet,
 
-    ReadResponse(Result<Vec<u8>, KeyValueError>),
-    WriteResponse(Result<Vec<u8>, KeyValueError>),
-    ExistResponse(Result<bool, KeyValueError>),
+    GetResponse(Result<Vec<u8>, KeyValueError>),
+    SetResponse(Result<Vec<u8>, KeyValueError>),
+    ExistsResponse(Result<bool, KeyValueError>),
+    ListKeysResponse(Result<(Vec<String>, u64), KeyValueError>),
 }
 
 #[derive(Debug, Default)]
 pub struct Model {
     pub value: i32,
+    pub keys: Vec<String>,
+    pub cursor: u64,
     pub successful: bool,
 }
 
@@ -41,13 +45,17 @@ impl crux_core::App for App {
     fn update(&self, event: Event, model: &mut Model, caps: &Capabilities) {
         let key = "test".to_string();
         match event {
-            Event::Get => caps.key_value.get(key, Event::ReadResponse),
+            Event::Get => caps.key_value.get(key, Event::GetResponse),
             Event::Set => {
                 caps.key_value
-                    .set(key, 42i32.to_ne_bytes().to_vec(), Event::WriteResponse);
+                    .set(key, 42i32.to_ne_bytes().to_vec(), Event::SetResponse);
             }
-            Event::Delete => caps.key_value.delete(key, Event::WriteResponse),
-            Event::Exists => caps.key_value.exists(key, Event::ExistResponse),
+            Event::Delete => caps.key_value.delete(key, Event::SetResponse),
+            Event::Exists => caps.key_value.exists(key, Event::ExistsResponse),
+            Event::ListKeys => {
+                caps.key_value
+                    .list_keys("test:".to_string(), 0, Event::ListKeysResponse)
+            }
 
             Event::GetThenSet => caps.compose.spawn(|ctx| {
                 let kv = caps.key_value.clone();
@@ -62,33 +70,42 @@ impl crux_core::App for App {
                         .set_async("test_num".to_string(), (num + 1).to_ne_bytes().to_vec())
                         .await;
 
-                    ctx.update_app(Event::WriteResponse(result))
+                    ctx.update_app(Event::SetResponse(result))
                 }
             }),
 
-            Event::ReadResponse(Ok(value)) => {
+            Event::GetResponse(Ok(value)) => {
                 let (int_bytes, _rest) = value.split_at(std::mem::size_of::<i32>());
                 model.value = i32::from_ne_bytes(int_bytes.try_into().unwrap());
             }
 
-            Event::WriteResponse(Ok(_response)) => {
+            Event::SetResponse(Ok(_response)) => {
                 model.successful = true;
                 caps.render.render()
             }
 
-            Event::ExistResponse(Ok(_response)) => {
+            Event::ExistsResponse(Ok(_response)) => {
                 model.successful = true;
                 caps.render.render()
             }
 
-            Event::ExistResponse(Err(error)) => {
+            Event::ListKeysResponse(Ok((keys, cursor))) => {
+                model.keys = keys;
+                model.cursor = cursor;
+                caps.render.render()
+            }
+
+            Event::GetResponse(Err(error)) => {
+                panic!("error: {:?}", error);
+            }
+            Event::SetResponse(Err(error)) => {
+                panic!("error: {:?}", error);
+            }
+            Event::ExistsResponse(Err(error)) => {
                 panic!("Error: {:?}", error);
             }
-            Event::ReadResponse(Err(error)) => {
-                panic!("error: {:?}", error);
-            }
-            Event::WriteResponse(Err(error)) => {
-                panic!("error: {:?}", error);
+            Event::ListKeysResponse(Err(error)) => {
+                panic!("Error: {:?}", error);
             }
         }
     }
@@ -241,6 +258,44 @@ fn test_exists() {
     app.update(event, &mut model);
 
     assert!(model.successful);
+}
+
+#[test]
+fn test_list_keys() {
+    let app = AppTester::<App, _>::default();
+    let mut model = Model::default();
+
+    let updated = app.update(Event::ListKeys, &mut model);
+
+    let effect = updated.into_effects().next().unwrap();
+    let Effect::KeyValue(mut request) = effect else {
+        panic!("Expected KeyValue effect");
+    };
+
+    let KeyValueOperation::ListKeys { prefix, cursor } = request.operation.clone() else {
+        panic!("Expected list keys operation");
+    };
+
+    assert_eq!(prefix, "test:");
+    assert_eq!(cursor, 0);
+
+    let updated = app
+        .resolve(
+            &mut request,
+            KeyValueResult::Ok {
+                response: KeyValueResponse::ListKeys {
+                    keys: vec!["test:1".to_string(), "test:2".to_string()],
+                    cursor: 2,
+                },
+            },
+        )
+        .unwrap();
+
+    let event = updated.events.into_iter().next().unwrap();
+    app.update(event, &mut model);
+
+    assert_eq!(model.keys, vec!["test:1".to_string(), "test:2".to_string()]);
+    assert_eq!(model.cursor, 2);
 }
 
 #[test]

--- a/examples/cat_facts/cli/src/core.rs
+++ b/examples/cat_facts/cli/src/core.rs
@@ -112,6 +112,10 @@ pub fn process_effect(core: &Core, effect: Effect, tx: &Arc<Sender<Effect>>) -> 
             }
             KeyValueOperation::Delete { key: _ } => unimplemented!("delete"),
             KeyValueOperation::Exists { key: _ } => unimplemented!("exists"),
+            KeyValueOperation::ListKeys {
+                prefix: _,
+                cursor: _,
+            } => unimplemented!("list_keys"),
         },
 
         Effect::Platform(mut request) => {


### PR DESCRIPTION
Adds ability to list the keys in the store, providing a prefix (which can be an empty string), and a cursor for pagination (can be 0 to start from the beginning).