### PR TITLE
crux_time API improvement

### DIFF
--- a/crux_time/src/lib.rs
+++ b/crux_time/src/lib.rs
@@ -44,7 +44,7 @@ fn get_timer_id() -> TimerId {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum TimeResponse {
-    Now(Instant),
+    Now { instant: Instant },
     InstantArrived { id: TimerId },
     DurationElapsed { id: TimerId },
     Cleared { id: TimerId },
@@ -300,10 +300,15 @@ mod test {
 
     #[test]
     fn test_serializing_the_response_types_as_json() {
-        let now = TimeResponse::Now(Instant::new(1, 2).expect("valid instant"));
+        let now = TimeResponse::Now {
+            instant: Instant::new(1, 2).expect("valid instant"),
+        };
 
         let serialized = serde_json::to_string(&now).unwrap();
-        assert_eq!(&serialized, r#"{"now":{"seconds":1,"nanos":2}}"#);
+        assert_eq!(
+            &serialized,
+            r#"{"now":{"instant":{"seconds":1,"nanos":2}}}"#
+        );
 
         let deserialized: TimeResponse = serde_json::from_str(&serialized).unwrap();
         assert_eq!(now, deserialized);

--- a/crux_time/tests/time_test.rs
+++ b/crux_time/tests/time_test.rs
@@ -66,8 +66,8 @@ mod shared {
                     }
                 }),
                 Event::Set(time) => {
-                    if let TimeResponse::Now(time) = time {
-                        let time: DateTime<Utc> = time.try_into().unwrap();
+                    if let TimeResponse::Now { instant } = time {
+                        let time: DateTime<Utc> = instant.try_into().unwrap();
                         model.time = time.to_rfc3339();
                         caps.render.render()
                     }
@@ -155,8 +155,8 @@ mod shell {
 
             let effs = match msg {
                 Some(CoreMessage::Event(m)) => core.process_event(m),
-                Some(CoreMessage::Response(Outcome::Time(mut request, result))) => {
-                    core.resolve(&mut request, TimeResponse::Now(result))
+                Some(CoreMessage::Response(Outcome::Time(mut request, instant))) => {
+                    core.resolve(&mut request, TimeResponse::Now { instant })
                 }
                 _ => vec![],
             };
@@ -205,7 +205,9 @@ mod tests {
             .expect_time();
 
         let now: DateTime<Utc> = "2022-12-01T01:47:12.746202562+00:00".parse().unwrap();
-        let response = TimeResponse::Now(now.try_into().unwrap());
+        let response = TimeResponse::Now {
+            instant: now.try_into().unwrap(),
+        };
         let _update = app.resolve_to_event_then_update(request, response, &mut model);
 
         assert_eq!(app.view(&model).time, "2022-12-01T01:47:12.746202562+00:00");


### PR DESCRIPTION
This is a suggestion to remove the `id: TimerId` argument from various `crux_time` APIs. In my opinion it doesn't make sense to provide this value, it should be considered an opaque type useful only inside `crux_time` (so perhaps consider removing the ability to independently create `TimerId`s too). YMMV!

Obviously this is a *breaking change*.