### PR TITLE
Add AppTester::new

### DIFF
--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -47,7 +47,6 @@ where
     where
         Ef: Send + 'static,
         App::Capabilities: WithContext<App::Event, Ef>,
-        App::Event: Send,
     {
         Self {
             app,
@@ -88,7 +87,6 @@ impl<App, Ef> Default for AppTester<App, Ef>
 where
     App: crate::App,
     App::Capabilities: WithContext<App::Event, Ef>,
-    App::Event: Send,
     Ef: Send + 'static,
 {
     fn default() -> Self {

--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -40,6 +40,21 @@ impl<App, Ef> AppTester<App, Ef>
 where
     App: crate::App,
 {
+    /// Create an `AppTester` instance for an existing app instance. This can be used if your App
+    /// has a constructor other than `Default`, for example when used as a child app and expecting
+    /// configuration from the parent
+    pub fn new(app: App) -> Self
+    where
+        Ef: Send + 'static,
+        App::Capabilities: WithContext<App::Event, Ef>,
+        App::Event: Send,
+    {
+        Self {
+            app,
+            ..Default::default()
+        }
+    }
+
     /// Run the app's `update` function with an event and a model state
     ///
     /// You can use the resulting [`Update`] to inspect the effects which were requested

--- a/crux_core/tests/testing.rs
+++ b/crux_core/tests/testing.rs
@@ -1,0 +1,51 @@
+//! Test for the testing APIs
+
+use crux_core::testing::AppTester;
+
+mod app {
+    use crux_core::macros::Effect;
+    use crux_core::App;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    pub enum Event {
+        Hello,
+    }
+
+    #[derive(Effect)]
+    pub struct Capabilities {
+        render: crux_core::render::Render<Event>,
+    }
+
+    #[derive(Default)]
+    pub struct MyApp;
+
+    impl App for MyApp {
+        type Event = Event;
+        type Model = String;
+        type ViewModel = String;
+        type Capabilities = Capabilities;
+
+        fn update(&self, _event: Self::Event, _model: &mut Self::Model, caps: &Self::Capabilities) {
+            caps.render.render()
+        }
+
+        fn view(&self, model: &Self::Model) -> Self::ViewModel {
+            model.clone()
+        }
+    }
+}
+
+#[test]
+fn app_tester_new() {
+    let app = app::MyApp;
+    let tester = AppTester::new(app);
+
+    let mut model = "Hello".to_string();
+
+    let update = tester.update(app::Event::Hello, &mut model);
+
+    let effects = update.into_effects();
+
+    assert_eq!(effects.count(), 1);
+}


### PR DESCRIPTION
Convenient for creating non-default instances, e.g. in nested apps.