### PR TITLE
Add helper methods to `Update` to remove test boilerplate

### DIFF
--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -76,6 +76,21 @@ where
         Ok(self.context.updates())
     }
 
+    /// Resolve an effect `request` from previous update, then run the resulting event
+    ///
+    /// This helper is useful for the comment case where  one expects the effect to resolve
+    ///  to exactly one event, which should then be run by the app.
+    pub fn resolve_to_event_then_update<Op: Operation>(
+        &self,
+        request: &mut Request<Op>,
+        value: Op::Output,
+        model: &mut App::Model,
+    ) -> Update<Ef, App::Event> {
+        request.resolve(value).expect("failed to resolve request");
+        let event = self.context.updates().expect_one_event();
+        self.update(event, model)
+    }
+
     /// Run the app's `view` function with a model state
     pub fn view(&self, model: &App::Model) -> App::ViewModel {
         self.app.view(model)
@@ -146,6 +161,46 @@ impl<Ef, Ev> Update<Ef, Ev> {
 
     pub fn effects_mut(&mut self) -> impl Iterator<Item = &mut Ef> {
         self.effects.iter_mut()
+    }
+
+    /// Assert that the update contains exactly one effect and zero events,
+    /// and return the effect
+    pub fn expect_one_effect(mut self) -> Ef {
+        if self.events.is_empty() && self.effects.len() == 1 {
+            self.effects.pop().unwrap()
+        } else {
+            panic!(
+                "Expected one effect but found {} effect(s) and {} event(s)",
+                self.effects.len(),
+                self.events.len()
+            );
+        }
+    }
+
+    /// Assert that the update contains exactly one effect and zero events,
+    /// and return the effect
+    pub fn expect_one_event(mut self) -> Ev {
+        if self.effects.is_empty() && self.events.len() == 1 {
+            self.events.pop().unwrap()
+        } else {
+            panic!(
+                "Expected one event but found {} effect(s) and {} event(s)",
+                self.effects.len(),
+                self.events.len()
+            );
+        }
+    }
+
+    /// Assert that the update contains no effects or events
+    pub fn assert_empty(self) {
+        if self.effects.is_empty() && self.events.is_empty() {
+            return;
+        }
+        panic!(
+            "Expected empty update but found {} effect(s) and {} event(s)",
+            self.effects.len(),
+            self.events.len()
+        );
     }
 }
 

--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -78,8 +78,8 @@ where
 
     /// Resolve an effect `request` from previous update, then run the resulting event
     ///
-    /// This helper is useful for the comment case where  one expects the effect to resolve
-    ///  to exactly one event, which should then be run by the app.
+    /// This helper is useful for the common case where  one expects the effect to resolve
+    /// to exactly one event, which should then be run by the app.
     pub fn resolve_to_event_then_update<Op: Operation>(
         &self,
         request: &mut Request<Op>,
@@ -178,8 +178,8 @@ impl<Ef, Ev> Update<Ef, Ev> {
         }
     }
 
-    /// Assert that the update contains exactly one effect and zero events,
-    /// and return the effect
+    /// Assert that the update contains exactly one event and zero effects,
+    /// and return the event
     pub fn expect_one_event(mut self) -> Ev {
         if self.effects.is_empty() && self.events.len() == 1 {
             self.events.pop().unwrap()

--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -143,6 +143,7 @@ impl<Ef, Ev> AppContext<Ef, Ev> {
 /// Update test helper holds the result of running an app update using [`AppTester::update`]
 /// or resolving a request with [`AppTester::resolve`].
 #[derive(Debug)]
+#[must_use]
 pub struct Update<Ef, Ev> {
     /// Effects requested from the update run
     pub effects: Vec<Ef>,

--- a/crux_http/tests/with_tester.rs
+++ b/crux_http/tests/with_tester.rs
@@ -177,7 +177,7 @@ mod tests {
         });
 
         for event in update.events {
-            app.update(event, &mut model);
+            app.update(event, &mut model).assert_empty();
         }
         assert_eq!(model.body, "\"hello\"");
         assert_eq!(model.values, vec!["my_value1", "my_value2"]);

--- a/crux_kv/src/tests.rs
+++ b/crux_kv/src/tests.rs
@@ -162,7 +162,7 @@ fn test_get() {
         .unwrap();
 
     let event = updated.events.into_iter().next().unwrap();
-    app.update(event, &mut model);
+    let _update = app.update(event, &mut model);
 
     assert_eq!(model.value, 42);
 }
@@ -198,7 +198,7 @@ fn test_set() {
         .unwrap();
 
     let event = updated.events.into_iter().next().unwrap();
-    app.update(event, &mut model);
+    let _update = app.update(event, &mut model);
 
     assert!(model.successful);
 }
@@ -233,7 +233,7 @@ fn test_delete() {
         .unwrap();
 
     let event = updated.events.into_iter().next().unwrap();
-    app.update(event, &mut model);
+    let _update = app.update(event, &mut model);
 
     assert!(model.successful);
 }
@@ -266,7 +266,7 @@ fn test_exists() {
         .unwrap();
 
     let event = updated.events.into_iter().next().unwrap();
-    app.update(event, &mut model);
+    let _update = app.update(event, &mut model);
 
     assert!(model.successful);
 }
@@ -303,7 +303,7 @@ fn test_list_keys() {
         .unwrap();
 
     let event = updated.events.into_iter().next().unwrap();
-    app.update(event, &mut model);
+    let _update = app.update(event, &mut model);
 
     assert_eq!(model.keys, vec!["test:1".to_string(), "test:2".to_string()]);
     assert_eq!(model.cursor, 2);
@@ -362,7 +362,7 @@ pub fn test_kv_async() -> Result<()> {
         .unwrap();
 
     let event = update.events.into_iter().next().unwrap();
-    app.update(event, &mut model);
+    let _update = app.update(event, &mut model);
 
     assert!(model.successful);
 

--- a/crux_kv/src/tests.rs
+++ b/crux_kv/src/tests.rs
@@ -208,12 +208,10 @@ fn test_delete() {
     let app = AppTester::<App, _>::default();
     let mut model = Model::default();
 
-    let updated = app.update(Event::Delete, &mut model);
-
-    let effect = updated.into_effects().next().unwrap();
-    let Effect::KeyValue(mut request) = effect else {
-        panic!("Expected KeyValue effect");
-    };
+    let mut request = app
+        .update(Event::Delete, &mut model)
+        .expect_one_effect()
+        .expect_key_value();
 
     let KeyValueOperation::Delete { key } = request.operation.clone() else {
         panic!("Expected delete operation");
@@ -221,19 +219,15 @@ fn test_delete() {
 
     assert_eq!(key, "test");
 
-    let updated = app
-        .resolve(
-            &mut request,
-            KeyValueResult::Ok {
-                response: KeyValueResponse::Delete {
-                    previous: Value::None,
-                },
+    let _updated = app.resolve_to_event_then_update(
+        &mut request,
+        KeyValueResult::Ok {
+            response: KeyValueResponse::Delete {
+                previous: Value::None,
             },
-        )
-        .unwrap();
-
-    let event = updated.events.into_iter().next().unwrap();
-    let _update = app.update(event, &mut model);
+        },
+        &mut model,
+    );
 
     assert!(model.successful);
 }
@@ -243,12 +237,10 @@ fn test_exists() {
     let app = AppTester::<App, _>::default();
     let mut model = Model::default();
 
-    let updated = app.update(Event::Exists, &mut model);
-
-    let effect = updated.into_effects().next().unwrap();
-    let Effect::KeyValue(mut request) = effect else {
-        panic!("Expected KeyValue effect");
-    };
+    let mut request = app
+        .update(Event::Exists, &mut model)
+        .expect_one_effect()
+        .expect_key_value();
 
     let KeyValueOperation::Exists { key } = request.operation.clone() else {
         panic!("Expected exists operation");
@@ -256,17 +248,13 @@ fn test_exists() {
 
     assert_eq!(key, "test");
 
-    let updated = app
-        .resolve(
-            &mut request,
-            KeyValueResult::Ok {
-                response: KeyValueResponse::Exists { is_present: true },
-            },
-        )
-        .unwrap();
-
-    let event = updated.events.into_iter().next().unwrap();
-    let _update = app.update(event, &mut model);
+    let _updated = app.resolve_to_event_then_update(
+        &mut request,
+        KeyValueResult::Ok {
+            response: KeyValueResponse::Exists { is_present: true },
+        },
+        &mut model,
+    );
 
     assert!(model.successful);
 }
@@ -276,12 +264,10 @@ fn test_list_keys() {
     let app = AppTester::<App, _>::default();
     let mut model = Model::default();
 
-    let updated = app.update(Event::ListKeys, &mut model);
-
-    let effect = updated.into_effects().next().unwrap();
-    let Effect::KeyValue(mut request) = effect else {
-        panic!("Expected KeyValue effect");
-    };
+    let mut request = app
+        .update(Event::ListKeys, &mut model)
+        .expect_one_effect()
+        .expect_key_value();
 
     let KeyValueOperation::ListKeys { prefix, cursor } = request.operation.clone() else {
         panic!("Expected list keys operation");
@@ -290,20 +276,16 @@ fn test_list_keys() {
     assert_eq!(prefix, "test:");
     assert_eq!(cursor, 0);
 
-    let updated = app
-        .resolve(
-            &mut request,
-            KeyValueResult::Ok {
-                response: KeyValueResponse::ListKeys {
-                    keys: vec!["test:1".to_string(), "test:2".to_string()],
-                    next_cursor: 2,
-                },
+    let _update = app.resolve_to_event_then_update(
+        &mut request,
+        KeyValueResult::Ok {
+            response: KeyValueResponse::ListKeys {
+                keys: vec!["test:1".to_string(), "test:2".to_string()],
+                next_cursor: 2,
             },
-        )
-        .unwrap();
-
-    let event = updated.events.into_iter().next().unwrap();
-    let _update = app.update(event, &mut model);
+        },
+        &mut model,
+    );
 
     assert_eq!(model.keys, vec!["test:1".to_string(), "test:2".to_string()]);
     assert_eq!(model.cursor, 2);

--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -114,6 +114,8 @@ impl ToTokens for EffectStructReceiver {
 
                 let filter_fn = format_ident!("is_{}", field_name);
                 let map_fn = format_ident!("into_{}", field_name);
+                let expect_fn = format_ident!("expect_{}", field_name);
+                let name_as_str = field_name.to_string();
                 filters.push(quote! {
                     impl #effect_name {
                         pub fn #filter_fn(&self) -> bool {
@@ -128,6 +130,13 @@ impl ToTokens for EffectStructReceiver {
                                 Some(request)
                             } else {
                                 None
+                            }
+                        }
+                        pub fn #expect_fn(self) -> crux_core::Request<<#capability<#event> as ::crux_core::capability::Capability<#event>>::Operation> {
+                            if let #effect_name::#variant(request) = self {
+                                request
+                            } else {
+                                panic!("not a {} effect", #name_as_str)
                             }
                         }
                     }
@@ -275,6 +284,17 @@ mod tests {
             > {
                 if let Effect::Render(request) = self { Some(request) } else { None }
             }
+            pub fn expect_render(
+                self,
+            ) -> crux_core::Request<
+                <Render<Event> as ::crux_core::capability::Capability<Event>>::Operation,
+            > {
+                if let Effect::Render(request) = self {
+                    request
+                } else {
+                    panic!("not a {} effect", "render")
+                }
+            }
         }
         "###);
     }
@@ -345,6 +365,17 @@ mod tests {
                 >,
             > {
                 if let Effect::Render(request) = self { Some(request) } else { None }
+            }
+            pub fn expect_render(
+                self,
+            ) -> crux_core::Request<
+                <Render<Event> as ::crux_core::capability::Capability<Event>>::Operation,
+            > {
+                if let Effect::Render(request) = self {
+                    request
+                } else {
+                    panic!("not a {} effect", "render")
+                }
             }
         }
         "###);
@@ -460,6 +491,19 @@ mod tests {
             > {
                 if let MyEffect::Http(request) = self { Some(request) } else { None }
             }
+            pub fn expect_http(
+                self,
+            ) -> crux_core::Request<
+                <crux_http::Http<
+                    MyEvent,
+                > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+            > {
+                if let MyEffect::Http(request) = self {
+                    request
+                } else {
+                    panic!("not a {} effect", "http")
+                }
+            }
         }
         impl MyEffect {
             pub fn is_key_value(&self) -> bool {
@@ -475,6 +519,17 @@ mod tests {
                 >,
             > {
                 if let MyEffect::KeyValue(request) = self { Some(request) } else { None }
+            }
+            pub fn expect_key_value(
+                self,
+            ) -> crux_core::Request<
+                <KeyValue<MyEvent> as ::crux_core::capability::Capability<MyEvent>>::Operation,
+            > {
+                if let MyEffect::KeyValue(request) = self {
+                    request
+                } else {
+                    panic!("not a {} effect", "key_value")
+                }
             }
         }
         impl MyEffect {
@@ -492,6 +547,17 @@ mod tests {
             > {
                 if let MyEffect::Platform(request) = self { Some(request) } else { None }
             }
+            pub fn expect_platform(
+                self,
+            ) -> crux_core::Request<
+                <Platform<MyEvent> as ::crux_core::capability::Capability<MyEvent>>::Operation,
+            > {
+                if let MyEffect::Platform(request) = self {
+                    request
+                } else {
+                    panic!("not a {} effect", "platform")
+                }
+            }
         }
         impl MyEffect {
             pub fn is_render(&self) -> bool {
@@ -506,6 +572,17 @@ mod tests {
             > {
                 if let MyEffect::Render(request) = self { Some(request) } else { None }
             }
+            pub fn expect_render(
+                self,
+            ) -> crux_core::Request<
+                <Render<MyEvent> as ::crux_core::capability::Capability<MyEvent>>::Operation,
+            > {
+                if let MyEffect::Render(request) = self {
+                    request
+                } else {
+                    panic!("not a {} effect", "render")
+                }
+            }
         }
         impl MyEffect {
             pub fn is_time(&self) -> bool {
@@ -519,6 +596,17 @@ mod tests {
                 >,
             > {
                 if let MyEffect::Time(request) = self { Some(request) } else { None }
+            }
+            pub fn expect_time(
+                self,
+            ) -> crux_core::Request<
+                <Time<MyEvent> as ::crux_core::capability::Capability<MyEvent>>::Operation,
+            > {
+                if let MyEffect::Time(request) = self {
+                    request
+                } else {
+                    panic!("not a {} effect", "time")
+                }
             }
         }
         "###);

--- a/crux_time/tests/time_test.rs
+++ b/crux_time/tests/time_test.rs
@@ -192,7 +192,8 @@ mod tests {
 
         let now: DateTime<Utc> = "2022-12-01T01:47:12.746202562+00:00".parse().unwrap();
         let response = TimeResponse::Now(now.try_into().unwrap());
-        app.resolve_to_event_then_update(&mut request, response, &mut model);
+        app.resolve_to_event_then_update(&mut request, response, &mut model)
+            .assert_empty();
 
         assert_eq!(app.view(&model).time, "2022-12-01T01:47:12.746202562+00:00");
     }
@@ -212,13 +213,15 @@ mod tests {
             .expect_time();
 
         // resolve and update
-        app.resolve_to_event_then_update(&mut request1, TimeResponse::DurationElapsed, &mut model);
+        app.resolve_to_event_then_update(&mut request1, TimeResponse::DurationElapsed, &mut model)
+            .assert_empty();
 
         // resolving the first debounce should not set the debounce_complete flag
         assert!(!model.debounce_complete);
 
         // resolve and update
-        app.resolve_to_event_then_update(&mut request2, TimeResponse::DurationElapsed, &mut model);
+        app.resolve_to_event_then_update(&mut request2, TimeResponse::DurationElapsed, &mut model)
+            .assert_empty();
 
         // resolving the second debounce should set the debounce_complete flag
         assert!(model.debounce_complete);

--- a/crux_time/tests/time_test.rs
+++ b/crux_time/tests/time_test.rs
@@ -192,8 +192,7 @@ mod tests {
 
         let now: DateTime<Utc> = "2022-12-01T01:47:12.746202562+00:00".parse().unwrap();
         let response = TimeResponse::Now(now.try_into().unwrap());
-        app.resolve_to_event_then_update(&mut request, response, &mut model)
-            .assert_empty();
+        let _update = app.resolve_to_event_then_update(&mut request, response, &mut model);
 
         assert_eq!(app.view(&model).time, "2022-12-01T01:47:12.746202562+00:00");
     }


### PR DESCRIPTION
Here are a couple of ideas for how to make the tests less boilerplate-y. They are mostly minor helper methods but together I think they make the tests significantly more readable while also being more robust.

The most controversial parts are likely to be

* `fn expect_<effect>` to go along with `fn into_<effect>`
    - only saves a few keystrokes vs `into_<effect>().unwrap()` but I think it reads better
* Adding `#[must_use]` to the `Update` struct. This is to force the user to make it clear that they haven't forgotten that more stuff might happen in 'real life'
   - If we expect it to be empty, use `.assert_empty()`, otherwise write `let _update = ...` to silence the warning

I have ported a couple of tests to the new methods to illustrate how it might change how tests look. If we are happy with it I could expand the changes to all tests in the repo.