### PR TITLE
Debug fmt handles unicode boundaries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: latest
 

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -36,7 +36,7 @@ impl std::fmt::Debug for HttpRequest {
             if s.len() < 50 {
                 format!("\"{s}\"")
             } else {
-                format!("\"{}\"...", &s[..50])
+                format!("\"{}\"...", &s.chars().take(50).collect::<String>())
             }
         } else {
             format!("<binary data - {} bytes>", self.body.len())
@@ -310,12 +310,13 @@ mod tests {
         {
             // big
             let req = HttpRequest::post("http://example.com")
-                .body("abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz")
+                // we check that we handle unicode boundaries correctly
+                .body("abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstu😀😀😀😀😀😀")
                 .build();
             let repr = format!("{req:?}");
             assert_eq!(
                 repr,
-                r#"HttpReqeuest { method: "POST", url: "http://example.com", body: "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvw"... }"#
+                r#"HttpReqeuest { method: "POST", url: "http://example.com", body: "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstu😀😀"... }"#
             );
         }
 

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -36,7 +36,7 @@ impl std::fmt::Debug for HttpRequest {
             if s.len() < 50 {
                 format!("\"{s}\"")
             } else {
-                format!("\"{}\"...", &s.chars().take(50).collect::<String>())
+                format!("\"{}\"...", s.chars().take(50).collect::<String>())
             }
         } else {
             format!("<binary data - {} bytes>", self.body.len())

--- a/crux_kv/src/lib.rs
+++ b/crux_kv/src/lib.rs
@@ -49,7 +49,7 @@ impl std::fmt::Debug for KeyValueOperation {
                     if s.len() < 50 {
                         format!("\"{s}\"")
                     } else {
-                        format!("\"{}\"...", &s[..50])
+                        format!("\"{}\"...", &s.chars().take(50).collect::<String>())
                     }
                 } else {
                     format!("<binary data - {} bytes>", value.len())

--- a/crux_kv/src/lib.rs
+++ b/crux_kv/src/lib.rs
@@ -45,11 +45,11 @@ impl std::fmt::Debug for KeyValueOperation {
         match self {
             KeyValueOperation::Get { key } => f.debug_struct("Get").field("key", key).finish(),
             KeyValueOperation::Set { key, value } => {
-                let body_repr = if let Ok(s) = std::str::from_utf8(&value) {
+                let body_repr = if let Ok(s) = std::str::from_utf8(value) {
                     if s.len() < 50 {
                         format!("\"{s}\"")
                     } else {
-                        format!("\"{}\"...", &s.chars().take(50).collect::<String>())
+                        format!("\"{}\"...", s.chars().take(50).collect::<String>())
                     }
                 } else {
                     format!("<binary data - {} bytes>", value.len())

--- a/crux_kv/src/tests.rs
+++ b/crux_kv/src/tests.rs
@@ -395,13 +395,13 @@ fn test_kv_operation_debug_repr() {
         let op = KeyValueOperation::Set {
             key: "my key".into(),
             value:
-                b"abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz"
-                    .to_vec(),
+                // we check that we handle unicode boundaries correctly
+                "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstu😀😀😀😀😀😀".as_bytes().to_vec(),
         };
         let repr = format!("{op:?}");
         assert_eq!(
             repr,
-            r#"Set { key: "my key", value: "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvw"... }"#
+            r#"Set { key: "my key", value: "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstu😀😀"... }"#
         );
     }
 


### PR DESCRIPTION
I realised that #253 can introduce a panic when handling non-ascii unicode character (see e.g. https://old.reddit.com/r/rust/comments/765n76/psa_caution_with_slicing_strings/). Here is the fix.

Also bumped the `pnpm` action to `v4`, as suggested in https://github.com/pnpm/pnpm/issues/6424.