### PR TITLE
Drop model to avoid deadlock

### DIFF
--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -83,6 +83,9 @@ where
 
         self.app.update(event, &mut model, &self.capabilities);
 
+        // drop the model here, we don't want to hold the lock for the process() call
+        drop(model);
+
         self.process()
     }
     // ANCHOR_END: process_event


### PR DESCRIPTION
Under certain specific circumstances, it was possible cause a deadlock due to not dropping a lock on the model.

I haven't yet worked out exactly why/when this happens (or rather, why it doesn't happen always/often), but here's the fix.