### PR TITLE
must_use on app.update()

### DIFF
--- a/examples/bridge_echo/Cargo.lock
+++ b/examples/bridge_echo/Cargo.lock
@@ -447,9 +447,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crux_core"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4f3d9faf1f5cbce21e41950cdcc9df9f6a946420a434737741b0e6b15aebbb"
+checksum = "f7254d2fca79de45e1e595fa7d32a0d3d8bfec85ee02b250cc216af6b7f01162"
 dependencies = [
  "anyhow",
  "bincode",
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bd454f045322bf00e9618fdbcfe0ea8f12051ceacb67f244e7c79b4152d23e"
+checksum = "6628a214f3754bdea8f05bf9ebbe62cd6bff48f7a4bea52ecb14cbd1743484ad"
 dependencies = [
  "darling",
  "proc-macro-error",

--- a/examples/bridge_echo/shared/src/app.rs
+++ b/examples/bridge_echo/shared/src/app.rs
@@ -76,9 +76,9 @@ mod test {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        app.update(Event::Tick, &mut model);
-        app.update(Event::Tick, &mut model);
-        app.update(Event::Tick, &mut model);
+        let _ = app.update(Event::Tick, &mut model);
+        let _ = app.update(Event::Tick, &mut model);
+        let _ = app.update(Event::Tick, &mut model);
 
         let actual_view = app.view(&model);
         let expected_view = ViewModel { count: 3 };
@@ -91,14 +91,14 @@ mod test {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        app.update(Event::Tick, &mut model);
-        app.update(Event::Tick, &mut model);
-        app.update(Event::Tick, &mut model);
-        app.update(Event::NewPeriod, &mut model);
-        app.update(Event::Tick, &mut model);
-        app.update(Event::Tick, &mut model);
-        app.update(Event::NewPeriod, &mut model);
-        app.update(Event::Tick, &mut model);
+        let _ = app.update(Event::Tick, &mut model);
+        let _ = app.update(Event::Tick, &mut model);
+        let _ = app.update(Event::Tick, &mut model);
+        let _ = app.update(Event::NewPeriod, &mut model);
+        let _ = app.update(Event::Tick, &mut model);
+        let _ = app.update(Event::Tick, &mut model);
+        let _ = app.update(Event::NewPeriod, &mut model);
+        let _ = app.update(Event::Tick, &mut model);
 
         let expected = Model {
             log: vec![3, 2],

--- a/examples/cat_facts/Cargo.lock
+++ b/examples/cat_facts/Cargo.lock
@@ -433,9 +433,9 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crux_core"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4f3d9faf1f5cbce21e41950cdcc9df9f6a946420a434737741b0e6b15aebbb"
+checksum = "f7254d2fca79de45e1e595fa7d32a0d3d8bfec85ee02b250cc216af6b7f01162"
 dependencies = [
  "anyhow",
  "bincode",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5fb65e45d44626e340b6605bb92c8d87b4342e090cfa548f913746a2ebdc999"
+checksum = "bf0c2c59aee43cfd5a02ddf3eea264e59bc8317b731fa57905bfd62c4eb84c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -475,21 +475,22 @@ dependencies = [
 
 [[package]]
 name = "crux_kv"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed3640a5be1a460c6b258f5d30b6fbf9463eeadbea01368fc9600e726ac8d9c"
+checksum = "ce5b90cf04e92216c2a5c4a878bd832b220ca70238228f271323be95585d7c1d"
 dependencies = [
  "anyhow",
  "crux_core",
  "serde",
+ "serde_bytes",
  "thiserror",
 ]
 
 [[package]]
 name = "crux_macros"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bd454f045322bf00e9618fdbcfe0ea8f12051ceacb67f244e7c79b4152d23e"
+checksum = "6628a214f3754bdea8f05bf9ebbe62cd6bff48f7a4bea52ecb14cbd1743484ad"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -500,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "crux_platform"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f429df9750ccf0a0d603888f1a88f84ea62a828fd3355ad16efc7411678efd7e"
+checksum = "ea670b8e6fa544ea8f9cd435624eea4d763d867298a8e7575ee71bcdd0859452"
 dependencies = [
  "crux_core",
  "serde",
@@ -510,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "crux_time"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12084e1472d98794210f5568edf69112e830a48ba7e7029a4d454433d643ef7b"
+checksum = "705d7974afd4343ae6f52dd588ff74b5a383c212232324be7449b6b7342ce08f"
 dependencies = [
  "chrono",
  "crux_core",

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -271,7 +271,7 @@ mod tests {
         assert_eq!(update.events, vec![Event::SetFact(Ok(expected_response))]);
 
         for event in update.events {
-            app.update(event, &mut model);
+            let _ = app.update(event, &mut model);
         }
 
         assert_let!(Effect::Http(request), effects.next().unwrap());
@@ -288,7 +288,7 @@ mod tests {
             .resolve(request, response)
             .expect("should resolve successfully");
         for event in update.events {
-            app.update(event, &mut model);
+            let _ = app.update(event, &mut model);
         }
 
         assert_eq!(model.cat_fact, Some(a_fact));

--- a/examples/cat_facts/shared/src/app/platform.rs
+++ b/examples/cat_facts/shared/src/app/platform.rs
@@ -67,7 +67,7 @@ mod tests {
             .resolve(request, response)
             .expect("should resolve successfully");
         for event in update.events {
-            app.update(event, &mut model);
+            let _ = app.update(event, &mut model);
         }
 
         assert_eq!(model.platform, "platform");

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -489,17 +489,6 @@ checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
 name = "brotli"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
@@ -1029,9 +1018,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crux_core"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4f3d9faf1f5cbce21e41950cdcc9df9f6a946420a434737741b0e6b15aebbb"
+checksum = "f7254d2fca79de45e1e595fa7d32a0d3d8bfec85ee02b250cc216af6b7f01162"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1049,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5fb65e45d44626e340b6605bb92c8d87b4342e090cfa548f913746a2ebdc999"
+checksum = "bf0c2c59aee43cfd5a02ddf3eea264e59bc8317b731fa57905bfd62c4eb84c80"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1071,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bd454f045322bf00e9618fdbcfe0ea8f12051ceacb67f244e7c79b4152d23e"
+checksum = "6628a214f3754bdea8f05bf9ebbe62cd6bff48f7a4bea52ecb14cbd1743484ad"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -3334,7 +3323,19 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
 dependencies = [
- "jsonptr",
+ "jsonptr 0.4.7",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "json-patch"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "863726d7afb6bc2590eeff7135d923545e5e964f004c2ccf8716c25e70a86f08"
+dependencies = [
+ "jsonptr 0.6.3",
  "serde",
  "serde_json",
  "thiserror",
@@ -3347,6 +3348,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
 dependencies = [
  "fluent-uri",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dea2b27dd239b2556ed7a25ba842fe47fd602e7fc7433c2a8d6106d4d9edd70"
+dependencies = [
  "serde",
  "serde_json",
 ]
@@ -3959,7 +3970,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.82",
@@ -5943,9 +5954,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce2818e803ce3097987296623ed8c0d9f65ed93b4137ff9a83e168bdbf62932"
+checksum = "d3889b392db6d32a105d3757230ea0220090b8f94c90d3e60b6c5eb91178ab1b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5993,16 +6004,16 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935f9b3c49b22b3e2e485a57f46d61cd1ae07b1cbb2ba87387a387caf2d8c4e7"
+checksum = "9f96827ccfb1aa40d55d0ded79562d18ba18566657a553f992a982d755148376"
 dependencies = [
  "anyhow",
  "cargo_toml",
  "dirs",
  "glob",
  "heck 0.5.0",
- "json-patch",
+ "json-patch 3.0.1",
  "schemars",
  "semver",
  "serde",
@@ -6015,14 +6026,14 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d7443dd4f0b597704b6a14b964ee2ed16e99928d8e6292ae9825f09fbcd30e"
+checksum = "8947f16f47becd9e9cd39b74ee337fd1981574d78819be18e4384d85e5a0b82f"
 dependencies = [
  "base64 0.22.1",
- "brotli 6.0.0",
+ "brotli",
  "ico",
- "json-patch",
+ "json-patch 2.0.0",
  "plist",
  "png",
  "proc-macro2",
@@ -6042,9 +6053,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2c0963ccfc3f5194415f2cce7acc975942a8797fbabfb0aa1ed6f59326ae7f"
+checksum = "8bd1c8d4a66799d3438747c3a79705cd665a95d6f24cb5f315413ff7a981fe2a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6056,9 +6067,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8f437293d6f5e5dce829250f4dbdce4e0b52905e297a6689cc2963eb53ac728"
+checksum = "a1ef7363e7229ac8d04e8a5d405670dbd43dde8fc4bc3bc56105c35452d03784"
 dependencies = [
  "dpi",
  "gtk",
@@ -6105,14 +6116,14 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc65d6f5c54e56b66258948a6d9e47a82ea41f4b5a7612bfbdd1634c2913ed0"
 dependencies = [
- "brotli 7.0.0",
+ "brotli",
  "cargo_metadata 0.18.1",
  "ctor",
  "dunce",
  "glob",
  "html5ever",
  "infer 0.16.0",
- "json-patch",
+ "json-patch 2.0.0",
  "kuchikiki",
  "log",
  "memchr",
@@ -7555,9 +7566,9 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.46.2"
+version = "0.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa1c8c760041c64ce6be99f83d6cb55fe3fcd85a1ad46d32895f6e65cee87ba"
+checksum = "cd5cdf57c66813d97601181349c63b96994b3074fc3d7a31a8cce96e968e3bbd"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/examples/counter/shared/src/app.rs
+++ b/examples/counter/shared/src/app.rs
@@ -258,7 +258,7 @@ mod tests {
             .expect("Update to succeed");
 
         // send the generated (internal) `Set` event back into the app
-        app.update(update.events[0].clone(), &mut model);
+        let _ = app.update(update.events[0].clone(), &mut model);
 
         // check that the model has been updated correctly
         insta::assert_yaml_snapshot!(model, @r###"
@@ -319,7 +319,7 @@ mod tests {
         // run the event loop in order to send the (internal) `Set` event
         // back into the app
         for event in update.events {
-            app.update(event, &mut model);
+            let _ = app.update(event, &mut model);
         }
 
         // check that the model has been updated correctly

--- a/examples/hello_world/Cargo.lock
+++ b/examples/hello_world/Cargo.lock
@@ -241,9 +241,9 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crux_core"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4f3d9faf1f5cbce21e41950cdcc9df9f6a946420a434737741b0e6b15aebbb"
+checksum = "f7254d2fca79de45e1e595fa7d32a0d3d8bfec85ee02b250cc216af6b7f01162"
 dependencies = [
  "anyhow",
  "bincode",
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bd454f045322bf00e9618fdbcfe0ea8f12051ceacb67f244e7c79b4152d23e"
+checksum = "6628a214f3754bdea8f05bf9ebbe62cd6bff48f7a4bea52ecb14cbd1743484ad"
 dependencies = [
  "darling",
  "proc-macro-error",

--- a/examples/notes/Cargo.lock
+++ b/examples/notes/Cargo.lock
@@ -300,9 +300,9 @@ checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crux_core"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4f3d9faf1f5cbce21e41950cdcc9df9f6a946420a434737741b0e6b15aebbb"
+checksum = "f7254d2fca79de45e1e595fa7d32a0d3d8bfec85ee02b250cc216af6b7f01162"
 dependencies = [
  "anyhow",
  "bincode",
@@ -320,21 +320,22 @@ dependencies = [
 
 [[package]]
 name = "crux_kv"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed3640a5be1a460c6b258f5d30b6fbf9463eeadbea01368fc9600e726ac8d9c"
+checksum = "ce5b90cf04e92216c2a5c4a878bd832b220ca70238228f271323be95585d7c1d"
 dependencies = [
  "anyhow",
  "crux_core",
  "serde",
+ "serde_bytes",
  "thiserror",
 ]
 
 [[package]]
 name = "crux_macros"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bd454f045322bf00e9618fdbcfe0ea8f12051ceacb67f244e7c79b4152d23e"
+checksum = "6628a214f3754bdea8f05bf9ebbe62cd6bff48f7a4bea52ecb14cbd1743484ad"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -957,6 +958,15 @@ dependencies = [
  "once_cell",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/examples/notes/shared/src/app.rs
+++ b/examples/notes/shared/src/app.rs
@@ -661,7 +661,7 @@ mod save_load_tests {
             .unwrap();
         for event in update.events {
             println!("Event: {event:?}");
-            app.update(event, &mut model);
+            let _ = app.update(event, &mut model);
         }
 
         // Before the timer fires, insert another character, which should
@@ -696,7 +696,7 @@ mod save_load_tests {
             .unwrap();
         for event in update.events {
             println!("Event: {event:?}");
-            app.update(event, &mut model);
+            let _ = app.update(event, &mut model);
         }
 
         // Time passes
@@ -707,7 +707,7 @@ mod save_load_tests {
             .unwrap();
         for event in update.events {
             println!("Event: {event:?}");
-            app.update(event, &mut model);
+            let _ = app.update(event, &mut model);
         }
 
         // One more edit. Should result in a timer, but not in cancellation

--- a/examples/simple_counter/Cargo.lock
+++ b/examples/simple_counter/Cargo.lock
@@ -503,9 +503,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crux_core"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4f3d9faf1f5cbce21e41950cdcc9df9f6a946420a434737741b0e6b15aebbb"
+checksum = "f7254d2fca79de45e1e595fa7d32a0d3d8bfec85ee02b250cc216af6b7f01162"
 dependencies = [
  "anyhow",
  "bincode",
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bd454f045322bf00e9618fdbcfe0ea8f12051ceacb67f244e7c79b4152d23e"
+checksum = "6628a214f3754bdea8f05bf9ebbe62cd6bff48f7a4bea52ecb14cbd1743484ad"
 dependencies = [
  "darling",
  "proc-macro-error",

--- a/examples/simple_counter/shared/src/app.rs
+++ b/examples/simple_counter/shared/src/app.rs
@@ -116,8 +116,8 @@ mod test {
         let app = AppTester::<Counter, _>::default();
         let mut model = Model::default();
 
-        app.update(Event::Increment, &mut model);
-        app.update(Event::Reset, &mut model);
+        let _ = app.update(Event::Increment, &mut model);
+        let _ = app.update(Event::Reset, &mut model);
 
         let actual_view = app.view(&model).count;
         let expected_view = "Count is: 0";
@@ -129,11 +129,11 @@ mod test {
         let app = AppTester::<Counter, _>::default();
         let mut model = Model::default();
 
-        app.update(Event::Increment, &mut model);
-        app.update(Event::Reset, &mut model);
-        app.update(Event::Decrement, &mut model);
-        app.update(Event::Increment, &mut model);
-        app.update(Event::Increment, &mut model);
+        let _ = app.update(Event::Increment, &mut model);
+        let _ = app.update(Event::Reset, &mut model);
+        let _ = app.update(Event::Decrement, &mut model);
+        let _ = app.update(Event::Increment, &mut model);
+        let _ = app.update(Event::Increment, &mut model);
 
         let actual_view = app.view(&model).count;
         let expected_view = "Count is: 1";

--- a/examples/tap_to_pay/shared/src/app.rs
+++ b/examples/tap_to_pay/shared/src/app.rs
@@ -168,7 +168,7 @@ mod tests {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        app.update(Event::SetAmount(1000), &mut model);
+        let _ = app.update(Event::SetAmount(1000), &mut model);
         let view = app.view(&model);
 
         assert_eq!(
@@ -176,7 +176,7 @@ mod tests {
             Screen::Payment(payment(1000, PaymentStatus::New))
         );
 
-        app.update(Event::StartPayment, &mut model);
+        let _ = app.update(Event::StartPayment, &mut model);
         let view = app.view(&model);
 
         assert_eq!(
@@ -197,7 +197,7 @@ mod tests {
         // Time passed
         let update = app.resolve(request, ()).expect("should resolve");
         for event in update.events {
-            app.update(event, &mut model);
+            let _ = app.update(event, &mut model);
         }
 
         let view = app.view(&model);
@@ -206,7 +206,7 @@ mod tests {
             Screen::Payment(payment(1000, PaymentStatus::Completed(Receipt::default())))
         );
 
-        app.update(
+        let _ = app.update(
             Event::SetReceiptEmail("bob@fake.com".to_string()),
             &mut model,
         );
@@ -239,7 +239,7 @@ mod tests {
         // Time passed
         let update = app.resolve(request, ()).expect("should update");
         for event in update.events {
-            app.update(event, &mut model);
+            let _ = app.update(event, &mut model);
         }
 
         let view = app.view(&model);
@@ -253,7 +253,7 @@ mod tests {
             Screen::Payment(payment(1000, PaymentStatus::Completed(expected_receipt)))
         );
 
-        app.update(Event::CompletePayment, &mut model);
+        let _ = app.update(Event::CompletePayment, &mut model);
         let view = app.view(&model);
 
         assert_eq!(view.screen, Screen::Payment(Payment::default()));
@@ -264,8 +264,8 @@ mod tests {
         let app = AppTester::<App, _>::default();
         let mut model = Model::default();
 
-        app.update(Event::SetAmount(0), &mut model);
-        app.update(Event::StartPayment, &mut model);
+        let _ = app.update(Event::SetAmount(0), &mut model);
+        let _ = app.update(Event::StartPayment, &mut model);
 
         let actual = app.view(&model);
         let expected = ViewModel {


### PR DESCRIPTION
Update tests in examples to use the return value from `app.update()`.

This is temporary  and will be succeeded by https://github.com/redbadger/crux/pull/280