### PR TITLE
http capability: add body_form to http request builder

### DIFF
--- a/crux_http/src/request_builder.rs
+++ b/crux_http/src/request_builder.rs
@@ -230,7 +230,7 @@ where
 
     /// Pass form data as the request body. The form data needs to be
     /// serializable to name-value pairs.
-    /// 
+    ///
     /// # Mime
     ///
     /// The `content-type` is set to `application/x-www-form-urlencoded`.
@@ -241,7 +241,7 @@ where
     /// form data.
     ///
     /// # Examples
-    /// 
+    ///
     /// ```no_run
     /// # use std::collections::HashMap;
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }

--- a/crux_http/src/request_builder.rs
+++ b/crux_http/src/request_builder.rs
@@ -228,6 +228,40 @@ where
         self.body(Body::from(bytes.as_ref()))
     }
 
+    /// Pass form data as the request body. The form data needs to be
+    /// serializable to name-value pairs.
+    /// 
+    /// # Mime
+    ///
+    /// The `content-type` is set to `application/x-www-form-urlencoded`.
+    ///
+    /// # Errors
+    ///
+    /// An error will be returned if the provided data cannot be serialized to
+    /// form data.
+    ///
+    /// # Examples
+    /// 
+    /// ```no_run
+    /// # use std::collections::HashMap;
+    /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
+    /// # struct Capabilities { http: crux_http::Http<Event> }
+    /// # fn update(caps: &Capabilities) {
+    /// let form_data = HashMap::from([
+    ///     ("name", "Alice"),
+    ///     ("location", "UK"),
+    /// ]);
+    /// caps.http
+    ///     .post("https://httpbin.org/post")
+    ///     .body_form(&form_data)
+    ///     .expect("could not serialize body")
+    ///     .send(Event::ReceiveResponse)
+    /// # }
+    /// ```
+    pub fn body_form(self, form: &impl Serialize) -> crate::Result<Self> {
+        Ok(self.body(Body::from_form(form)?))
+    }
+
     /// Set the URL querystring.
     ///
     /// # Examples


### PR DESCRIPTION
For the http capability... Following the same pattern as constructing other body types (body as bytes plus specific content-type header), this little change adds the ability to create a body for posting forms. Any name-value pair structure that can be serialised and url-encoded can be used as the data type. The doc comment example uses a HashMap for instance.