### PR TITLE
Mark HTTP body with serde_bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "http-types-red-badger-temporary-fork",
  "pin-project-lite",
  "serde",
+ "serde_bytes",
  "serde_json",
  "thiserror",
  "url",
@@ -1458,6 +1459,15 @@ dependencies = [
  "once_cell",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -26,6 +26,7 @@ futures-util = "0.3"
 http-types = { package = "http-types-red-badger-temporary-fork", version = "2.12.0", default-features = false }
 pin-project-lite = "0.2.14"
 serde = { workspace = true, features = ["derive"] }
+serde_bytes = "0.11"
 serde_json = "1.0.128"
 thiserror = "1.0.63"
 url = "2.5.2"

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -27,6 +27,7 @@ pub struct HttpRequest {
     pub url: String,
     #[builder(setter(custom))]
     pub headers: Vec<HttpHeader>,
+    #[serde(with = "serde_bytes")]
     pub body: Vec<u8>,
 }
 
@@ -107,6 +108,7 @@ pub struct HttpResponse {
     pub status: u16, // FIXME this probably should be a giant enum instead.
     #[builder(setter(custom))]
     pub headers: Vec<HttpHeader>,
+    #[serde(with = "serde_bytes")]
     pub body: Vec<u8>,
 }
 


### PR DESCRIPTION
This marks the `body` field in `crux_http`'s `HttpRequest` and `HttpResponse` types with the `#[serde(with = "serde_bytes")]` annotation. This is effectively a hint for Serde to serialize it as a byte array instead of a vector of numbers.

See also: https://docs.rs/serde_bytes/latest/serde_bytes/

I could put this behind a feature flag, but given that the annotation is ignored on formats that don't support byte arrays, I think there might be no need. This also means it will remain a vector of numbers for JSON encoding, since JSON has no functionality for binary encoding. The annotation is mainly relevant for formats such as MessagePack and CBOR.

For formats that work with fixed-size vectors, such as bincode, I don't think there will be any difference either, although I have not tested this.