### PR TITLE
update API for crux_kv

### DIFF
--- a/crux_kv/README.md
+++ b/crux_kv/README.md
@@ -2,7 +2,7 @@
 
 This crate contains the `KeyValue` capability, which can be used to ask the Shell to read from, and write to, a key-value store.
 
-Currently it provides an interface for getting, setting, and deleting keys, and checking if keys exists in the store.
+Currently it provides an interface for getting, setting, and deleting keys, checking if keys exists in the store, and listing keys that start with a prefix.
 
 ## About Crux Capabilities
 

--- a/crux_kv/src/value.rs
+++ b/crux_kv/src/value.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+/// The value stored under a key.
+///
+/// `Value::None` is used to represent the absence of a value.
+///
+/// Note: we can't use `Option` here because generics are not currently
+/// supported across the FFI boundary, when using the builtin typegen.
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
+pub enum Value {
+    None,
+    Bytes(Vec<u8>),
+}
+
+impl From<Vec<u8>> for Value {
+    fn from(bytes: Vec<u8>) -> Self {
+        Value::Bytes(bytes)
+    }
+}
+
+impl From<Value> for Option<Vec<u8>> {
+    fn from(value: Value) -> Option<Vec<u8>> {
+        match value {
+            Value::None => None,
+            Value::Bytes(bytes) => Some(bytes),
+        }
+    }
+}
+
+impl From<Option<Vec<u8>>> for Value {
+    fn from(val: Option<Vec<u8>>) -> Self {
+        match val {
+            None => Value::None,
+            Some(bytes) => Value::Bytes(bytes),
+        }
+    }
+}

--- a/examples/cat_facts/Cargo.lock
+++ b/examples/cat_facts/Cargo.lock
@@ -392,12 +392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,13 +424,12 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crux_core"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "bincode",
  "crossbeam-channel",
  "crux_macros",
- "derive_more",
  "erased-serde",
  "futures",
  "serde",
@@ -445,7 +438,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "uuid",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -467,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "crux_kv"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -488,18 +480,16 @@ dependencies = [
 
 [[package]]
 name = "crux_platform"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
- "anyhow",
  "crux_core",
  "serde",
 ]
 
 [[package]]
 name = "crux_time"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
- "anyhow",
  "chrono",
  "crux_core",
  "serde",
@@ -570,19 +560,6 @@ checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core",
  "syn 2.0.63",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2093,15 +2070,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustix"

