### PR TITLE
`Clone` bound on `Operation` (breaking) and test helper methods

### DIFF
--- a/crux_core/src/capability/mod.rs
+++ b/crux_core/src/capability/mod.rs
@@ -213,7 +213,7 @@ use channel::Sender;
 ///     type Output = HttpResponse;
 /// }
 /// ```
-pub trait Operation: serde::Serialize + PartialEq + Send + 'static {
+pub trait Operation: serde::Serialize + Clone + PartialEq + Send + 'static {
     /// `Output` assigns the type this request results in.
     type Output: serde::de::DeserializeOwned + Send + 'static;
 }
@@ -238,7 +238,7 @@ pub trait Operation: serde::Serialize + PartialEq + Send + 'static {
 /// # }
 ///
 /// ```
-#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum Never {}
 
 /// Implement `Operation` for `Never` to allow using it as a capability operation.
@@ -258,7 +258,7 @@ impl Operation for Never {
 /// # pub struct Http<Ev> {
 /// #     context: CapabilityContext<HttpRequest, Ev>,
 /// # }
-/// # #[derive(serde::Serialize, serde::Deserialize, PartialEq, Eq)] pub struct HttpRequest;
+/// # #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)] pub struct HttpRequest;
 /// # impl Operation for HttpRequest {
 /// #     type Output = ();
 /// # }
@@ -372,8 +372,8 @@ pub trait WithContext<Ev, Ef> {
 /// For example (from `crux_time`)
 ///
 /// ```rust
-/// # #[derive(PartialEq,serde::Serialize)]pub struct TimeRequest;
-/// # #[derive(serde::Deserialize)]pub struct TimeResponse(pub String);
+/// # #[derive(Clone, PartialEq, serde::Serialize)] pub struct TimeRequest;
+/// # #[derive(Clone, serde::Deserialize)] pub struct TimeResponse(pub String);
 /// # impl crux_core::capability::Operation for TimeRequest {
 /// #     type Output = TimeResponse;
 /// # }
@@ -625,7 +625,7 @@ mod tests {
     #[allow(dead_code)]
     enum Event {}
 
-    #[derive(PartialEq, Serialize)]
+    #[derive(PartialEq, Clone, Serialize)]
     struct Op {}
 
     impl Operation for Op {

--- a/crux_core/src/capability/shell_request.rs
+++ b/crux_core/src/capability/shell_request.rs
@@ -119,7 +119,7 @@ mod tests {
 
     use crate::capability::{channel, executor_and_spawner, CapabilityContext, Operation};
 
-    #[derive(serde::Serialize, PartialEq, Eq, Debug)]
+    #[derive(serde::Serialize, Clone, PartialEq, Eq, Debug)]
     struct TestOperation;
 
     impl Operation for TestOperation {

--- a/crux_core/src/capability/shell_stream.rs
+++ b/crux_core/src/capability/shell_stream.rs
@@ -92,7 +92,7 @@ mod tests {
 
     use crate::capability::{channel, executor_and_spawner, CapabilityContext, Operation};
 
-    #[derive(serde::Serialize, PartialEq, Eq, Debug)]
+    #[derive(serde::Serialize, Clone, PartialEq, Eq, Debug)]
     struct TestOperation;
 
     impl Operation for TestOperation {

--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -210,7 +210,7 @@ impl<Ef, Ev> Update<Ef, Ev> {
     where
         P: FnMut(&Ef) -> bool,
     {
-        let (matching_effects, other_effects) = self.take_partitioned_effects(predicate);
+        let (matching_effects, other_effects) = self.take_effects_partitioned_by(predicate);
 
         self.effects = other_effects.into_iter().collect();
 
@@ -219,7 +219,7 @@ impl<Ef, Ev> Update<Ef, Ev> {
 
     /// Take all of the effects out of the [`Update`]
     /// and split them into those matching `predicate` and the rest
-    pub fn take_partitioned_effects<P>(&mut self, predicate: P) -> (VecDeque<Ef>, VecDeque<Ef>)
+    pub fn take_effects_partitioned_by<P>(&mut self, predicate: P) -> (VecDeque<Ef>, VecDeque<Ef>)
     where
         P: FnMut(&Ef) -> bool,
     {

--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -1,6 +1,6 @@
 //! Testing support for unit testing Crux apps.
 use anyhow::Result;
-use std::sync::Arc;
+use std::{collections::VecDeque, sync::Arc};
 
 use crate::{
     capability::{
@@ -202,6 +202,30 @@ impl<Ef, Ev> Update<Ef, Ev> {
             self.effects.len(),
             self.events.len()
         );
+    }
+
+    /// Take effects matching the `predicate` out of the [`Update`]
+    /// and return them, mutating the `Update`
+    pub fn take_effects<P>(&mut self, predicate: P) -> VecDeque<Ef>
+    where
+        P: FnMut(&Ef) -> bool,
+    {
+        let (matching_effects, other_effects) = self.take_partitioned_effects(predicate);
+
+        self.effects = other_effects.into_iter().collect();
+
+        matching_effects
+    }
+
+    /// Take all of the effects out of the [`Update`]
+    /// and split them into those matching `predicate` and the rest
+    pub fn take_partitioned_effects<P>(&mut self, predicate: P) -> (VecDeque<Ef>, VecDeque<Ef>)
+    where
+        P: FnMut(&Ef) -> bool,
+    {
+        std::mem::take(&mut self.effects)
+            .into_iter()
+            .partition(predicate)
     }
 }
 

--- a/crux_core/tests/capability_orchestration.rs
+++ b/crux_core/tests/capability_orchestration.rs
@@ -62,7 +62,7 @@ pub mod capabilities {
         use crux_core::macros::Capability;
         use serde::{Deserialize, Serialize};
 
-        #[derive(PartialEq, Serialize, Deserialize, Debug)]
+        #[derive(PartialEq, Clone, Serialize, Deserialize, Debug)]
         pub struct OpOne {
             number: usize,
         }
@@ -123,7 +123,7 @@ pub mod capabilities {
         use crux_core::macros::Capability;
         use serde::{Deserialize, Serialize};
 
-        #[derive(PartialEq, Serialize, Deserialize, Debug)]
+        #[derive(PartialEq, Clone, Serialize, Deserialize, Debug)]
         pub struct OpTwo {
             number: usize,
         }

--- a/crux_http/tests/with_tester.rs
+++ b/crux_http/tests/with_tester.rs
@@ -143,7 +143,7 @@ mod tests {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        let mut request = app
+        let request = &mut app
             .update(Event::Get, &mut model)
             .expect_one_effect()
             .expect_http();
@@ -157,7 +157,7 @@ mod tests {
 
         let actual = app
             .resolve(
-                &mut request,
+                request,
                 HttpResult::Ok(
                     HttpResponse::ok()
                         .json("hello")
@@ -186,7 +186,7 @@ mod tests {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        let mut request = app
+        let request = &mut app
             .update(Event::Post, &mut model)
             .expect_one_effect()
             .expect_http();
@@ -201,7 +201,7 @@ mod tests {
 
         let actual = app
             .resolve(
-                &mut request,
+                request,
                 HttpResult::Ok(HttpResponse::ok().json("The Body").build()),
             )
             .expect("Resolves successfully")
@@ -217,7 +217,7 @@ mod tests {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        let mut request = app
+        let request = &mut app
             .update(Event::GetPostChain, &mut model)
             .expect_one_effect()
             .expect_http();
@@ -227,9 +227,9 @@ mod tests {
             HttpRequest::get("http://example.com/").build()
         );
 
-        let mut request = app
+        let request = &mut app
             .resolve(
-                &mut request,
+                request,
                 HttpResult::Ok(HttpResponse::ok().body("secret_place").build()),
             )
             .expect("Resolves successfully")
@@ -242,10 +242,7 @@ mod tests {
         );
 
         let actual = app
-            .resolve(
-                &mut request,
-                HttpResult::Ok(HttpResponse::status(201).build()),
-            )
+            .resolve(request, HttpResult::Ok(HttpResponse::status(201).build()))
             .expect("Resolves successfully")
             .expect_one_event();
 
@@ -263,14 +260,14 @@ mod tests {
             .update(Event::ConcurrentGets, &mut model)
             .take_effects(Effect::is_http);
 
-        let mut request_one = requests.pop_front().unwrap().expect_http();
+        let request_one = &mut requests.pop_front().unwrap().expect_http();
 
         assert_eq!(
             request_one.operation,
             HttpRequest::get("http://example.com/one").build()
         );
 
-        let mut request_two = requests.pop_front().unwrap().expect_http();
+        let request_two = &mut requests.pop_front().unwrap().expect_http();
 
         assert_eq!(
             request_two.operation,
@@ -280,7 +277,7 @@ mod tests {
         // Resolve second request first, should not matter
         let update = app
             .resolve(
-                &mut request_two,
+                request_two,
                 HttpResult::Ok(HttpResponse::ok().body("one").build()),
             )
             .expect("Resolves successfully");
@@ -291,7 +288,7 @@ mod tests {
 
         let actual = app
             .resolve(
-                &mut request_one,
+                request_one,
                 HttpResult::Ok(HttpResponse::ok().body("one").build()),
             )
             .expect("Resolves successfully")
@@ -307,7 +304,7 @@ mod tests {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        let mut request = app
+        let request = &mut app
             .update(Event::Get, &mut model)
             .expect_one_effect()
             .expect_http();
@@ -321,7 +318,7 @@ mod tests {
 
         let actual = app
             .resolve(
-                &mut request,
+                request,
                 HttpResult::Err(crux_http::HttpError::Io(
                     "Socket shenanigans prevented the request".to_string(),
                 )),

--- a/crux_kv/src/tests.rs
+++ b/crux_kv/src/tests.rs
@@ -137,7 +137,7 @@ fn test_get() {
     let app = AppTester::<App, _>::default();
     let mut model = Model::default();
 
-    let mut request = app
+    let request = &mut app
         .update(Event::Get, &mut model)
         .expect_one_effect()
         .expect_key_value();
@@ -150,7 +150,7 @@ fn test_get() {
     );
 
     let _updated = app.resolve_to_event_then_update(
-        &mut request,
+        request,
         KeyValueResult::Ok {
             response: KeyValueResponse::Get {
                 value: 42i32.to_ne_bytes().to_vec().into(),
@@ -167,7 +167,7 @@ fn test_set() {
     let app = AppTester::<App, _>::default();
     let mut model = Model::default();
 
-    let mut request = app
+    let request = &mut app
         .update(Event::Set, &mut model)
         .expect_one_effect()
         .expect_key_value();
@@ -181,7 +181,7 @@ fn test_set() {
     );
 
     let _updated = app.resolve_to_event_then_update(
-        &mut request,
+        request,
         KeyValueResult::Ok {
             response: KeyValueResponse::Set {
                 previous: Value::None,
@@ -198,7 +198,7 @@ fn test_delete() {
     let app = AppTester::<App, _>::default();
     let mut model = Model::default();
 
-    let mut request = app
+    let request = &mut app
         .update(Event::Delete, &mut model)
         .expect_one_effect()
         .expect_key_value();
@@ -211,7 +211,7 @@ fn test_delete() {
     );
 
     let _updated = app.resolve_to_event_then_update(
-        &mut request,
+        request,
         KeyValueResult::Ok {
             response: KeyValueResponse::Delete {
                 previous: Value::None,
@@ -228,7 +228,7 @@ fn test_exists() {
     let app = AppTester::<App, _>::default();
     let mut model = Model::default();
 
-    let mut request = app
+    let request = &mut app
         .update(Event::Exists, &mut model)
         .expect_one_effect()
         .expect_key_value();
@@ -241,7 +241,7 @@ fn test_exists() {
     );
 
     let _updated = app.resolve_to_event_then_update(
-        &mut request,
+        request,
         KeyValueResult::Ok {
             response: KeyValueResponse::Exists { is_present: true },
         },
@@ -256,7 +256,7 @@ fn test_list_keys() {
     let app = AppTester::<App, _>::default();
     let mut model = Model::default();
 
-    let mut request = app
+    let request = &mut app
         .update(Event::ListKeys, &mut model)
         .expect_one_effect()
         .expect_key_value();
@@ -270,7 +270,7 @@ fn test_list_keys() {
     );
 
     let _updated = app.resolve_to_event_then_update(
-        &mut request,
+        request,
         KeyValueResult::Ok {
             response: KeyValueResponse::ListKeys {
                 keys: vec!["test:1".to_string(), "test:2".to_string()],
@@ -289,7 +289,7 @@ pub fn test_kv_async() -> Result<()> {
     let app = AppTester::<App, _>::default();
     let mut model = Model::default();
 
-    let mut request = app
+    let request = &mut app
         .update(Event::GetThenSet, &mut model)
         .expect_one_effect()
         .expect_key_value();
@@ -301,9 +301,9 @@ pub fn test_kv_async() -> Result<()> {
         }
     );
 
-    let mut request = app
+    let request = &mut app
         .resolve(
-            &mut request,
+            request,
             KeyValueResult::Ok {
                 response: KeyValueResponse::Get {
                     value: 17u32.to_ne_bytes().to_vec().into(),
@@ -323,7 +323,7 @@ pub fn test_kv_async() -> Result<()> {
     );
 
     let _updated = app.resolve_to_event_then_update(
-        &mut request,
+        request,
         KeyValueResult::Ok {
             response: KeyValueResponse::Set {
                 previous: Value::None,

--- a/crux_platform/src/lib.rs
+++ b/crux_platform/src/lib.rs
@@ -4,7 +4,7 @@ use crux_core::capability::{CapabilityContext, Operation};
 use crux_core::macros::Capability;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PlatformRequest;
 
 // TODO revisit this

--- a/crux_time/tests/time_test.rs
+++ b/crux_time/tests/time_test.rs
@@ -195,14 +195,14 @@ mod tests {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        let mut request = app
+        let request = &mut app
             .update(Event::GetAsync, &mut model)
             .expect_one_effect()
             .expect_time();
 
         let now: DateTime<Utc> = "2022-12-01T01:47:12.746202562+00:00".parse().unwrap();
         let response = TimeResponse::Now(now.try_into().unwrap());
-        let _update = app.resolve_to_event_then_update(&mut request, response, &mut model);
+        let _update = app.resolve_to_event_then_update(request, response, &mut model);
 
         assert_eq!(app.view(&model).time, "2022-12-01T01:47:12.746202562+00:00");
     }
@@ -212,18 +212,18 @@ mod tests {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        let mut request1 = app
+        let request1 = &mut app
             .update(Event::StartDebounce, &mut model)
             .expect_one_effect()
             .expect_time();
-        let mut request2 = app
+        let request2 = &mut app
             .update(Event::StartDebounce, &mut model)
             .expect_one_effect()
             .expect_time();
 
         // resolve and update
         app.resolve_to_event_then_update(
-            &mut request1,
+            request1,
             TimeResponse::DurationElapsed {
                 id: model.debounce_time_id.unwrap(),
             },
@@ -236,7 +236,7 @@ mod tests {
 
         // resolve and update
         app.resolve_to_event_then_update(
-            &mut request2,
+            request2,
             TimeResponse::DurationElapsed {
                 id: model.debounce_time_id.unwrap(),
             },
@@ -253,7 +253,7 @@ mod tests {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        let mut request1 = app
+        let request1 = &mut app
             .update(Event::StartDebounce, &mut model)
             .expect_one_effect()
             .expect_time();
@@ -261,7 +261,7 @@ mod tests {
         assert!(model.debounce_time_id.is_some());
 
         app.resolve_to_event_then_update(
-            &mut request1,
+            request1,
             TimeResponse::Cleared {
                 id: model.debounce_time_id.unwrap(),
             },

--- a/doctest_support/src/lib.rs
+++ b/doctest_support/src/lib.rs
@@ -5,7 +5,7 @@ pub mod compose {
             use crux_core::capability::{CapabilityContext, Operation};
             use serde::{Deserialize, Serialize};
 
-            #[derive(PartialEq, Serialize, Deserialize, Debug)]
+            #[derive(PartialEq, Clone, Serialize, Deserialize, Debug)]
             pub struct OpOne {
                 number: usize,
             }
@@ -79,7 +79,7 @@ pub mod compose {
             use crux_core::capability::{CapabilityContext, Operation};
             use serde::{Deserialize, Serialize};
 
-            #[derive(PartialEq, Serialize, Deserialize, Debug)]
+            #[derive(PartialEq, Clone, Serialize, Deserialize, Debug)]
             pub struct OpTwo {
                 number: usize,
             }

--- a/examples/bridge_echo/Cargo.toml
+++ b/examples/bridge_echo/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 anyhow = "1.0.90"
-crux_core = "0.9.0"
+crux_core = "0.9.1"
 serde = "1.0.210"
 
 [workspace.metadata.bin]

--- a/examples/bridge_echo/shared/src/app.rs
+++ b/examples/bridge_echo/shared/src/app.rs
@@ -58,7 +58,7 @@ impl crux_core::App for App {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crux_core::{assert_effect, testing::AppTester};
+    use crux_core::testing::AppTester;
 
     #[test]
     fn shows_initial_count() {
@@ -112,9 +112,9 @@ mod test {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        let update = app.update(Event::Tick, &mut model);
-
-        assert_effect!(update, Effect::Render(_));
+        app.update(Event::Tick, &mut model)
+            .expect_one_effect()
+            .expect_render();
     }
 
     #[test]
@@ -122,9 +122,9 @@ mod test {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        let update = app.update(Event::NewPeriod, &mut model);
-
-        assert_effect!(update, Effect::Render(_));
+        app.update(Event::NewPeriod, &mut model)
+            .expect_one_effect()
+            .expect_render();
     }
 }
 // ANCHOR_END: test

--- a/examples/cat_facts/Cargo.lock
+++ b/examples/cat_facts/Cargo.lock
@@ -144,12 +144,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_let_bind"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26da9bc03539eda841c2042fd584ee3982b652606f40dc9e7a828817eae79275"
-
-[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,9 +248,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "camino"
@@ -434,8 +428,6 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 [[package]]
 name = "crux_core"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7254d2fca79de45e1e595fa7d32a0d3d8bfec85ee02b250cc216af6b7f01162"
 dependencies = [
  "anyhow",
  "bincode",
@@ -454,8 +446,6 @@ dependencies = [
 [[package]]
 name = "crux_http"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0c2c59aee43cfd5a02ddf3eea264e59bc8317b731fa57905bfd62c4eb84c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -476,8 +466,6 @@ dependencies = [
 [[package]]
 name = "crux_kv"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5b90cf04e92216c2a5c4a878bd832b220ca70238228f271323be95585d7c1d"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -489,8 +477,6 @@ dependencies = [
 [[package]]
 name = "crux_macros"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6628a214f3754bdea8f05bf9ebbe62cd6bff48f7a4bea52ecb14cbd1743484ad"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -502,8 +488,6 @@ dependencies = [
 [[package]]
 name = "crux_platform"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea670b8e6fa544ea8f9cd435624eea4d763d867298a8e7575ee71bcdd0859452"
 dependencies = [
  "crux_core",
  "serde",
@@ -512,8 +496,6 @@ dependencies = [
 [[package]]
 name = "crux_time"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705d7974afd4343ae6f52dd588ff74b5a383c212232324be7449b6b7342ce08f"
 dependencies = [
  "chrono",
  "crux_core",
@@ -2247,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.211"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "1ac55e59090389fb9f0dd9e0f3c09615afed1d19094284d0b200441f13550793"
 dependencies = [
  "serde_derive",
 ]
@@ -2312,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.211"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "54be4f245ce16bc58d57ef2716271d0d4519e0f6defa147f6e081005bcb278ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2369,7 +2351,6 @@ dependencies = [
 name = "shared"
 version = "0.1.0"
 dependencies = [
- "assert_let_bind",
  "chrono",
  "crux_core",
  "crux_http",

--- a/examples/cat_facts/Cargo.toml
+++ b/examples/cat_facts/Cargo.toml
@@ -12,11 +12,16 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 anyhow = "1.0.90"
-crux_core = "0.9.0"
-crux_http = "0.10.1"
-crux_kv = "0.5.0"
-crux_platform = "0.2.0"
-crux_time = { version = "0.5.0", features = ["chrono"] }
+crux_core = { path = "../../crux_core" }
+crux_http = { path = "../../crux_http" }
+crux_kv = { path = "../../crux_kv" }
+crux_platform = { path = "../../crux_platform" }
+crux_time = { path = "../../crux_time", features = ["chrono"] }
+# crux_core = "0.9.1"
+# crux_http = "0.10.2"
+# crux_kv = "0.5.1"
+# crux_platform = "0.2.1"
+# crux_time = { version = "0.5.1", features = ["chrono"] }
 serde = "1.0.210"
 
 [workspace.metadata.bin]

--- a/examples/cat_facts/shared/Cargo.toml
+++ b/examples/cat_facts/shared/Cargo.toml
@@ -24,9 +24,6 @@ serde_json = "1.0.132"
 uniffi = "0.28.2"
 wasm-bindgen = "0.2.95"
 
-[dev-dependencies]
-assert_let_bind = "0.1.1"
-
 [target.uniffi-bindgen.dependencies]
 uniffi = { version = "0.28.2", features = ["cli"] }
 

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -231,7 +231,7 @@ mod tests {
         // send fetch event to app
         let (mut http_effects, mut render_effects) = app
             .update(Event::Fetch, &mut model)
-            .take_partitioned_effects(|e| e.is_http());
+            .take_effects_partitioned_by(Effect::is_http);
 
         // receive render effect
         render_effects.pop_front().unwrap().expect_render();
@@ -282,7 +282,7 @@ mod tests {
         // and check that we get a key value set event and a render event
         let (mut key_value_effects, mut render_effects) = app
             .update(event, &mut model)
-            .take_partitioned_effects(|e| e.is_key_value());
+            .take_effects_partitioned_by(Effect::is_key_value);
         render_effects.pop_front().unwrap().expect_render();
 
         let mut request = key_value_effects.pop_front().unwrap().expect_key_value();

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -246,17 +246,20 @@ mod tests {
             length: 13,
         };
 
-        let response = HttpResult::Ok(
-            HttpResponse::ok()
-                .body(r#"{ "fact": "cats are good", "length": 13 }"#)
-                .build(),
-        );
-
+        // resolve the request with a simulated response from the web API
         let event = app
-            .resolve(&mut request, response)
+            .resolve(
+                &mut request,
+                HttpResult::Ok(
+                    HttpResponse::ok()
+                        .body(r#"{ "fact": "cats are good", "length": 13 }"#)
+                        .build(),
+                ),
+            )
             .expect("should resolve successfully")
             .expect_one_event();
 
+        // check that the app emitted an (internal) event to update the model
         assert_eq!(
             event,
             Event::SetFact(Ok(ResponseBuilder::ok().body(a_fact.clone()).build()))

--- a/examples/cat_facts/shared/src/app/platform.rs
+++ b/examples/cat_facts/shared/src/app/platform.rs
@@ -47,7 +47,6 @@ impl crux_core::App for App {
 
 #[cfg(test)]
 mod tests {
-    use assert_let_bind::assert_let;
     use crux_core::testing::AppTester;
     use crux_platform::PlatformResponse;
 
@@ -58,17 +57,15 @@ mod tests {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        let mut update = app.update(Event::Get, &mut model);
-
-        assert_let!(Effect::Platform(request), &mut update.effects[0]);
+        let mut request = app
+            .update(Event::Get, &mut model)
+            .expect_one_effect()
+            .expect_platform();
 
         let response = PlatformResponse("platform".to_string());
-        let update = app
-            .resolve(request, response)
-            .expect("should resolve successfully");
-        for event in update.events {
-            let _ = app.update(event, &mut model);
-        }
+        app.resolve_to_event_then_update(&mut request, response, &mut model)
+            .expect_one_effect()
+            .expect_render();
 
         assert_eq!(model.platform, "platform");
         assert_eq!(app.view(&model).platform, "Hello platform");

--- a/examples/cat_facts/shared/src/app/platform.rs
+++ b/examples/cat_facts/shared/src/app/platform.rs
@@ -57,13 +57,13 @@ mod tests {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        let mut request = app
+        let request = &mut app
             .update(Event::Get, &mut model)
             .expect_one_effect()
             .expect_platform();
 
         let response = PlatformResponse("platform".to_string());
-        app.resolve_to_event_then_update(&mut request, response, &mut model)
+        app.resolve_to_event_then_update(request, response, &mut model)
             .expect_one_effect()
             .expect_render();
 

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -159,12 +159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_let_bind"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26da9bc03539eda841c2042fd584ee3982b652606f40dc9e7a828817eae79275"
-
-[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,8 +1013,6 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 [[package]]
 name = "crux_core"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7254d2fca79de45e1e595fa7d32a0d3d8bfec85ee02b250cc216af6b7f01162"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1039,8 +1031,6 @@ dependencies = [
 [[package]]
 name = "crux_http"
 version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0c2c59aee43cfd5a02ddf3eea264e59bc8317b731fa57905bfd62c4eb84c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1061,8 +1051,6 @@ dependencies = [
 [[package]]
 name = "crux_macros"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6628a214f3754bdea8f05bf9ebbe62cd6bff48f7a4bea52ecb14cbd1743484ad"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -5584,7 +5572,6 @@ dependencies = [
 name = "shared"
 version = "0.1.0"
 dependencies = [
- "assert_let_bind",
  "async-sse",
  "async-std",
  "chrono",

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -20,8 +20,10 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 anyhow = "1.0.90"
-crux_core = "0.9.1"
-crux_http = "0.10.2"
+crux_core = { path = "../../crux_core" }
+crux_http = { path = "../../crux_http" }
+# crux_core = "0.9.1"
+# crux_http = "0.10.2"
 serde = "1.0.210"
 
 [workspace.metadata.bin]

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -20,8 +20,8 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 anyhow = "1.0.90"
-crux_core = "0.9.0"
-crux_http = "0.10.1"
+crux_core = "0.9.1"
+crux_http = "0.10.2"
 serde = "1.0.210"
 
 [workspace.metadata.bin]

--- a/examples/counter/shared/Cargo.toml
+++ b/examples/counter/shared/Cargo.toml
@@ -26,7 +26,6 @@ url = "2.5.2"
 wasm-bindgen = "0.2.95"
 
 [dev-dependencies]
-assert_let_bind = "0.1.1"
 insta = { version = "1.40.0", features = ["yaml"] }
 
 [target.uniffi-bindgen.dependencies]

--- a/examples/counter/shared/src/app.rs
+++ b/examples/counter/shared/src/app.rs
@@ -151,7 +151,7 @@ mod tests {
 
         // check that the app emitted an HTTP request,
         // capturing the request in the process
-        let mut request = update.expect_one_effect().expect_http();
+        let request = &mut update.expect_one_effect().expect_http();
 
         // check that the request is a GET to the correct URL
         let actual = request.operation.clone();
@@ -163,7 +163,7 @@ mod tests {
             .body(r#"{ "value": 1, "updated_at": 1672531200000 }"#)
             .build();
         let update = app
-            .resolve(&mut request, HttpResult::Ok(response))
+            .resolve(request, HttpResult::Ok(response))
             .expect("an update");
 
         // check that the app emitted an (internal) event to update the model
@@ -244,7 +244,7 @@ mod tests {
 
         // check that the app also emitted an HTTP request,
         // capturing the request in the process
-        let mut request = http.pop_front().unwrap().expect_http();
+        let request = &mut http.pop_front().unwrap().expect_http();
 
         // check that the request is a POST to the correct URL
         let actual = &request.operation;
@@ -256,7 +256,7 @@ mod tests {
             .body(r#"{ "value": 2, "updated_at": 1672531200000 }"#)
             .build();
         let _updated =
-            app.resolve_to_event_then_update(&mut request, HttpResult::Ok(response), &mut model);
+            app.resolve_to_event_then_update(request, HttpResult::Ok(response), &mut model);
 
         // check that the model has been updated correctly
         insta::assert_yaml_snapshot!(model, @r###"
@@ -302,7 +302,7 @@ mod tests {
 
         // check that the app also emitted an HTTP request,
         // capturing the request in the process
-        let mut request = http.pop_front().unwrap().expect_http();
+        let request = &mut http.pop_front().unwrap().expect_http();
 
         // check that the request is a POST to the correct URL
         let actual = &request.operation;
@@ -314,7 +314,7 @@ mod tests {
             .body(r#"{ "value": -1, "updated_at": 1672531200000 }"#)
             .build();
         let _updated =
-            app.resolve_to_event_then_update(&mut request, HttpResult::Ok(response), &mut model);
+            app.resolve_to_event_then_update(request, HttpResult::Ok(response), &mut model);
 
         // check that the model has been updated correctly
         insta::assert_yaml_snapshot!(model, @r###"
@@ -335,11 +335,12 @@ mod tests {
             .expect_one_effect()
             .expect_sse();
 
-        let actual = &request.operation;
-        let expected = &SseRequest {
-            url: "https://crux-counter.fly.dev/sse".to_string(),
-        };
-        assert_eq!(actual, expected);
+        assert_eq!(
+            request.operation,
+            SseRequest {
+                url: "https://crux-counter.fly.dev/sse".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/examples/counter/shared/src/app.rs
+++ b/examples/counter/shared/src/app.rs
@@ -127,7 +127,6 @@ mod tests {
     use super::{App, Event, Model};
     use crate::capabilities::sse::SseRequest;
     use crate::{Count, Effect};
-    use assert_let_bind::assert_let;
     use chrono::{TimeZone, Utc};
     use crux_core::{assert_effect, testing::AppTester};
     use crux_http::protocol::HttpResult;
@@ -148,15 +147,15 @@ mod tests {
         let mut model = Model::default();
 
         // send a `Get` event to the app
-        let mut update = app.update(Event::Get, &mut model);
+        let update = app.update(Event::Get, &mut model);
 
         // check that the app emitted an HTTP request,
         // capturing the request in the process
-        assert_let!(Effect::Http(request), &mut update.effects[0]);
+        let mut request = update.expect_one_effect().expect_http();
 
         // check that the request is a GET to the correct URL
-        let actual = &request.operation;
-        let expected = &HttpRequest::get("https://crux-counter.fly.dev/").build();
+        let actual = request.operation.clone();
+        let expected = HttpRequest::get("https://crux-counter.fly.dev/").build();
         assert_eq!(actual, expected);
 
         // resolve the request with a simulated response from the web API
@@ -164,7 +163,7 @@ mod tests {
             .body(r#"{ "value": 1, "updated_at": 1672531200000 }"#)
             .build();
         let update = app
-            .resolve(request, HttpResult::Ok(response))
+            .resolve(&mut request, HttpResult::Ok(response))
             .expect("an update");
 
         // check that the app emitted an (internal) event to update the model
@@ -227,8 +226,11 @@ mod tests {
         // send an `Increment` event to the app
         let mut update = app.update(Event::Increment, &mut model);
 
+        // split the effects into render and HTTP requests
+        let (mut render, mut http) = update.take_partitioned_effects(|e| e.is_render());
+
         // check that the app asked the shell to render
-        assert_effect!(update, Effect::Render(_));
+        render.pop_front().unwrap().expect_render();
 
         // we are expecting our model to be updated "optimistically" before the
         // HTTP request completes, so the value should have been updated
@@ -242,7 +244,7 @@ mod tests {
 
         // check that the app also emitted an HTTP request,
         // capturing the request in the process
-        assert_let!(Effect::Http(request), &mut update.effects[1]);
+        let mut request = http.pop_front().unwrap().expect_http();
 
         // check that the request is a POST to the correct URL
         let actual = &request.operation;
@@ -253,12 +255,8 @@ mod tests {
         let response = HttpResponse::ok()
             .body(r#"{ "value": 2, "updated_at": 1672531200000 }"#)
             .build();
-        let update = app
-            .resolve(request, HttpResult::Ok(response))
-            .expect("Update to succeed");
-
-        // send the generated (internal) `Set` event back into the app
-        let _ = app.update(update.events[0].clone(), &mut model);
+        let _updated =
+            app.resolve_to_event_then_update(&mut request, HttpResult::Ok(response), &mut model);
 
         // check that the model has been updated correctly
         insta::assert_yaml_snapshot!(model, @r###"
@@ -286,8 +284,11 @@ mod tests {
         // send a `Decrement` event to the app
         let mut update = app.update(Event::Decrement, &mut model);
 
+        // split the effects into render and HTTP requests
+        let (mut render, mut http) = update.take_partitioned_effects(|e| e.is_render());
+
         // check that the app asked the shell to render
-        assert_effect!(update, Effect::Render(_));
+        render.pop_front().unwrap().expect_render();
 
         // we are expecting our model to be updated "optimistically" before the
         // HTTP request completes, so the value should have been updated
@@ -301,7 +302,7 @@ mod tests {
 
         // check that the app also emitted an HTTP request,
         // capturing the request in the process
-        assert_let!(Effect::Http(request), &mut update.effects[1]);
+        let mut request = http.pop_front().unwrap().expect_http();
 
         // check that the request is a POST to the correct URL
         let actual = &request.operation;
@@ -312,15 +313,8 @@ mod tests {
         let response = HttpResponse::ok()
             .body(r#"{ "value": -1, "updated_at": 1672531200000 }"#)
             .build();
-        let update = app
-            .resolve(request, HttpResult::Ok(response))
-            .expect("a successful update");
-
-        // run the event loop in order to send the (internal) `Set` event
-        // back into the app
-        for event in update.events {
-            let _ = app.update(event, &mut model);
-        }
+        let _updated =
+            app.resolve_to_event_then_update(&mut request, HttpResult::Ok(response), &mut model);
 
         // check that the model has been updated correctly
         insta::assert_yaml_snapshot!(model, @r###"
@@ -336,9 +330,10 @@ mod tests {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        let update = app.update(Event::StartWatch, &mut model);
-
-        assert_let!(Effect::ServerSentEvents(request), &update.effects[0]);
+        let request = app
+            .update(Event::StartWatch, &mut model)
+            .expect_one_effect()
+            .expect_sse();
 
         let actual = &request.operation;
         let expected = &SseRequest {
@@ -358,9 +353,9 @@ mod tests {
         };
         let event = Event::Update(count);
 
-        let update = app.update(event, &mut model);
-
-        assert_effect!(update, Effect::Render(_));
+        app.update(event, &mut model)
+            .expect_one_effect()
+            .expect_render();
 
         // check that the model has been updated correctly
         insta::assert_yaml_snapshot!(model, @r###"

--- a/examples/counter/shared/src/app.rs
+++ b/examples/counter/shared/src/app.rs
@@ -227,7 +227,7 @@ mod tests {
         let mut update = app.update(Event::Increment, &mut model);
 
         // split the effects into render and HTTP requests
-        let (mut render, mut http) = update.take_partitioned_effects(|e| e.is_render());
+        let (mut render, mut http) = update.take_effects_partitioned_by(Effect::is_render);
 
         // check that the app asked the shell to render
         render.pop_front().unwrap().expect_render();
@@ -285,7 +285,7 @@ mod tests {
         let mut update = app.update(Event::Decrement, &mut model);
 
         // split the effects into render and HTTP requests
-        let (mut render, mut http) = update.take_partitioned_effects(|e| e.is_render());
+        let (mut render, mut http) = update.take_effects_partitioned_by(Effect::is_render);
 
         // check that the app asked the shell to render
         render.pop_front().unwrap().expect_render();

--- a/examples/hello_world/Cargo.lock
+++ b/examples/hello_world/Cargo.lock
@@ -242,8 +242,6 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 [[package]]
 name = "crux_core"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7254d2fca79de45e1e595fa7d32a0d3d8bfec85ee02b250cc216af6b7f01162"
 dependencies = [
  "anyhow",
  "bincode",
@@ -262,8 +260,6 @@ dependencies = [
 [[package]]
 name = "crux_macros"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6628a214f3754bdea8f05bf9ebbe62cd6bff48f7a4bea52ecb14cbd1743484ad"
 dependencies = [
  "darling",
  "proc-macro-error",

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 anyhow = "1.0.90"
-crux_core = "0.9.0"
+crux_core = "0.9.1"
 serde = "1.0.210"
 
 [workspace.metadata.bin]

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -12,7 +12,8 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 anyhow = "1.0.90"
-crux_core = "0.9.1"
+crux_core = { path = "../../crux_core" }
+# crux_core = "0.9.1"
 serde = "1.0.210"
 
 [workspace.metadata.bin]

--- a/examples/hello_world/shared/src/app.rs
+++ b/examples/hello_world/shared/src/app.rs
@@ -47,7 +47,7 @@ impl App for Hello {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crux_core::{assert_effect, testing::AppTester};
+    use crux_core::testing::AppTester;
 
     #[test]
     fn hello_says_hello_world() {
@@ -58,7 +58,7 @@ mod tests {
         let update = hello.update(Event::None, &mut model);
 
         // Check update asked us to `Render`
-        assert_effect!(update, Effect::Render(_));
+        update.expect_one_effect().expect_render();
 
         // Make sure the view matches our expectations
         let actual_view = &hello.view(&model).data;

--- a/examples/notes/Cargo.lock
+++ b/examples/notes/Cargo.lock
@@ -301,8 +301,6 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 [[package]]
 name = "crux_core"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7254d2fca79de45e1e595fa7d32a0d3d8bfec85ee02b250cc216af6b7f01162"
 dependencies = [
  "anyhow",
  "bincode",
@@ -321,8 +319,6 @@ dependencies = [
 [[package]]
 name = "crux_kv"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce5b90cf04e92216c2a5c4a878bd832b220ca70238228f271323be95585d7c1d"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -334,8 +330,6 @@ dependencies = [
 [[package]]
 name = "crux_macros"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6628a214f3754bdea8f05bf9ebbe62cd6bff48f7a4bea52ecb14cbd1743484ad"
 dependencies = [
  "darling",
  "proc-macro-error",

--- a/examples/notes/Cargo.toml
+++ b/examples/notes/Cargo.toml
@@ -12,8 +12,10 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 anyhow = "1.0"
-crux_core = "0.9.1"
-crux_kv = "0.5.1"
+crux_core = { path = "../../crux_core" }
+crux_kv = { path = "../../crux_kv" }
+# crux_core = "0.9.1"
+# crux_kv = "0.5.1"
 serde = "1.0"
 
 [workspace.metadata.bin]

--- a/examples/notes/Cargo.toml
+++ b/examples/notes/Cargo.toml
@@ -12,8 +12,8 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 anyhow = "1.0"
-crux_core = "0.9.0"
-crux_kv = "0.5.0"
+crux_core = "0.9.1"
+crux_kv = "0.5.1"
 serde = "1.0"
 
 [workspace.metadata.bin]

--- a/examples/notes/shared/src/app.rs
+++ b/examples/notes/shared/src/app.rs
@@ -561,9 +561,9 @@ mod save_load_tests {
         // this will eventually take a document ID
         let mut requests = app
             .update(Event::Open, &mut model)
-            .take_effects(|e| e.is_key_value());
+            .take_effects(Effect::is_key_value);
 
-        let mut request = requests.pop_front().unwrap().expect_key_value();
+        let request = &mut requests.pop_front().unwrap().expect_key_value();
         assert_eq!(
             request.operation,
             KeyValueOperation::Get {
@@ -579,7 +579,7 @@ mod save_load_tests {
                 value: note.save().into(),
             },
         };
-        let update = app.resolve_to_event_then_update(&mut request, response, &mut model);
+        let update = app.resolve_to_event_then_update(request, response, &mut model);
         assert_effect!(update, Effect::Render(_));
 
         assert_eq!(app.view(&model).text, "LOADED");
@@ -600,7 +600,7 @@ mod save_load_tests {
             .update(Event::Open, &mut model)
             .take_effects(Effect::is_key_value);
 
-        let mut request = requests.pop_front().unwrap().expect_key_value();
+        let request = &mut requests.pop_front().unwrap().expect_key_value();
         assert_eq!(
             request.operation,
             KeyValueOperation::Get {
@@ -613,7 +613,7 @@ mod save_load_tests {
         // Read was unsuccessful
         let event = app
             .resolve(
-                &mut request,
+                request,
                 KeyValueResult::Ok {
                     response: KeyValueResponse::Get { value: Value::None },
                 },
@@ -652,7 +652,7 @@ mod save_load_tests {
             .into_effects()
             .filter_map(Effect::into_timer);
 
-        let mut request = requests.next().unwrap();
+        let request = &mut requests.next().unwrap();
         assert_let!(
             TimerOperation::Start {
                 id: first_id,
@@ -665,7 +665,7 @@ mod save_load_tests {
 
         // Tells app the timer was created
         let update = app
-            .resolve(&mut request, TimerOutput::Created { id: first_id })
+            .resolve(request, TimerOutput::Created { id: first_id })
             .unwrap();
         for event in update.events {
             println!("Event: {event:?}");

--- a/examples/notes/shared/src/app.rs
+++ b/examples/notes/shared/src/app.rs
@@ -330,8 +330,9 @@ mod editing_tests {
             ..Default::default()
         };
 
-        let update = app.update(Event::MoveCursor(5), &mut model);
-        assert_effect!(update, Effect::Render(_));
+        app.update(Event::MoveCursor(5), &mut model)
+            .expect_one_effect()
+            .expect_render();
 
         let view = app.view(&model);
 
@@ -349,8 +350,9 @@ mod editing_tests {
             ..Default::default()
         };
 
-        let update = app.update(Event::Select(2, 5), &mut model);
-        assert_effect!(update, Effect::Render(_));
+        app.update(Event::Select(2, 5), &mut model)
+            .expect_one_effect()
+            .expect_render();
 
         let view = app.view(&model);
 
@@ -557,14 +559,19 @@ mod save_load_tests {
         };
 
         // this will eventually take a document ID
-        let update = app.update(Event::Open, &mut model);
-        let requests = &mut update.into_effects().filter_map(Effect::into_key_value);
+        let mut requests = app
+            .update(Event::Open, &mut model)
+            .take_effects(|e| e.is_key_value());
 
-        let mut request = requests.next().unwrap();
-        assert_let!(KeyValueOperation::Get { key }, &request.operation);
-        assert_eq!(key, "note");
+        let mut request = requests.pop_front().unwrap().expect_key_value();
+        assert_eq!(
+            request.operation,
+            KeyValueOperation::Get {
+                key: "note".to_string()
+            }
+        );
 
-        assert!(requests.next().is_none());
+        assert!(requests.is_empty());
 
         // Read was successful
         let response = KeyValueResult::Ok {
@@ -572,13 +579,8 @@ mod save_load_tests {
                 value: note.save().into(),
             },
         };
-        let update = app.resolve(&mut request, response).unwrap();
-        assert_eq!(update.events.len(), 1);
-
-        for e in update.events {
-            let update = app.update(e, &mut model);
-            assert_effect!(update, Effect::Render(_));
-        }
+        let update = app.resolve_to_event_then_update(&mut request, response, &mut model);
+        assert_effect!(update, Effect::Render(_));
 
         assert_eq!(app.view(&model).text, "LOADED");
     }
@@ -596,36 +598,42 @@ mod save_load_tests {
         // this will eventually take a document ID
         let requests = &mut app
             .update(Event::Open, &mut model)
-            .into_effects()
-            .filter_map(Effect::into_key_value);
+            .take_effects(Effect::is_key_value);
 
-        let mut request = requests.next().unwrap();
-        assert_let!(KeyValueOperation::Get { key }, &request.operation);
-        assert_eq!(key, "note");
+        let mut request = requests.pop_front().unwrap().expect_key_value();
+        assert_eq!(
+            request.operation,
+            KeyValueOperation::Get {
+                key: "note".to_string()
+            }
+        );
 
-        assert!(requests.next().is_none());
+        assert!(requests.is_empty());
 
         // Read was unsuccessful
-        let update = app
+        let event = app
             .resolve(
                 &mut request,
                 KeyValueResult::Ok {
                     response: KeyValueResponse::Get { value: Value::None },
                 },
             )
+            .unwrap()
+            .expect_one_event();
+
+        let save = app
+            .update(event, &mut model)
+            .into_effects()
+            .find_map(Effect::into_key_value)
             .unwrap();
-        assert_eq!(update.events.len(), 1);
 
-        for e in update.events {
-            let save = app
-                .update(e, &mut model)
-                .into_effects()
-                .find_map(Effect::into_key_value)
-                .unwrap();
-
-            assert_let!(KeyValueOperation::Set { key, value: _ }, &save.operation);
-            assert_eq!(key, "note");
-        }
+        assert_eq!(
+            save.operation,
+            KeyValueOperation::Set {
+                key: "note".to_string(),
+                value: model.note.save().into(),
+            }
+        );
     }
 
     #[test]
@@ -691,24 +699,20 @@ mod save_load_tests {
         assert!(requests.next().is_none());
 
         // Tell app the second timer was created
-        let update = app
-            .resolve(start_request, TimerOutput::Created { id: second_id })
-            .unwrap();
-        for event in update.events {
-            println!("Event: {event:?}");
-            let _ = app.update(event, &mut model);
-        }
+        let _updated = app.resolve_to_event_then_update(
+            start_request,
+            TimerOutput::Created { id: second_id },
+            &mut model,
+        );
 
         // Time passes
 
         // Fire the timer
-        let update = app
-            .resolve(start_request, TimerOutput::Finished { id: second_id })
-            .unwrap();
-        for event in update.events {
-            println!("Event: {event:?}");
-            let _ = app.update(event, &mut model);
-        }
+        let _updated = app.resolve_to_event_then_update(
+            start_request,
+            TimerOutput::Finished { id: second_id },
+            &mut model,
+        );
 
         // One more edit. Should result in a timer, but not in cancellation
         let update = app.update(Event::Backspace, &mut model);
@@ -748,13 +752,13 @@ mod save_load_tests {
             .find_map(Effect::into_key_value)
             .unwrap();
 
-        assert_let!(
-            KeyValueOperation::Set { key, value },
-            &write_request.operation
+        assert_eq!(
+            write_request.operation,
+            KeyValueOperation::Set {
+                key: "note".to_string(),
+                value: model.note.save().into()
+            }
         );
-
-        assert_eq!(key, "note");
-        assert_eq!(value, &model.note.save());
     }
 }
 

--- a/examples/tap_to_pay/Cargo.toml
+++ b/examples/tap_to_pay/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.68"
 
 [workspace.dependencies]
 anyhow = "1.0.90"
-crux_core = "0.9.0"
+crux_core = "0.9.1"
 serde = "1.0.210"
 
 [workspace.metadata.bin]


### PR DESCRIPTION
- Adds a `Clone` bound on  the `Operation` trait so that we can examine the operation and still resolve its owning request later on — this is a breaking change.
- Adds a `take_effects` method on `Update` to allow you to take effects off the Update that match the predicate
- Adds a `take_effects_partitioned_by` method on `Update` to allow you to take effects off the Update that match the predicate and also the remaining effects that don't match
- Updates all the crates' tests and the examples' tests to make use of these new testing helpers (and the ones already released in `crux_core` 0.9.0 and 0.9.1)
- Note: the examples now reference local crates, but I'll change that after the helpers are published