### PR TITLE
capability typegen feature must depend on core typegen

### DIFF
--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 default = ["encoding"]
 # requires web-sys for TextDecoder on wasm
 encoding = ["encoding_rs", "web-sys"]
-typegen = []
+typegen = ["crux_core/typegen"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crux_kv/Cargo.toml
+++ b/crux_kv/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 rust-version.workspace = true
 
 [features]
-typegen = []
+typegen = ["crux_core/typegen"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crux_time/Cargo.toml
+++ b/crux_time/Cargo.toml
@@ -11,7 +11,7 @@ keywords.workspace = true
 rust-version.workspace = true
 
 [features]
-typegen = []
+typegen = ["crux_core/typegen"]
 
 [dependencies]
 crux_core = { version = "0.9.0", path = "../crux_core" }


### PR DESCRIPTION
This was an oversight on previously released capabilities `crux_http`, `crux_kv` and `crux_time`, which could not be built for the `typegen` feature, because its dependency on `crux-core/typegen` was not specified.

It probably didn't end up affecting common usage because `crux-core` (with `typegen` enabled) is usually specified as a build dependency in the `shared_types` crates, but for correctness all features should be buildable.