### PR TITLE
`crux-time` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "crux_core"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -402,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "crux_kv"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -413,7 +413,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "crux_core",
  "crux_http",
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "crux_platform"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "crux_core",
  "serde",
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "crux_time"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "crux_core",

--- a/crux_core/CHANGELOG.md
+++ b/crux_core/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/redbadger/crux/compare/crux_core-v0.10.0...crux_core-v0.10.1) - 2025-01-07
+
+### Other
+
+- [drop model to avoid deadlock](https://github.com/redbadger/crux/pull/287)
+
 ## [0.10.0](https://github.com/redbadger/crux/compare/crux_core-v0.9.1...crux_core-v0.10.0) - 2024-10-23
 
 Several additional methods to help with testing Crux apps:

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_core"
 description = "Cross-platform app development in Rust"
-version = "0.10.0"
+version = "0.10.1"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true
@@ -20,7 +20,7 @@ all-features = true
 anyhow.workspace = true
 bincode = "1.3.3"
 crossbeam-channel = "0.5.13"
-crux_macros = { version = "0.4.1", path = "../crux_macros" }
+crux_macros = { version = "0.4.2", path = "../crux_macros" }
 erased-serde = "0.4"
 futures = "0.3.31"
 serde = { workspace = true, features = ["derive"] }

--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -8,11 +8,17 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.10.4](https://github.com/redbadger/crux/compare/crux_http-v0.10.3...crux_http-v0.10.4) - 2025-01-07
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.10.3](https://github.com/redbadger/crux/compare/crux_http-v0.10.2...crux_http-v0.10.3) - 2024-10-23
 
 ### Other
 
-- tidy and docs udpate
+- tidy and docs update
 - update http and kv tests to use new API
 
 ## [0.10.2](https://github.com/redbadger/crux/compare/crux_http-v0.10.1...crux_http-v0.10.2) - 2024-20-21

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_http"
 description = "HTTP capability for use with crux_core"
-version = "0.10.3"
+version = "0.10.4"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true
@@ -19,7 +19,7 @@ typegen = ["crux_core/typegen"]
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1.83"
-crux_core = { version = "0.10.0", path = "../crux_core" }
+crux_core = { version = "0.10.1", path = "../crux_core" }
 derive_builder = "0.20.2"
 encoding_rs = { version = "0.8.34", optional = true }
 futures-util = "0.3"

--- a/crux_kv/CHANGELOG.md
+++ b/crux_kv/CHANGELOG.md
@@ -8,11 +8,17 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.5.3](https://github.com/redbadger/crux/compare/crux_kv-v0.5.2...crux_kv-v0.5.3) - 2025-01-07
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.5.2](https://github.com/redbadger/crux/compare/crux_kv-v0.5.1...crux_kv-v0.5.2) - 2024-10-23
 
 ### Other
 
-- tidy and docs udpate
+- tidy and docs update
 - update http and kv tests to use new API
 
 ## [0.5.1](https://github.com/redbadger/crux/compare/crux_kv-v0.5.0...crux_kv-v0.5.1) - 2024-20-21

--- a/crux_kv/Cargo.toml
+++ b/crux_kv/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_kv"
 description = "Key-Value capability for use with crux_core"
-version = "0.5.2"
+version = "0.5.3"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ typegen = ["crux_core/typegen"]
 
 [dependencies]
 anyhow.workspace = true
-crux_core = { version = "0.10.0", path = "../crux_core" }
+crux_core = { version = "0.10.1", path = "../crux_core" }
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = "0.11.15"
 thiserror = "1.0.65"

--- a/crux_macros/CHANGELOG.md
+++ b/crux_macros/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/redbadger/crux/compare/crux_macros-v0.4.1...crux_macros-v0.4.2) - 2025-01-07
+
+### Other
+
+- deps
+
 ## [0.4.1](https://github.com/redbadger/crux/compare/crux_macros-v0.4.0...crux_macros-v0.4.1) - 2024-20-21
 
 - no changes, just updated dependencies

--- a/crux_macros/Cargo.toml
+++ b/crux_macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_macros"
 description = "Macros for use with crux_core"
-version = "0.4.1"
+version = "0.4.2"
 authors.workspace = true
 repository.workspace = true
 edition.workspace = true

--- a/crux_platform/CHANGELOG.md
+++ b/crux_platform/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/redbadger/crux/compare/crux_platform-v0.2.2...crux_platform-v0.2.3) - 2025-01-07
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.2.2](https://github.com/redbadger/crux/compare/crux_platform-v0.2.1...crux_platform-v0.2.2) - 2024-10-23
 
 ### Other

--- a/crux_platform/Cargo.toml
+++ b/crux_platform/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_platform"
 description = "Platform capability for use with crux_core"
-version = "0.2.2"
+version = "0.2.3"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true
@@ -11,5 +11,5 @@ keywords.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-crux_core = { version = "0.10.0", path = "../crux_core" }
+crux_core = { version = "0.10.1", path = "../crux_core" }
 serde = { workspace = true, features = ["derive"] }

--- a/crux_time/CHANGELOG.md
+++ b/crux_time/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/redbadger/crux/compare/crux_time-v0.6.0...crux_time-v0.7.0) - 2025-01-07
+
+### Breaking change
+
+The API has been improved, which is a breaking change. More details in these PR descriptions:
+
+- [crux_time API improvement](https://github.com/redbadger/crux/pull/284)
+- [Cancelling a timer also aborts the cancelled task](https://github.com/redbadger/crux/pull/292)
+
+
+### Other
+
+- :Now is struct-like
+- improve crux_time API
+- remove pin_project
+- add some more comments
+- cancelling a timer also aborts the cancelled task
+
 ## [0.6.0](https://github.com/redbadger/crux/compare/crux_time-v0.5.1...crux_time-v0.6.0) - 2024-10-23
 
 ### Added
@@ -17,7 +35,7 @@ and this project adheres to
 
 ### Other
 
-- tidy and docs udpate
+- tidy and docs update
 - remove unused test event
 
 ## [0.5.1](https://github.com/redbadger/crux/compare/crux_time-v0.5.0...crux_time-v0.5.1) - 2024-10-21

--- a/crux_time/Cargo.toml
+++ b/crux_time/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_time"
 description = "Time capability for use with crux_core"
-version = "0.6.0"
+version = "0.7.0"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true
@@ -15,7 +15,7 @@ typegen = ["crux_core/typegen"]
 
 [dependencies]
 chrono = { version = "0.4.38", features = ["serde"], optional = true }
-crux_core = { version = "0.10.0", path = "../crux_core" }
+crux_core = { version = "0.10.1", path = "../crux_core" }
 serde = { workspace = true, features = ["derive"] }
 thiserror = "1.0.65"
 


### PR DESCRIPTION
## Major release of `crux_time`: v0.7.0

The API has been improved, which is a breaking change. More details in these PR descriptions:

- [crux_time API improvement](https://github.com/redbadger/crux/pull/284)
- [Cancelling a timer also aborts the cancelled task](https://github.com/redbadger/crux/pull/292)

## Minor release of other crates