### PR TITLE
(WIP) RFC: Command abstraction for effects

### DIFF
--- a/crux_core/src/capability/executor.rs
+++ b/crux_core/src/capability/executor.rs
@@ -116,6 +116,8 @@ impl QueuingExecutor {
                         // until all remaining work is 'unavailable', at which point we will bail
                         // out of the loop, leaving the queued work to be finished by another thread.
                         // This strategy should avoid dropping work or busy-looping
+                        // FIXME: are we potentially sending ourselves `Unavailable` and reading it
+                        // in a loop - busy looping here?
                         self.ready_sender.send(task_id).expect("could not requeue");
                     }
                     RunTask::Missing => {

--- a/crux_core/src/capability/shell_request.rs
+++ b/crux_core/src/capability/shell_request.rs
@@ -26,10 +26,19 @@ impl ShellRequest<()> {
     }
 }
 
+// State shared between the ShellRequest future itself and the
+// Request's resolve callback. The resolve callback is responsible
+// for advancing the state from Pending to Complete
+//
+// FIXME this should be a tri-state enum instead:
+// - ReadyToSend(Box<dyn FnOnce() + Send + 'static>)
+// - Pending(Waker)
+// - Complete(T)
 struct SharedState<T> {
+    // the effect's output
     result: Option<T>,
-    waker: Option<Waker>,
     send_request: Option<Box<dyn FnOnce() + Send + 'static>>,
+    waker: Option<Waker>,
 }
 
 impl<T> Future for ShellRequest<T> {

--- a/crux_core/src/command/mod.rs
+++ b/crux_core/src/command/mod.rs
@@ -1,0 +1,163 @@
+use std::future::Future;
+use std::sync::Arc;
+use std::task::{Context, Wake};
+
+use crossbeam_channel::{Receiver, Sender}; // TODO: do we want to use capability channel here?
+use futures::future;
+use futures::task::ArcWake;
+use futures::FutureExt;
+use slab::Slab;
+
+use crate::capability::Operation;
+use crate::Request;
+
+#[derive(Clone, Copy, Debug)]
+struct TaskId(usize);
+
+type BoxFuture = future::BoxFuture<'static, ()>;
+
+pub struct Command<Effect> {
+    effects: Receiver<Effect>,
+    ready_queue: Receiver<TaskId>,
+    tasks: Slab<BoxFuture>,
+}
+
+pub struct CommandContext<Effect> {
+    effects: Sender<Effect>,
+}
+
+impl<Effect> CommandContext<Effect> {
+    fn notify_shell<Op>(&self, operation: Op)
+    where
+        Op: Operation,
+        Effect: From<Request<Op>>,
+    {
+        let request = Request::resolves_never(operation);
+
+        self.effects
+            .send(request.into())
+            .expect("Could not send notification, effect channel disconnected");
+    }
+}
+
+impl<Effect> Command<Effect>
+where
+    Effect: Send + 'static,
+{
+    pub fn new<F, Fut>(create_task: F) -> Self
+    where
+        F: FnOnce(CommandContext<Effect>) -> Fut,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        let (effect_sender, effect_receiver) = crossbeam_channel::unbounded();
+        let (ready_sender, ready_receiver) = crossbeam_channel::unbounded();
+
+        let context = CommandContext {
+            effects: effect_sender,
+        };
+
+        let task = create_task(context).boxed();
+        let mut tasks = Slab::with_capacity(1);
+        let task_id = TaskId(tasks.insert(task));
+
+        ready_sender
+            .send(task_id)
+            .expect("Could not make task ready, ready channel disconnected");
+
+        Command {
+            effects: effect_receiver,
+            ready_queue: ready_receiver,
+            tasks,
+        }
+    }
+
+    pub fn done() -> Self {
+        let (_, effects) = crossbeam_channel::bounded(0);
+        let (_, ready_queue) = crossbeam_channel::bounded(0);
+
+        Command {
+            effects,
+            ready_queue,
+            tasks: Slab::new(),
+        }
+    }
+
+    pub fn notify_shell<Op>(operation: Op) -> Self
+    where
+        Op: Operation,
+        Effect: From<Request<Op>>,
+    {
+        Command::new(|ctx| async move { ctx.notify_shell(operation) })
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.tasks.is_empty()
+    }
+
+    pub fn effects(&mut self) -> Vec<Effect> {
+        self.run_until_settled();
+
+        self.effects.try_iter().collect()
+    }
+}
+
+struct CommandWaker {
+    task_id: TaskId,
+}
+
+impl Wake for CommandWaker {
+    fn wake(self: Arc<Self>) {
+        self.wake_by_ref();
+    }
+
+    fn wake_by_ref(self: &Arc<Self>) {
+        // TODO: actually notify the command,
+        // otherwise we're stuck on the first .await point
+    }
+}
+
+enum TaskState {
+    Missing,
+    Suspended,
+    Completed,
+}
+
+// Command is actually an async executor of sorts
+impl<Effect> Command<Effect> {
+    // Run all tasks until all of them are pending
+    fn run_until_settled(&mut self) {
+        while let Ok(task_id) = self.ready_queue.try_recv() {
+            match self.run_task(task_id) {
+                TaskState::Missing => {
+                    // The task has been evicted because it completed.  This can happen when
+                    // a _running_ task schedules itself to wake, but then completes and gets
+                    // removed
+                }
+                TaskState::Suspended => {
+                    // Task suspended, we pick it up again when it's woken up
+                }
+                TaskState::Completed => {
+                    // Remove and drop the task it's finished
+                    drop(self.tasks.remove(task_id.0));
+                }
+            }
+        }
+    }
+
+    fn run_task(&mut self, task_id: TaskId) -> TaskState {
+        let Some(task) = self.tasks.get_mut(task_id.0) else {
+            return TaskState::Missing;
+        };
+
+        let waker = Arc::new(CommandWaker { task_id }).into();
+        let context = &mut Context::from_waker(&waker);
+
+        match task.as_mut().poll(context) {
+            std::task::Poll::Pending => TaskState::Suspended,
+            std::task::Poll::Ready(_) => TaskState::Completed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crux_core/src/command/tests/mod.rs
+++ b/crux_core/src/command/tests/mod.rs
@@ -1,0 +1,41 @@
+mod basic {
+    use super::super::Command;
+    use crate::{render::RenderOperation, Request};
+
+    enum Effect {
+        Render(Request<RenderOperation>),
+    }
+
+    impl From<Request<RenderOperation>> for Effect {
+        fn from(request: Request<RenderOperation>) -> Self {
+            Self::Render(request)
+        }
+    }
+
+    #[test]
+    fn done_can_be_created() {
+        let cmd: Command<Effect> = Command::done();
+
+        assert!(cmd.is_done())
+    }
+
+    #[test]
+    fn notify_can_be_created_with_an_operation() {
+        let cmd: Command<Effect> = Command::notify_shell(RenderOperation);
+
+        assert!(!cmd.is_done())
+    }
+
+    #[test]
+    fn notify_effect_can_be_inspected() {
+        let mut cmd = Command::notify_shell(RenderOperation);
+
+        let mut effects = cmd.effects();
+
+        assert!(!effects.is_empty());
+
+        let Effect::Render(request) = effects.remove(0);
+
+        assert_eq!(request.operation, RenderOperation)
+    }
+}

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -156,6 +156,7 @@ pub mod testing;
 pub mod typegen;
 
 mod capabilities;
+mod command;
 mod core;
 
 use serde::Serialize;
@@ -163,6 +164,7 @@ use serde::Serialize;
 pub use self::{
     capabilities::*,
     capability::{Capability, WithContext},
+    command::Command,
     core::{Core, Effect, Request},
 };
 pub use crux_macros as macros;


### PR DESCRIPTION
**NOTE**: This is veru much WIP, so only basic notes for anyone interested. I'll update the description when the implementation is complete to the initial draft.

This is a revised effect API which attempts to go back to the original signature of `App::update`, which returned a `Command` - an abstraction for the requested effects. 

Command is the async effect state machine produced by a single update call. 
* The succinct explanation is that commands are the effect runtime extracted into a self-contained type
* Commands can be created directly with a shell notification / request / stream or an app event to send next
* Commands can also be created with a callback that returns a future. It gets access to a type similar to the curent CapabilityContext, which lets the future send shell requests and events _and_ spawn other futures
* All the produced effects and events are collected and surfaced by the command
  * this is useful for testing, and removes the need for `AppTester` for basic testing 
  * this _also_ enables additional flexibility for "hosting" or virtualising commands when composing apps, for example all the HTTP effects coming out of a child app could be transformed into a websocket effect and later resolved back to HTTP. Longshot, but could be handy
* Command is itself a future. It's similar to [FuturesUnordered](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.13/futures/stream/struct.FuturesUnordered.html) - when polled it polles one or more child futures until they either settle (then it's pending), or complete (then it's ready). This means that 
  * Commands should run just fine on the existing executor
  * Capability APIs can simply create commands and potentially work with the same API in sync and async contexts (except need to solve how effects and events get patched through from the command up in an async context)
* Command can be "hosted" - given effect and event channels to send into, so that it can be run on the existing executor without changes. This might be removed later in favour of the executor having special handling for commands, where it actively reads the effects and events from them and hands them to the core.
* Commands compose to get basic concurrency without the `async` ceremonies, with APIs like `.then`, and combinators like `join`, `join_all` and `select`. We _might_ get those for free as a consequence of Commands being futures.
* Commands support mapping and enable nicer app composition with more flexibility. One can `map_effect` and `map_event` on a Comand instance to adapt a child app command to the parent app. The mapping can therefore be different for different calls to child `update` (e.g. patching events through to a _different_ child app and other crazy business) 

This should have some nice side-effects like
* Capabilities won't need context any more, they just become Command creators and focus on defining the shell protocol
* Apps will declare their own `Effect` type  instead of Capabilities type and a macro derived Effect (although we can help define it with macros still)
* Async code as a "last resort" for effect composition, only when it's actually more convenient than combinator nonsense 
* Compose capability can go away - commands support all of that directly
* No need for AppTester - commands can be inspectd and driven by tests directly

### TODO

- [x] basic creation for a no-op
- [x] shell notifications
- [ ] events to app
- [ ] shell requests
- [ ] shell streams
- [ ] spawning further tasks from inside commands
- [ ] Command combinators
- [ ] Mapping for app composition

Obviously there's also work to make sure everything is backwards compatible with current stuff and there's a decent migration path.