--- a/examples/cat_facts/cli/src/core.rs
+++ b/examples/cat_facts/cli/src/core.rs
@@ -10,7 +10,9 @@ use tokio::{
 use tracing::debug;
 
 use shared::{
-    key_value::{error::KeyValueError, KeyValueOperation, KeyValueResponse, KeyValueResult},
+    key_value::{
+        error::KeyValueError, value::Value, KeyValueOperation, KeyValueResponse, KeyValueResult,
+    },
     platform::PlatformResponse,
     time::{Instant, TimeResponse},
     CatFactCapabilities, CatFacts, Effect, Event,
@@ -67,7 +69,9 @@ pub fn process_effect(core: &Core, effect: Effect, tx: &Arc<Sender<Effect>>) -> 
                     async move {
                         let response = match read_state(&key).await {
                             Ok(value) => KeyValueResult::Ok {
-                                response: KeyValueResponse::Get { value },
+                                response: KeyValueResponse::Get {
+                                    value: value.into(),
+                                },
                             },
                             Err(err) => KeyValueResult::Err {
                                 error: KeyValueError::Io {
@@ -94,7 +98,9 @@ pub fn process_effect(core: &Core, effect: Effect, tx: &Arc<Sender<Effect>>) -> 
                     async move {
                         let response = match write_state(&key, &value).await {
                             Ok(()) => KeyValueResult::Ok {
-                                response: KeyValueResponse::Set { previous: vec![] },
+                                response: KeyValueResponse::Set {
+                                    previous: Value::None,
+                                },
                             },
                             Err(err) => KeyValueResult::Err {
                                 error: KeyValueError::Io {

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -71,7 +71,7 @@ pub enum Event {
     #[serde(skip)]
     Platform(platform::Event),
     #[serde(skip)]
-    SetState(Result<Vec<u8>, KeyValueError>), // receive the data to restore state with
+    SetState(Result<Option<Vec<u8>>, KeyValueError>), // receive the data to restore state with
     #[serde(skip)]
     CurrentTime(TimeResponse),
     #[serde(skip)]
@@ -180,11 +180,14 @@ impl App for CatFacts {
             Event::Restore => {
                 caps.key_value.get(KEY.to_string(), Event::SetState);
             }
-            Event::SetState(Ok(value)) => {
+            Event::SetState(Ok(Some(value))) => {
                 if let Ok(m) = serde_json::from_slice::<Model>(&value) {
                     *model = m;
                     caps.render.render();
                 };
+            }
+            Event::SetState(Ok(None)) => {
+                // no state to restore
             }
             Event::SetState(Err(_)) => {
                 // handle error

--- a/examples/cat_facts/shared_types/build.rs
+++ b/examples/cat_facts/shared_types/build.rs
@@ -4,7 +4,7 @@ use crux_core::typegen::TypeGen;
 
 use shared::{
     http::HttpError,
-    key_value::{error::KeyValueError, KeyValueResponse},
+    key_value::{error::KeyValueError, value::Value, KeyValueResponse},
     CatFacts,
 };
 
@@ -15,9 +15,13 @@ fn main() -> anyhow::Result<()> {
 
     gen.register_app::<CatFacts>()?;
 
+    // types from `crux_http` that aren't automatically discovered
     gen.register_type::<HttpError>()?;
+
+    // types from `crux_kv` that aren't automatically discovered
     gen.register_type::<KeyValueResponse>()?;
     gen.register_type::<KeyValueError>()?;
+    gen.register_type::<Value>()?;
 
     let output_root = PathBuf::from("./generated");
 

--- a/examples/notes/Cargo.lock
+++ b/examples/notes/Cargo.lock
@@ -266,12 +266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,13 +300,12 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crux_core"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "bincode",
  "crossbeam-channel",
  "crux_macros",
- "derive_more",
  "erased-serde",
  "futures",
  "serde",
@@ -321,12 +314,11 @@ dependencies = [
  "serde_json",
  "thiserror",
  "uuid",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "crux_kv"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -388,19 +380,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.63",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -911,15 +890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
 ]
 
 [[package]]

--- a/examples/notes/shared_types/build.rs
+++ b/examples/notes/shared_types/build.rs
@@ -1,5 +1,5 @@
 use crux_core::typegen::TypeGen;
-use crux_kv::{error::KeyValueError, KeyValueResponse};
+use crux_kv::{error::KeyValueError, value::Value, KeyValueResponse};
 use shared::{NoteEditor, TextCursor};
 use std::path::PathBuf;
 
@@ -15,6 +15,7 @@ fn main() -> anyhow::Result<()> {
     gen.register_type::<TextCursor>()?;
     gen.register_type::<KeyValueResponse>()?;
     gen.register_type::<KeyValueError>()?;
+    gen.register_type::<Value>()?;
 
     let output_root = PathBuf::from("./generated");
 

--- a/examples/notes/web-nextjs/src/app/core.ts
+++ b/examples/notes/web-nextjs/src/app/core.ts
@@ -28,6 +28,8 @@ import {
   KeyValueResultVariantOk,
   KeyValueResponseVariantGet,
   KeyValueResponseVariantSet,
+  ValueVariantNone,
+  ValueVariantBytes,
 } from "shared_types/types/shared_types";
 import {
   BincodeSerializer,
@@ -157,14 +159,19 @@ export class Core {
           case KeyValueOperationVariantGet: {
             const { key: readKey } = request as KeyValueOperationVariantGet;
 
-            let data = window.localStorage.getItem(readKey);
-            let bytes: number[] | null = data == null ? data : JSON.parse(data);
+            const data = window.localStorage.getItem(readKey);
+            const bytes: number[] | null =
+              data == null ? data : JSON.parse(data);
+            const value =
+              bytes == null
+                ? new ValueVariantNone()
+                : new ValueVariantBytes(bytes);
 
             console.log(`Loaded document (${bytes?.length || 0} bytes)`);
             this.respond(
               uuid,
               new KeyValueResultVariantOk(
-                new KeyValueResponseVariantGet(bytes || []),
+                new KeyValueResponseVariantGet(value),
               ),
             );
 
@@ -181,7 +188,9 @@ export class Core {
 
             this.respond(
               uuid,
-              new KeyValueResultVariantOk(new KeyValueResponseVariantSet([])),
+              new KeyValueResultVariantOk(
+                new KeyValueResponseVariantSet(new ValueVariantNone()),
+              ),
             );
 
             break;


### PR DESCRIPTION
Introduces a `Value` enum, which is essentially a monnomorphised `Option<Vec<u8>>` to represent responses where the key does not exist (`get()`), or there was no previous value (`delete()` or `set()`). This type needs to exist as we can't (currently) get `Option<T>` over the FFI boundary. Note:  for now, `build.rs` for shared types libraries need to register this `Value` type explicitly as `serde_reflection` won't see it.