### PR TITLE
use cargo-ndk-android instead of rust-android-gradle plugin

### DIFF
--- a/examples/cat_facts/Android/.idea/compiler.xml
+++ b/examples/cat_facts/Android/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="21" />
+    <bytecodeTargetLevel target="20" />
   </component>
 </project>

--- a/examples/cat_facts/Android/.idea/gradle.xml
+++ b/examples/cat_facts/Android/.idea/gradle.xml
@@ -6,7 +6,7 @@
       <GradleProjectSettings>
         <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+        <option name="gradleJvm" value="20" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/examples/cat_facts/Android/.idea/misc.xml
+++ b/examples/cat_facts/Android/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_20" default="true" project-jdk-name="20" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/examples/cat_facts/Android/.idea/runConfigurations.xml
+++ b/examples/cat_facts/Android/.idea/runConfigurations.xml
@@ -5,8 +5,12 @@
       <set>
         <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
         <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
         <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
         <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
       </set>
     </option>
   </component>

--- a/examples/cat_facts/Android/build.gradle
+++ b/examples/cat_facts/Android/build.gradle
@@ -4,5 +4,5 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.rust.android) apply false
+    alias(libs.plugins.cargo.ndk) apply false
 }

--- a/examples/cat_facts/Android/gradle/libs.versions.toml
+++ b/examples/cat_facts/Android/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
-agp = "8.7.0"
+agp = "8.7.1"
 kotlin = "2.0.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.6"
-activityCompose = "1.9.2"
-composeBom = "2024.09.03"
+activityCompose = "1.9.3"
+composeBom = "2024.10.00"
 
 # added
 jna = "5.15.0"
@@ -16,7 +16,7 @@ rustAndroid = "0.9.4"
 ktorClient = "2.2.2"
 appcompat = "1.7.0"
 material = "1.12.0"
-materialIconsExtended = "1.7.3"
+materialIconsExtended = "1.7.4"
 coilCompose = "2.0.0-rc01"
 
 [libraries]
@@ -50,5 +50,5 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 
 # added
-rust-android = { id = "org.mozilla.rust-android-gradle.rust-android", version.ref = "rustAndroid" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+cargo-ndk = { id = "com.github.willir.rust.cargo-ndk-android", version = "0.3.4" }

--- a/examples/cat_facts/Android/shared/.gitignore
+++ b/examples/cat_facts/Android/shared/.gitignore
@@ -1,1 +1,2 @@
 /build
+jniLibs

--- a/examples/cat_facts/Android/shared/build.gradle
+++ b/examples/cat_facts/Android/shared/build.gradle
@@ -7,7 +7,7 @@ android {
     namespace 'com.redbadger.catfacts.shared'
     compileSdk 34
 
-    ndkVersion "27.1.12297006"
+    ndkVersion "28.0.12433566"
 
     defaultConfig {
         minSdk 34
@@ -25,9 +25,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_20
         targetCompatibility JavaVersion.VERSION_20
-    }
-    kotlinOptions {
-        jvmTarget = '20'
     }
     sourceSets {
         main.java.srcDirs += "${projectDir}/../../shared_types/generated/java"
@@ -49,37 +46,16 @@ dependencies {
     androidTestImplementation libs.androidx.espresso.core
 }
 
-apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
+apply plugin: 'com.github.willir.rust.cargo-ndk-android'
 
-cargo {
-    module = "../.."
-    libname = "shared"
-    // these are the four recommended targets for Android that will ensure your library works on all mainline android devices
-    // make sure you have included the rust toolchain for each of these targets: \
-    // `rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android`
-    targets = ["arm", "arm64", "x86", "x86_64"]
-    extraCargoBuildArguments = ['--package', 'shared']
-    cargoCommand = System.getProperty("user.home") + "/.cargo/bin/cargo"
-    rustcCommand = System.getProperty("user.home") + "/.cargo/bin/rustc"
-    pythonCommand = "python3"
+cargoNdk {
+    module = "../shared"
+    targetDirectory = "../target"
 }
 
 afterEvaluate {
-    // The `cargoBuild` task isn't available until after evaluation.
-    android.libraryVariants.configureEach { variant ->
-        def productFlavor = ""
-        variant.productFlavors.each {
-            productFlavor += "${it.name.capitalize()}"
-        }
-        def buildType = "${variant.buildType.name.capitalize()}"
-
-        tasks.named("compileDebugKotlin") {
-            it.dependsOn(tasks.named("typesGen"), tasks.named("bindGen"))
-        }
-
-        tasks.named("generate${productFlavor}${buildType}Assets") {
-            it.dependsOn(tasks.named("cargoBuild"))
-        }
+    tasks.named("compileDebugKotlin") {
+        it.dependsOn(tasks.named("typesGen"), tasks.named("bindGen"))
     }
 }
 
@@ -88,11 +64,11 @@ tasks.register('bindGen', Exec) {
     workingDir "../../"
     if (System.getProperty('os.name').toLowerCase().contains('windows')) {
         commandLine("cmd", "/c",
-                "cargo build -p shared && " + "target\\debug\\uniffi-bindgen generate shared\\src\\shared.udl " + "--language kotlin " + "--out-dir " + outDir.replace('/', '\\'))
+                "cargo build --package shared --bin uniffi-bindgen && " + "target\\debug\\uniffi-bindgen generate shared\\src\\shared.udl " + "--language kotlin " + "--out-dir " + outDir.replace('/', '\\'))
     } else {
         commandLine("sh", "-c",
                 """\
-                cargo build -p shared && \
+                cargo build --package shared --bin uniffi-bindgen && \
                 target/debug/uniffi-bindgen generate shared/src/shared.udl \
                 --language kotlin \
                 --out-dir $outDir

--- a/examples/cat_facts/Cargo.lock
+++ b/examples/cat_facts/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37bf3594c4c988a53154954629820791dde498571819ae4ca50ca811e060cc95"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "anymap2"
@@ -1888,9 +1888,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -2229,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.211"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac55e59090389fb9f0dd9e0f3c09615afed1d19094284d0b200441f13550793"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
@@ -2294,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.211"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54be4f245ce16bc58d57ef2716271d0d4519e0f6defa147f6e081005bcb278ff"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2529,18 +2529,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2574,9 +2574,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",


### PR DESCRIPTION
For the Android examples, this PR explores the use of [`cargo-ndk`](https://github.com/bbqsrc/cargo-ndk) and the [`cargo-ndk-android`](https://github.com/willir/cargo-ndk-android-gradle) plugin instead of Mozilla's [`rust-android-gradle`](https://github.com/mozilla/rust-android-gradle) plugin.

It was prompted by the failure of the Mozilla plugin when I upgraded Python to 3.13 (linking failed because the `pipes` import fails as this has now been removed from python). I've raised an issue (https://github.com/mozilla/rust-android-gradle/issues/153), for which I'd be happy to submit a PR but not sure if/when it would be merged. 

In the meantime, this is an alternative that _might_ be simpler overall, not sure.