### PR TITLE
Fix a bug caused by drop order of the `Core` struct

### DIFF
--- a/crux_core/src/capability/executor.rs
+++ b/crux_core/src/capability/executor.rs
@@ -52,7 +52,7 @@ impl Spawner {
 
         self.task_sender
             .send(task)
-            .expect("to be able to send tasks on an unbounded queue")
+            .expect("unable to spawn an async task, task sender channel is disconnected.")
     }
 }
 // ANCHOR_END: spawning
@@ -65,7 +65,7 @@ impl ArcWake for Task {
         arc_self
             .task_sender
             .send(cloned)
-            .expect("to be able to send tasks on an unbounded queue")
+            .expect("unable to wake an async task, task sender channel is disconnected.")
     }
 }
 // ANCHOR_END: arc_wake

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -27,12 +27,20 @@ pub struct Core<Ef, A>
 where
     A: App,
 {
+    // WARNING: The user controlled types _must_ be defined first
+    // so that they are dropped first, in case they contain coordination
+    // primitives which attempt to wake up a future when dropped. For that
+    // reason the executor _must_ outlive the user type instances
+
+    // user types
     model: RwLock<A::Model>,
-    executor: QueuingExecutor,
     capabilities: A::Capabilities,
+    app: A,
+
+    // internals
     requests: Receiver<Ef>,
     capability_events: Receiver<A::Event>,
-    app: A,
+    executor: QueuingExecutor,
 }
 // ANCHOR_END: core
 


### PR DESCRIPTION
This is a very subtle problem with the order of the fields of the `Core` type interacting with the async runtime when using channels (and possibly other coordination primitives).

The problem is this:

1. A capability creates a long running future with a loop
2. In order to communicate with this future it creates a channel, gives the receving end to the future and holds the sending end
3. The future gets to the point of receiving from the channel and suspends on `.await`. 
4. If the core is now dropped, then due to the original ordering of the fields, the executor is dropped first, causing the `task_sender` channel to close.
5. The `A::Capabilities` instance is dropped, dropping the capability instance, including the sending end of the channel
6. The channel's `Drop` implementation closes the channel, which wakes up the future, so that the `recv()` method can return `Err`
7. The `ArcWake` implementation on the task spawned by Crux's `Spawner` [attempts to `.send` self to the `task_sender`](https://github.com/redbadger/crux/blob/master/crux_core/src/capability/executor.rs#L67), which fails, because the receving end dropped in step 4, and we panic on the `.expect`

To fix, I've reordered the fields of Core to drop the user defined types first, so that any Crux infrastructure they rely on is still alive when any `Drop` implementations in them run.