### PR TITLE
Simplify construction of capabilities, so they don't require the app type

### DIFF
--- a/crux_core/src/capability/mod.rs
+++ b/crux_core/src/capability/mod.rs
@@ -343,7 +343,7 @@ pub trait Capability<Ev> {
 /// #         }
 /// #     }
 /// # }
-/// impl crux_core::WithContext<App, Effect> for Capabilities {
+/// impl crux_core::WithContext<Event, Effect> for Capabilities {
 ///     fn new_with_context(
 ///         context: crux_core::capability::ProtoContext<Effect, Event>,
 ///     ) -> Capabilities {
@@ -354,11 +354,8 @@ pub trait Capability<Ev> {
 ///     }
 /// }
 /// ```
-pub trait WithContext<App, Ef>
-where
-    App: crate::App,
-{
-    fn new_with_context(context: ProtoContext<Ef, App::Event>) -> App::Capabilities;
+pub trait WithContext<Ev, Ef> {
+    fn new_with_context(context: ProtoContext<Ef, Ev>) -> Self;
 }
 
 /// An interface for capabilities to interact with the app and the shell.

--- a/crux_core/src/capability/mod.rs
+++ b/crux_core/src/capability/mod.rs
@@ -71,7 +71,6 @@
 //!     // Shell to dispatch side-effect requests to the right capability implementation
 //!     // (and, in some languages, checking that all necessary capabilities are implemented)
 //!     #[derive(Effect)]
-//!     #[effect(app = "MyApp")]
 //!     pub struct Capabilities {
 //!         pub render: Render<Event>
 //!     }

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -47,9 +47,9 @@ where
     /// let core: Core<HelloEffect, Hello> = Core::new::<HelloCapabilities>();
     /// ```
     ///
-    pub fn new<Capabilities>() -> Self
+    pub fn new() -> Self
     where
-        Capabilities: WithContext<A, Ef>,
+        A::Capabilities: WithContext<A::Event, Ef>,
     {
         let (request_sender, request_receiver) = capability::channel();
         let (event_sender, event_receiver) = capability::channel();
@@ -60,7 +60,7 @@ where
             model: Default::default(),
             executor,
             app: Default::default(),
-            capabilities: Capabilities::new_with_context(capability_context),
+            capabilities: <<A as App>::Capabilities>::new_with_context(capability_context),
             requests: request_receiver,
             capability_events: event_receiver,
         }
@@ -128,9 +128,9 @@ impl<Ef, A> Default for Core<Ef, A>
 where
     Ef: Effect,
     A: App,
-    A::Capabilities: WithContext<A, Ef>,
+    A::Capabilities: WithContext<A::Event, Ef>,
 {
     fn default() -> Self {
-        Self::new::<A::Capabilities>()
+        Self::new()
     }
 }

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -44,7 +44,7 @@ where
     /// Create an instance of the Crux core to start a Crux application, e.g.
     ///
     /// ```rust,ignore
-    /// let core: Core<HelloEffect, Hello> = Core::new::<HelloCapabilities>();
+    /// let core: Core<HelloEffect, Hello> = Core::new();
     /// ```
     ///
     pub fn new() -> Self

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -61,7 +61,6 @@
 //!// will use to request side effects from the Shell
 //!#[cfg_attr(feature = "typegen", derive(crux_core::macros::Export))]
 //!#[derive(Effect)]
-//!#[effect(app = "Hello")]
 //!pub struct Capabilities {
 //!    pub render: Render<Event>,
 //!}

--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -72,7 +72,7 @@ where
 impl<App, Ef> Default for AppTester<App, Ef>
 where
     App: crate::App,
-    App::Capabilities: WithContext<App, Ef>,
+    App::Capabilities: WithContext<App::Event, Ef>,
     App::Event: Send,
     Ef: Send + 'static,
 {

--- a/crux_core/tests/capability_runtime.rs
+++ b/crux_core/tests/capability_runtime.rs
@@ -129,11 +129,11 @@ mod tests {
     use crux_core::Core;
     use rand::prelude::*;
 
-    use super::app::{Capabilities, Effect, Event, MyApp};
+    use super::app::{Effect, Event, MyApp};
 
     #[test]
     fn fetches_a_tree() {
-        let core: Core<Effect, MyApp> = Core::new::<Capabilities>();
+        let core: Core<Effect, MyApp> = Core::new();
 
         let mut effects: VecDeque<Effect> = core.process_event(Event::Fetch).into();
 

--- a/crux_core/tests/capability_runtime.rs
+++ b/crux_core/tests/capability_runtime.rs
@@ -92,7 +92,6 @@ mod app {
     }
 
     #[derive(Effect)]
-    #[effect(app = "MyApp")]
     pub struct Capabilities {
         crawler: super::capability::Crawler<Event>,
         render: crux_core::render::Render<Event>,

--- a/crux_macros/README.md
+++ b/crux_macros/README.md
@@ -56,7 +56,6 @@ than `App`, you can specify its name:
 
 ```rust
 #[derive(Effect)]
-#[effect(app = "MyApp")]
 pub struct Capabilities {
     pub render: Render<Event>,
 }
@@ -68,7 +67,6 @@ this:
 ```rust
 #[derive(Effect)]
 #[effect(name = "MyEffect")]
-#[effect(app = "MyApp")]
 pub struct Capabilities {
     pub render: Render<Event>,
 }
@@ -78,7 +76,7 @@ Or, more idiomatically, combine them into one usage, like this:
 
 ```rust
 #[derive(Effect)]
-#[effect(name = "MyEffect", app = "MyApp")]
+#[effect(name = "MyEffect")]
 pub struct Capabilities {
     pub render: Render<Event>,
 }
@@ -88,7 +86,7 @@ Full usage might look something like this:
 
 ```rust
 #[derive(Effect)]
-#[effect(name = "MyEffect", app = "MyApp")]
+#[effect(name = "MyEffect")]
 pub struct CatFactCapabilities {
     pub http: Http<MyEvent>,
     pub key_value: KeyValue<MyEvent>,

--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -56,14 +56,6 @@ impl ToTokens for EffectStructReceiver {
             None => (quote!(Effect), quote!(EffectFfi), quote!("Effect")),
         };
 
-        let app = match self.app {
-            Some(ref app) => quote!(#app),
-            None => {
-                let x = Type::from_string("App").unwrap();
-                quote!(#x)
-            }
-        };
-
         let fields = self
             .data
             .as_ref()
@@ -166,7 +158,7 @@ impl ToTokens for EffectStructReceiver {
                 }
             }
 
-            impl ::crux_core::WithContext<#app, #effect_name> for #ident {
+            impl ::crux_core::WithContext<#event, #effect_name> for #ident {
                 fn new_with_context(context: ::crux_core::capability::ProtoContext<#effect_name, #event>) -> #ident {
                     #ident {
                         #(#with_context_fields ,)*
@@ -262,7 +254,7 @@ mod tests {
                 }
             }
         }
-        impl ::crux_core::WithContext<App, Effect> for Capabilities {
+        impl ::crux_core::WithContext<Event, Effect> for Capabilities {
             fn new_with_context(
                 context: ::crux_core::capability::ProtoContext<Effect, Event>,
             ) -> Capabilities {
@@ -325,7 +317,7 @@ mod tests {
                 }
             }
         }
-        impl ::crux_core::WithContext<App, Effect> for Capabilities {
+        impl ::crux_core::WithContext<Event, Effect> for Capabilities {
             fn new_with_context(
                 context: ::crux_core::capability::ProtoContext<Effect, Event>,
             ) -> Capabilities {
@@ -441,7 +433,7 @@ mod tests {
                 }
             }
         }
-        impl ::crux_core::WithContext<MyApp, MyEffect> for MyCapabilities {
+        impl ::crux_core::WithContext<MyEvent, MyEffect> for MyCapabilities {
             fn new_with_context(
                 context: ::crux_core::capability::ProtoContext<MyEffect, MyEvent>,
             ) -> MyCapabilities {

--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -1,4 +1,4 @@
-use darling::{ast, util, FromDeriveInput, FromField, FromMeta, ToTokens};
+use darling::{ast, util, FromDeriveInput, FromField, ToTokens};
 use proc_macro2::{Literal, TokenStream};
 use proc_macro_error::{abort_call_site, OptionExt};
 use quote::{format_ident, quote};
@@ -10,7 +10,6 @@ use syn::{DeriveInput, GenericArgument, Ident, PathArguments, Type};
 struct EffectStructReceiver {
     ident: Ident,
     name: Option<Ident>,
-    app: Option<Type>,
     data: ast::Data<util::Ignored, EffectFieldReceiver>,
 }
 
@@ -355,7 +354,7 @@ mod tests {
     fn full() {
         let input = r#"
             #[derive(Effect)]
-            #[effect(name = "MyEffect", app = "MyApp")]
+            #[effect(name = "MyEffect")]
             pub struct MyCapabilities {
                 pub http: crux_http::Http<MyEvent>,
                 pub key_value: KeyValue<MyEvent>,

--- a/crux_macros/src/export.rs
+++ b/crux_macros/src/export.rs
@@ -9,8 +9,6 @@ use syn::{DeriveInput, GenericArgument, Ident, PathArguments, Type};
 struct ExportStructReceiver {
     ident: Ident,
     name: Option<Ident>, // also used by the effect derive macro to name the effect
-    #[allow(dead_code)] // `app` is used by the effect derive macro only
-    app: Option<Type>,
     data: ast::Data<util::Ignored, ExportFieldReceiver>,
 }
 

--- a/crux_macros/src/lib.rs
+++ b/crux_macros/src/lib.rs
@@ -46,7 +46,7 @@ use syn::parse_macro_input;
 /// #     }
 /// # }
 /// #[derive(Effect)]
-/// #[effect(name = "MyEffect", app = "MyApp")]
+/// #[effect(name = "MyEffect")]
 /// pub struct MyCapabilities {
 ///     pub http: crux_http::Http<MyEvent>,
 ///     pub render: Render<MyEvent>,

--- a/docs/src/getting_started/core.md
+++ b/docs/src/getting_started/core.md
@@ -235,12 +235,12 @@ pub struct Capabilities {
 }
 ```
 
-The `Export` and `Effect` derive macros can be configured with the `effect` attribute if you need to specify the name of the effect type, and/or the name of your `App` e.g.:
+The `Export` and `Effect` derive macros can be configured with the `effect` attribute if you need to specify a different name for the Effect type e.g.:
 
 ```rust,ignore
 #[cfg_attr(feature = "typegen", derive(Export))]
 #[derive(Effect)]
-#[effect(name = "MyEffect", app = "MyApp")]
+#[effect(name = "MyEffect")]
 pub struct Capabilities {
     render: Render<Event>,
     pub_sub: PubSub<Event>,

--- a/docs/src/guide/hello_world.md
+++ b/docs/src/guide/hello_world.md
@@ -94,7 +94,6 @@ use crux_core::render::Render;
 use crux_core::macros::Effect;
 
 #[derive(Effect)]
-#[effect(app = "Hello")]
 pub struct Capabilities {
     render: Render<Event>,
 }
@@ -118,7 +117,6 @@ use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "typegen", derive(crux_core::macros::Export))]
 #[derive(Effect)]
-#[effect(app = "Hello")]
 pub struct Capabilities {
     render: Render<Event>,
 }

--- a/docs/src/guide/testing.md
+++ b/docs/src/guide/testing.md
@@ -213,7 +213,6 @@ our `Capabilities` struct looked like this...
 
 #[cfg_attr(feature = "typegen", derive(crux_core::macros::Export))]
 #[derive(Effect)]
-#[effect(app = "NoteEditor")]
 pub struct Capabilities {
     timer: Timer<Event>,
     render: Render<Event>,

--- a/examples/bridge_echo/cli/src/core.rs
+++ b/examples/bridge_echo/cli/src/core.rs
@@ -3,12 +3,12 @@ use crossbeam_channel::Sender;
 use std::sync::Arc;
 use tracing::debug;
 
-use shared::{App, Capabilities, Effect, Event};
+use shared::{App, Effect, Event};
 
 pub type Core = Arc<shared::Core<Effect, App>>;
 
 pub fn new() -> Core {
-    Arc::new(shared::Core::new::<Capabilities>())
+    Arc::new(shared::Core::new())
 }
 
 pub fn update(core: &Core, event: Event, tx: &Arc<Sender<Effect>>) -> Result<()> {

--- a/examples/bridge_echo/shared/src/lib.rs
+++ b/examples/bridge_echo/shared/src/lib.rs
@@ -12,7 +12,7 @@ pub use app::*;
 uniffi::include_scaffolding!("shared");
 
 lazy_static! {
-    static ref CORE: Bridge<Effect, App> = Bridge::new(Core::new::<Capabilities>());
+    static ref CORE: Bridge<Effect, App> = Bridge::new(Core::new());
 }
 
 #[wasm_bindgen]

--- a/examples/bridge_echo/web-leptos/src/core.rs
+++ b/examples/bridge_echo/web-leptos/src/core.rs
@@ -1,12 +1,12 @@
 use std::rc::Rc;
 
 use leptos::{SignalUpdate, WriteSignal};
-use shared::{App, Capabilities, Effect, Event, ViewModel};
+use shared::{App, Effect, Event, ViewModel};
 
 pub type Core = Rc<shared::Core<Effect, App>>;
 
 pub fn new() -> Core {
-    Rc::new(shared::Core::new::<Capabilities>())
+    Rc::new(shared::Core::new())
 }
 
 pub fn update(core: &Core, event: Event, render: WriteSignal<ViewModel>) {

--- a/examples/cat_facts/cli/src/core.rs
+++ b/examples/cat_facts/cli/src/core.rs
@@ -15,7 +15,7 @@ use shared::{
     },
     platform::PlatformResponse,
     time::{Instant, TimeResponse},
-    CatFactCapabilities, CatFacts, Effect, Event,
+    CatFacts, Effect, Event,
 };
 
 use crate::http;
@@ -23,7 +23,7 @@ use crate::http;
 pub type Core = Arc<shared::Core<Effect, CatFacts>>;
 
 pub fn new() -> Core {
-    Arc::new(shared::Core::new::<CatFactCapabilities>())
+    Arc::new(shared::Core::new())
 }
 
 pub fn update(core: &Core, event: Event, tx: &Arc<Sender<Effect>>) -> Result<()> {

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -87,7 +87,6 @@ pub struct CatFacts {
 
 #[cfg_attr(feature = "typegen", derive(crux_core::macros::Export))]
 #[derive(crux_core::macros::Effect)]
-#[effect(app = "CatFacts")]
 pub struct CatFactCapabilities {
     pub http: Http<Event>,
     pub key_value: KeyValue<Event>,

--- a/examples/cat_facts/shared/src/lib.rs
+++ b/examples/cat_facts/shared/src/lib.rs
@@ -17,7 +17,7 @@ pub use app::*;
 uniffi::include_scaffolding!("shared");
 
 lazy_static! {
-    static ref CORE: Bridge<Effect, CatFacts> = Bridge::new(Core::new::<CatFactCapabilities>());
+    static ref CORE: Bridge<Effect, CatFacts> = Bridge::new(Core::new());
 }
 
 #[wasm_bindgen]

--- a/examples/cat_facts/web-yew/src/core.rs
+++ b/examples/cat_facts/web-yew/src/core.rs
@@ -2,7 +2,7 @@ use gloo_console::log;
 use shared::{
     platform::PlatformResponse,
     time::{Instant, TimeResponse},
-    CatFactCapabilities, CatFacts, Effect, Event,
+    CatFacts, Effect, Event,
 };
 use std::rc::Rc;
 use yew::{platform::spawn_local, Callback};
@@ -17,7 +17,7 @@ pub enum Message {
 }
 
 pub fn new() -> Core {
-    Rc::new(shared::Core::new::<CatFactCapabilities>())
+    Rc::new(shared::Core::new())
 }
 
 pub fn update(core: &Core, event: Event, callback: &Callback<Message>) {

--- a/examples/counter/cli/src/core.rs
+++ b/examples/counter/cli/src/core.rs
@@ -5,14 +5,14 @@ use std::sync::Arc;
 use tokio::spawn;
 use tracing::debug;
 
-use shared::{App, Capabilities, Effect, Event};
+use shared::{App, Effect, Event};
 
 use crate::{http, sse};
 
 pub type Core = Arc<shared::Core<Effect, App>>;
 
 pub fn new() -> Core {
-    Arc::new(shared::Core::new::<Capabilities>())
+    Arc::new(shared::Core::new())
 }
 
 pub fn update(core: &Core, event: Event, tx: &Arc<Sender<Effect>>) -> Result<()> {

--- a/examples/counter/shared/src/lib.rs
+++ b/examples/counter/shared/src/lib.rs
@@ -16,7 +16,7 @@ pub use capabilities::sse;
 uniffi::include_scaffolding!("shared");
 
 lazy_static! {
-    static ref CORE: Bridge<Effect, App> = Bridge::new(Core::new::<Capabilities>());
+    static ref CORE: Bridge<Effect, App> = Bridge::new(Core::new());
 }
 
 #[wasm_bindgen]

--- a/examples/counter/tauri/src-tauri/src/lib.rs
+++ b/examples/counter/tauri/src-tauri/src/lib.rs
@@ -7,10 +7,10 @@ use lazy_static::lazy_static;
 use std::sync::Arc;
 use tauri::Manager;
 
-use shared::{App, Capabilities, Core, Effect, Event};
+use shared::{App, Core, Effect, Event};
 
 lazy_static! {
-    static ref CORE: Arc<Core<Effect, App>> = Arc::new(Core::new::<Capabilities>());
+    static ref CORE: Arc<Core<Effect, App>> = Arc::new(Core::new());
 }
 
 fn handle_event(

--- a/examples/counter/web-dioxus/src/core.rs
+++ b/examples/counter/web-dioxus/src/core.rs
@@ -5,7 +5,7 @@ use dioxus::{
     signals::Writable,
 };
 use futures_util::{StreamExt, TryStreamExt};
-use shared::{App, Capabilities, Effect, Event, ViewModel};
+use shared::{App, Effect, Event, ViewModel};
 use tracing::debug;
 use wasm_bindgen_futures::spawn_local;
 
@@ -22,7 +22,7 @@ impl CoreService {
     pub fn new(view: Signal<ViewModel>) -> Self {
         debug!("initializing core service");
         Self {
-            core: Rc::new(shared::Core::new::<Capabilities>()),
+            core: Rc::new(shared::Core::new()),
             view,
         }
     }

--- a/examples/counter/web-leptos/src/core.rs
+++ b/examples/counter/web-leptos/src/core.rs
@@ -2,14 +2,14 @@ use std::rc::Rc;
 
 use futures_util::TryStreamExt;
 use leptos::{spawn_local, SignalUpdate, WriteSignal};
-use shared::{App, Capabilities, Effect, Event, ViewModel};
+use shared::{App, Effect, Event, ViewModel};
 
 use crate::{http, sse};
 
 pub type Core = Rc<shared::Core<Effect, App>>;
 
 pub fn new() -> Core {
-    Rc::new(shared::Core::new::<Capabilities>())
+    Rc::new(shared::Core::new())
 }
 
 pub fn update(core: &Core, event: Event, render: WriteSignal<ViewModel>) {

--- a/examples/counter/web-yew/src/core.rs
+++ b/examples/counter/web-yew/src/core.rs
@@ -1,6 +1,6 @@
 use futures_util::TryStreamExt;
 use gloo_console::log;
-use shared::{App, Capabilities, Effect, Event};
+use shared::{App, Effect, Event};
 use std::rc::Rc;
 use yew::{platform::spawn_local, Callback};
 
@@ -14,7 +14,7 @@ pub enum Message {
 }
 
 pub fn new() -> Core {
-    Rc::new(shared::Core::new::<Capabilities>())
+    Rc::new(shared::Core::new())
 }
 
 pub fn update(core: &Core, event: Event, callback: &Callback<Message>) {

--- a/examples/hello_world/shared/src/app.rs
+++ b/examples/hello_world/shared/src/app.rs
@@ -17,7 +17,6 @@ pub struct ViewModel {
 }
 
 #[derive(crux_core::macros::Effect)]
-#[effect(app = "Hello")]
 pub struct Capabilities {
     render: Render<Event>,
 }

--- a/examples/hello_world/shared/src/lib.rs
+++ b/examples/hello_world/shared/src/lib.rs
@@ -12,7 +12,7 @@ pub use app::*;
 uniffi::include_scaffolding!("shared");
 
 lazy_static! {
-    static ref CORE: Bridge<Effect, Hello> = Bridge::new(Core::new::<Capabilities>());
+    static ref CORE: Bridge<Effect, Hello> = Bridge::new(Core::new());
 }
 
 #[wasm_bindgen]

--- a/examples/notes/shared/src/app.rs
+++ b/examples/notes/shared/src/app.rs
@@ -106,7 +106,6 @@ impl From<&Model> for ViewModel {
 
 #[cfg_attr(feature = "typegen", derive(crux_core::macros::Export))]
 #[derive(crux_core::macros::Effect)]
-#[effect(app = "NoteEditor")]
 pub struct Capabilities {
     timer: Timer<Event>,
     render: Render<Event>,

--- a/examples/notes/shared/src/lib.rs
+++ b/examples/notes/shared/src/lib.rs
@@ -12,7 +12,7 @@ pub use app::*;
 uniffi::include_scaffolding!("shared");
 
 lazy_static! {
-    static ref CORE: Bridge<Effect, NoteEditor> = Bridge::new(Core::new::<Capabilities>());
+    static ref CORE: Bridge<Effect, NoteEditor> = Bridge::new(Core::new());
 }
 
 #[wasm_bindgen]

--- a/examples/simple_counter/shared/src/app.rs
+++ b/examples/simple_counter/shared/src/app.rs
@@ -21,7 +21,6 @@ pub struct ViewModel {
 
 #[cfg_attr(feature = "typegen", derive(crux_core::macros::Export))]
 #[derive(crux_core::macros::Effect)]
-#[effect(app = "Counter")]
 pub struct Capabilities {
     render: Render<Event>,
 }

--- a/examples/simple_counter/shared/src/lib.rs
+++ b/examples/simple_counter/shared/src/lib.rs
@@ -12,7 +12,7 @@ pub use app::*;
 uniffi::include_scaffolding!("shared");
 
 lazy_static! {
-    static ref CORE: Bridge<Effect, Counter> = Bridge::new(Core::new::<Capabilities>());
+    static ref CORE: Bridge<Effect, Counter> = Bridge::new(Core::new());
 }
 
 #[wasm_bindgen]

--- a/examples/simple_counter/web-dioxus/src/core.rs
+++ b/examples/simple_counter/web-dioxus/src/core.rs
@@ -5,7 +5,7 @@ use dioxus::{
     signals::Writable,
 };
 use futures_util::StreamExt;
-use shared::{Capabilities, Counter, Effect, Event, ViewModel};
+use shared::{Counter, Effect, Event, ViewModel};
 use tracing::debug;
 
 type Core = Rc<shared::Core<Effect, Counter>>;
@@ -19,7 +19,7 @@ impl CoreService {
     pub fn new(view: Signal<ViewModel>) -> Self {
         debug!("initializing core service");
         Self {
-            core: Rc::new(shared::Core::new::<Capabilities>()),
+            core: Rc::new(shared::Core::new()),
             view,
         }
     }

--- a/examples/simple_counter/web-leptos/src/core.rs
+++ b/examples/simple_counter/web-leptos/src/core.rs
@@ -1,12 +1,12 @@
 use std::rc::Rc;
 
 use leptos::{SignalUpdate, WriteSignal};
-use shared::{Capabilities, Counter, Effect, Event, ViewModel};
+use shared::{Counter, Effect, Event, ViewModel};
 
 pub type Core = Rc<shared::Core<Effect, Counter>>;
 
 pub fn new() -> Core {
-    Rc::new(shared::Core::new::<Capabilities>())
+    Rc::new(shared::Core::new())
 }
 
 pub fn update(core: &Core, event: Event, render: WriteSignal<ViewModel>) {

--- a/examples/simple_counter/web-yew/src/core.rs
+++ b/examples/simple_counter/web-yew/src/core.rs
@@ -1,4 +1,4 @@
-use shared::{Capabilities, Counter, Effect, Event};
+use shared::{Counter, Effect, Event};
 use std::rc::Rc;
 use yew::Callback;
 
@@ -10,7 +10,7 @@ pub enum Message {
 }
 
 pub fn new() -> Core {
-    Rc::new(shared::Core::new::<Capabilities>())
+    Rc::new(shared::Core::new())
 }
 
 pub fn update(core: &Core, event: Event, callback: &Callback<Message>) {

--- a/examples/tap_to_pay/shared/src/app.rs
+++ b/examples/tap_to_pay/shared/src/app.rs
@@ -36,7 +36,6 @@ pub enum Screen {
 }
 
 #[derive(crux_core::macros::Effect)]
-#[effect(app = "App")]
 #[cfg_attr(feature = "typegen", derive(crux_core::macros::Export))]
 pub struct Capabilities {
     render: Render<Event>,

--- a/examples/tap_to_pay/shared/src/lib.rs
+++ b/examples/tap_to_pay/shared/src/lib.rs
@@ -10,7 +10,7 @@ use lazy_static::lazy_static;
 uniffi::include_scaffolding!("shared");
 
 lazy_static! {
-    static ref CORE: Bridge<Effect, App> = Bridge::new(Core::new::<Capabilities>());
+    static ref CORE: Bridge<Effect, App> = Bridge::new(Core::new());
 }
 
 pub fn process_event(data: &[u8]) -> Vec<u8> {

--- a/templates/simple_counter/shared/src/app.rs
+++ b/templates/simple_counter/shared/src/app.rs
@@ -21,7 +21,6 @@ pub struct ViewModel {
 
 #[cfg_attr(feature = "typegen", derive(crux_core::macros::Export))]
 #[derive(crux_core::macros::Effect)]
-#[effect(app = "Counter")]
 pub struct Capabilities {
     render: Render<Event>,
 }


### PR DESCRIPTION
This was preventing having Apps with generic parameters, because the Effect derive macro would want the type name for the App.

Turns out that was down to the type definition of `WithContext` which required the `App` type, but doesn't strictly need to. It's job is to map capability's output to type `Effect` (wrapping it). 

`WithEffect` can now, strictly speaking, be implemented on anything, but we do restrict it down to being the App's capabilities type further up the chain in `Core::new`.

A nice side effect (possibly independent?) is that `Core::new` no longer needs to be generic. Sadly that also makes this a breaking change 😢 