### PR TITLE
Command support in Core

### DIFF
--- a/crux_core/src/bridge/mod.rs
+++ b/crux_core/src/bridge/mod.rs
@@ -5,7 +5,6 @@ use bincode::{DefaultOptions, Options};
 use erased_serde::Serialize as _;
 use serde::{Deserialize, Serialize};
 
-use crate::Effect;
 use crate::{App, Core};
 use registry::{EffectId, ResolveRegistry};
 // ResolveByte is public to be accessible from crux_macros
@@ -29,21 +28,19 @@ where
 
 /// Bridge is a core wrapper presenting the same interface as the [`Core`] but in a
 /// serialized form, using bincode as the serialization format.
-pub struct Bridge<Eff, A>
+pub struct Bridge<A>
 where
-    Eff: Effect,
     A: App,
 {
-    inner: BridgeWithSerializer<Eff, A>,
+    inner: BridgeWithSerializer<A>,
 }
 
-impl<Eff, A> Bridge<Eff, A>
+impl<A> Bridge<A>
 where
-    Eff: Effect + Send + 'static,
     A: App,
 {
     /// Create a new Bridge using the provided `core`.
-    pub fn new(core: Core<Eff, A>) -> Self {
+    pub fn new(core: Core<A>) -> Self {
         Self {
             inner: BridgeWithSerializer::new(core),
         }
@@ -122,22 +119,20 @@ where
 /// it using separate tooling.
 // used in docs/internals/bridge.md
 // ANCHOR: bridge_with_serializer
-pub struct BridgeWithSerializer<Eff, A>
+pub struct BridgeWithSerializer<A>
 where
-    Eff: Effect,
     A: App,
 {
-    core: Core<Eff, A>,
+    core: Core<A>,
     registry: ResolveRegistry,
 }
 // ANCHOR_END: bridge_with_serializer
 
-impl<Eff, A> BridgeWithSerializer<Eff, A>
+impl<A> BridgeWithSerializer<A>
 where
-    Eff: Effect,
     A: App,
 {
-    pub fn new(core: Core<Eff, A>) -> Self {
+    pub fn new(core: Core<A>) -> Self {
         Self {
             core,
             registry: Default::default(),

--- a/crux_core/src/capabilities/compose.rs
+++ b/crux_core/src/capabilities/compose.rs
@@ -74,6 +74,7 @@ impl<Ev> Compose<Ev> {
     ///
     /// For example:
     /// ```
+    /// # use crux_core::Command;
     /// # use crux_core::macros::Effect;
     /// # use serde::Serialize;
     /// # #[derive(Default, Clone)]
@@ -98,8 +99,9 @@ impl<Ev> Compose<Ev> {
     /// #    type Model = Model;
     /// #    type ViewModel = Model;
     /// #    type Capabilities = Capabilities;
+    /// #    type Effect = Effect;
     /// #
-    ///     fn update(&self, event: Self::Event, model: &mut Self::Model, caps: &Self::Capabilities) {
+    ///     fn update(&self, event: Self::Event, model: &mut Self::Model, caps: &Self::Capabilities) -> Command<Effect, Event> {
     ///         match event {
     ///             Event::Trigger => caps.compose.spawn(|context| {
     ///                 let one = caps.one.clone();
@@ -119,6 +121,7 @@ impl<Ev> Compose<Ev> {
     ///                 model.total = one + two;
     ///             }
     ///         }
+    ///         Command::done()
     ///     }
     /// #
     /// #    fn view(&self, _model: &Self::Model) -> Self::ViewModel {

--- a/crux_core/src/capabilities/render.rs
+++ b/crux_core/src/capabilities/render.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     capability::{CapabilityContext, Operation},
-    Capability,
+    Capability, Command, Request,
 };
 
 /// Use an instance of `Render` to notify the Shell that it should update the user
@@ -65,4 +65,13 @@ impl<Ev> Capability<Ev> for Render<Ev> {
     {
         Render::new(self.context.map_event(f))
     }
+}
+
+/// Signal the shell that UI should be redrawn. Returns a `Command`.
+pub fn render<Effect, Event>() -> Command<Effect, Event>
+where
+    Effect: From<Request<RenderOperation>> + Send + 'static,
+    Event: Send + 'static,
+{
+    Command::notify_shell(RenderOperation)
 }

--- a/crux_core/src/capability/mod.rs
+++ b/crux_core/src/capability/mod.rs
@@ -10,6 +10,7 @@
 //!
 //! ```rust
 //!# use url::Url;
+//!# use crux_core::Command;
 //!# const API_URL: &str = "";
 //!# pub enum Event { Increment, Set(crux_http::Result<crux_http::Response<usize>>) }
 //!# #[derive(crux_core::macros::Effect)]
@@ -25,7 +26,8 @@
 //!#     type Model = Model;
 //!#     type ViewModel = ();
 //!#     type Capabilities = Capabilities;
-//! fn update(&self, event: Self::Event, model: &mut Self::Model, caps: &Self::Capabilities) {
+//!#     type Effect = Effect;
+//! fn update(&self, event: Self::Event, model: &mut Self::Model, caps: &Self::Capabilities) -> Command<Effect, Event> {
 //!     match event {
 //!         //...
 //!         Event::Increment => {
@@ -38,6 +40,7 @@
 //!         }
 //!         Event::Set(_) => todo!(),
 //!     }
+//!     Command::done()
 //! }
 //!# fn view(&self, model: &Self::Model) {
 //!#     unimplemented!()
@@ -58,7 +61,7 @@
 //!
 //! // An app module which can be reused in different apps
 //! mod my_app {
-//!     use crux_core::{capability::CapabilityContext, App, render::Render};
+//!     use crux_core::{capability::CapabilityContext, App, render::{self, Render, RenderOperation}, Command, Request};
 //!     use crux_core::macros::Effect;
 //!     use serde::{Serialize, Deserialize};
 //!
@@ -80,9 +83,10 @@
 //!         type Event = Event;
 //!         type ViewModel = ();
 //!         type Capabilities = Capabilities;
+//!         type Effect = Effect;
 //!
-//!         fn update(&self, event: Event, model: &mut (), caps: &Capabilities) {
-//!             caps.render.render();
+//!         fn update(&self, event: Event, model: &mut (), caps: &Capabilities) -> Command<Effect, Event> {
+//!             render::render()
 //!         }
 //!
 //!         fn view(&self, model: &()) {
@@ -333,7 +337,8 @@ pub trait Capability<Ev> {
 /// #     type Model = ();
 /// #     type ViewModel = ();
 /// #     type Capabilities = Capabilities;
-/// #     fn update(&self, _event: Self::Event, _model: &mut Self::Model, _caps: &Self::Capabilities) {
+/// #     type Effect = Effect;
+/// #     fn update(&self, _event: Self::Event, _model: &mut Self::Model, _caps: &Self::Capabilities) -> crux_core::Command<Effect, Event> {
 /// #         unimplemented!()
 /// #     }
 /// #     fn view(&self, _model: &Self::Model) -> Self::ViewModel {
@@ -571,7 +576,7 @@ where
     /// In a typical case you would implement `From` on the submodule's `Capabilities` type
     ///
     /// ```rust
-    /// # use crux_core::Capability;
+    /// # use crux_core::{Capability, Command};
     /// # #[derive(Default)]
     /// # struct App;
     /// # pub enum Event {
@@ -587,12 +592,13 @@ where
     /// #     type Model = ();
     /// #     type ViewModel = ();
     /// #     type Capabilities = Capabilities;
+    /// #     type Effect = Effect;
     /// #     fn update(
     /// #         &self,
     /// #         _event: Self::Event,
     /// #         _model: &mut Self::Model,
     /// #         _caps: &Self::Capabilities,
-    /// #     ) {
+    /// #     ) -> Command<Effect, Event> {
     /// #         unimplemented!()
     /// #     }
     /// #     fn view(&self, _model: &Self::Model) -> Self::ViewModel {
@@ -621,12 +627,13 @@ where
     /// #         type Model = ();
     /// #         type ViewModel = ();
     /// #         type Capabilities = Capabilities;
+    /// #         type Effect = Effect;
     /// #         fn update(
     /// #             &self,
     /// #             _event: Self::Event,
     /// #             _model: &mut Self::Model,
     /// #             _caps: &Self::Capabilities,
-    /// #         ) {
+    /// #         ) -> crux_core::Command<Effect, Event> {
     /// #             unimplemented!()
     /// #         }
     /// #         fn view(&self, _model: &Self::Model) -> Self::ViewModel {

--- a/crux_core/src/command/RFC.md
+++ b/crux_core/src/command/RFC.md
@@ -237,7 +237,7 @@ I suspect there are ways around this by storing some `Arc<Mutex<T>>`s in the mod
 ## Open questions and other considerations
 
 * I have not fully formed a migration plan yet - it should be possible for the two APIs to coexist for a few versions while people move over
-* The command API expects the `Effect` type to implement `From<Request<Op>>` for any capability Operations it is used with. We should probably allow these trivial implementations to be macro derived
+* The command API expects the `Effect` type to implement `From<Request<Op>>` for any capability Operations it is used with.
 * I have not fully thought about back-pressure in the Commands (for events, effects and spawned tasks) even to the level of "is any needed?"
 * I am not super sure about my implementation of task cancellation using atomics, because they break my head. Help.
 

--- a/crux_core/src/command/mod.rs
+++ b/crux_core/src/command/mod.rs
@@ -49,7 +49,9 @@ use executor::{AbortHandle, Task, TaskId};
 use futures::task::AtomicWaker;
 use futures::{FutureExt as _, Stream, StreamExt as _};
 use slab::Slab;
-use stream::{CommandOutput, CommandStreamExt as _};
+use stream::CommandStreamExt as _;
+
+pub use stream::CommandOutput;
 
 use crate::capability::Operation;
 use crate::Request;

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! ```rust
 //!// src/app.rs
-//!use crux_core::{render::Render, App, macros::Effect};
+//!use crux_core::{render::{self, Render}, App, macros::Effect, Command};
 //!use serde::{Deserialize, Serialize};
 //!
 //!// Model describing the application state
@@ -76,8 +76,10 @@
 //!    type ViewModel = String;
 //!    // Use the above Capabilities
 //!    type Capabilities = Capabilities;
+//!    // Use the above generated Effect
+//!    type Effect = Effect;
 //!
-//!    fn update(&self, event: Event, model: &mut Model, caps: &Capabilities) {
+//!    fn update(&self, event: Event, model: &mut Model, caps: &Capabilities) -> Command<Effect, Event> {
 //!        match event {
 //!            Event::Increment => model.count += 1,
 //!            Event::Decrement => model.count -= 1,
@@ -85,7 +87,7 @@
 //!        };
 //!
 //!        // Request a UI update
-//!        caps.render.render()
+//!        render::render()
 //!    }
 //!
 //!    fn view(&self, model: &Model) -> Self::ViewModel {

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -173,7 +173,7 @@ pub use crux_macros as macros;
 /// as the type argument to [`Core`] or [`Bridge`](bridge::Bridge).
 pub trait App: Default {
     /// Event, typically an `enum`, defines the actions that can be taken to update the application state.
-    type Event: Send + 'static;
+    type Event: Unpin + Send + 'static;
     /// Model, typically a `struct` defines the internal state of the application
     type Model: Default;
     /// ViewModel, typically a `struct` describes the user interface that should be
@@ -184,7 +184,7 @@ pub trait App: Default {
     type Capabilities;
     /// Effect, the enum carrying effect requests created by capabilities.
     /// Normally this type is derived from `Capabilities` using the `crux_macros::Effect` derive macro
-    type Effect;
+    type Effect: Effect + Unpin;
 
     /// Update method defines the transition from one `model` state to another in response to an `event`.
     ///

--- a/crux_core/src/typegen.rs
+++ b/crux_core/src/typegen.rs
@@ -18,6 +18,7 @@
 //!
 //! ```rust
 //! # mod shared {
+//! #     use crux_core::Command;
 //! #     use crux_core::render::Render;
 //! #     use crux_core::macros::Effect;
 //! #     use serde::{Deserialize, Serialize};
@@ -35,7 +36,10 @@
 //! #         type Model = ();
 //! #         type ViewModel = ViewModel;
 //! #         type Capabilities = Capabilities;
-//! #         fn update(&self, _event: Event, _model: &mut Self::Model, _caps: &Capabilities) {}
+//! #         type Effect = Effect;
+//! #         fn update(&self, _event: Event, _model: &mut Self::Model, _caps: &Capabilities) -> Command<Effect, Event> {
+//! #             todo!()
+//! #         }
 //! #         fn view(&self, _model: &Self::Model) -> Self::ViewModel {
 //! #             todo!();
 //! #         }

--- a/crux_core/tests/capability_orchestration.rs
+++ b/crux_core/tests/capability_orchestration.rs
@@ -1,5 +1,5 @@
 mod app {
-    use crux_core::macros::Effect;
+    use crux_core::{macros::Effect, Command};
     use futures::future::join;
     use serde::Serialize;
 
@@ -30,8 +30,14 @@ mod app {
         type Model = Model;
         type ViewModel = Model;
         type Capabilities = Capabilities;
+        type Effect = Effect;
 
-        fn update(&self, event: Self::Event, model: &mut Self::Model, caps: &Self::Capabilities) {
+        fn update(
+            &self,
+            event: Self::Event,
+            model: &mut Self::Model,
+            caps: &Self::Capabilities,
+        ) -> Command<Effect, Event> {
             match event {
                 Event::Trigger => caps.compose.spawn(|context| {
                     let one = caps.one.clone();
@@ -48,6 +54,8 @@ mod app {
                     model.total = one + two;
                 }
             }
+
+            Command::done()
         }
 
         fn view(&self, _model: &Self::Model) -> Self::ViewModel {

--- a/crux_core/tests/capability_orchestration.rs
+++ b/crux_core/tests/capability_orchestration.rs
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn updates_state_once_both_effects_are_done() {
-        let app: AppTester<App, Effect> = AppTester::default();
+        let app: AppTester<App> = AppTester::default();
         let mut model = Model::default();
 
         let update = app.update(Event::Trigger, &mut model);

--- a/crux_core/tests/capability_runtime.rs
+++ b/crux_core/tests/capability_runtime.rs
@@ -152,8 +152,8 @@ mod capability {
 }
 
 mod app {
-    use crux_core::macros::Effect;
     use crux_core::App;
+    use crux_core::{macros::Effect, Command};
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -178,8 +178,14 @@ mod app {
         type Model = Vec<usize>;
         type ViewModel = Vec<usize>;
         type Capabilities = Capabilities;
+        type Effect = Effect;
 
-        fn update(&self, event: Self::Event, model: &mut Self::Model, caps: &Self::Capabilities) {
+        fn update(
+            &self,
+            event: Self::Event,
+            model: &mut Self::Model,
+            caps: &Self::Capabilities,
+        ) -> Command<Effect, Event> {
             match event {
                 Event::Fetch => caps.crawler.fetch_tree(0, Event::Done),
                 Event::Pause => caps.crawler.pause(),
@@ -189,6 +195,8 @@ mod app {
                     caps.render.render();
                 }
             }
+
+            Command::done()
         }
 
         fn view(&self, model: &Self::Model) -> Self::ViewModel {

--- a/crux_core/tests/capability_runtime.rs
+++ b/crux_core/tests/capability_runtime.rs
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn fetches_a_tree() {
-        let core: Core<Effect, MyApp> = Core::new();
+        let core: Core<MyApp> = Core::new();
 
         let mut effects: VecDeque<Effect> = core.process_event(Event::Fetch).into();
 
@@ -259,7 +259,7 @@ mod tests {
 
     #[test]
     fn doesnt_crash_when_core_is_dropped() {
-        let core: Core<Effect, MyApp> = Core::new();
+        let core: Core<MyApp> = Core::new();
 
         // Spawns the task
         core.process_event(Event::Fetch);

--- a/crux_core/tests/json_bridge.rs
+++ b/crux_core/tests/json_bridge.rs
@@ -1,5 +1,6 @@
 mod app {
-    use crux_core::render::Render;
+    use crux_core::render::{self, Render, RenderOperation};
+    use crux_core::Request;
     use crux_core::{macros::Effect, Command};
     use serde::{Deserialize, Serialize};
 
@@ -24,11 +25,9 @@ mod app {
             &self,
             _event: Event,
             _model: &mut Self::Model,
-            caps: &Capabilities,
+            _caps: &Capabilities,
         ) -> Command<Effect, Event> {
-            caps.render.render();
-
-            Command::done()
+            render::render()
         }
 
         fn view(&self, _model: &Self::Model) -> Self::ViewModel {
@@ -37,17 +36,25 @@ mod app {
     }
 
     #[derive(Effect)]
+    #[allow(dead_code)]
     pub struct Capabilities {
         pub render: Render<Event>,
+    }
+
+    // FIXME: Remove after macro derive
+    impl From<Request<RenderOperation>> for Effect {
+        fn from(value: Request<RenderOperation>) -> Self {
+            Self::Render(value)
+        }
     }
 }
 
 mod core {
     use crux_core::bridge::BridgeWithSerializer;
 
-    use crate::app::{App, Effect};
+    use crate::app::App;
 
-    pub type Bridge = BridgeWithSerializer<Effect, App>;
+    pub type Bridge = BridgeWithSerializer<App>;
 }
 
 mod tests {

--- a/crux_core/tests/json_bridge.rs
+++ b/crux_core/tests/json_bridge.rs
@@ -1,6 +1,6 @@
 mod app {
-    use crux_core::macros::Effect;
     use crux_core::render::Render;
+    use crux_core::{macros::Effect, Command};
     use serde::{Deserialize, Serialize};
 
     #[derive(Default)]
@@ -18,9 +18,17 @@ mod app {
         type Model = ();
         type ViewModel = ViewModel;
         type Capabilities = Capabilities;
+        type Effect = Effect;
 
-        fn update(&self, _event: Event, _model: &mut Self::Model, caps: &Capabilities) {
+        fn update(
+            &self,
+            _event: Event,
+            _model: &mut Self::Model,
+            caps: &Capabilities,
+        ) -> Command<Effect, Event> {
             caps.render.render();
+
+            Command::done()
         }
 
         fn view(&self, _model: &Self::Model) -> Self::ViewModel {

--- a/crux_core/tests/json_bridge.rs
+++ b/crux_core/tests/json_bridge.rs
@@ -1,6 +1,5 @@
 mod app {
-    use crux_core::render::{self, Render, RenderOperation};
-    use crux_core::Request;
+    use crux_core::render::{self, Render};
     use crux_core::{macros::Effect, Command};
     use serde::{Deserialize, Serialize};
 
@@ -39,13 +38,6 @@ mod app {
     #[allow(dead_code)]
     pub struct Capabilities {
         pub render: Render<Event>,
-    }
-
-    // FIXME: Remove after macro derive
-    impl From<Request<RenderOperation>> for Effect {
-        fn from(value: Request<RenderOperation>) -> Self {
-            Self::Render(value)
-        }
     }
 }
 

--- a/crux_core/tests/testing.rs
+++ b/crux_core/tests/testing.rs
@@ -3,8 +3,9 @@
 use crux_core::testing::AppTester;
 
 mod app {
-    use crux_core::App;
+    use crux_core::render::RenderOperation;
     use crux_core::{macros::Effect, Command};
+    use crux_core::{render, App, Request};
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -13,8 +14,16 @@ mod app {
     }
 
     #[derive(Effect)]
+    #[allow(dead_code)]
     pub struct Capabilities {
         render: crux_core::render::Render<Event>,
+    }
+
+    // FIXME: Remove after macro derive
+    impl From<Request<RenderOperation>> for Effect {
+        fn from(value: Request<RenderOperation>) -> Self {
+            Self::Render(value)
+        }
     }
 
     #[derive(Default)]
@@ -31,11 +40,9 @@ mod app {
             &self,
             _event: Self::Event,
             _model: &mut Self::Model,
-            caps: &Self::Capabilities,
+            _caps: &Self::Capabilities,
         ) -> Command<Effect, Event> {
-            caps.render.render();
-
-            Command::done()
+            render::render()
         }
 
         fn view(&self, model: &Self::Model) -> Self::ViewModel {

--- a/crux_core/tests/testing.rs
+++ b/crux_core/tests/testing.rs
@@ -3,9 +3,8 @@
 use crux_core::testing::AppTester;
 
 mod app {
-    use crux_core::render::RenderOperation;
     use crux_core::{macros::Effect, Command};
-    use crux_core::{render, App, Request};
+    use crux_core::{render, App};
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -17,13 +16,6 @@ mod app {
     #[allow(dead_code)]
     pub struct Capabilities {
         render: crux_core::render::Render<Event>,
-    }
-
-    // FIXME: Remove after macro derive
-    impl From<Request<RenderOperation>> for Effect {
-        fn from(value: Request<RenderOperation>) -> Self {
-            Self::Render(value)
-        }
     }
 
     #[derive(Default)]

--- a/crux_core/tests/testing.rs
+++ b/crux_core/tests/testing.rs
@@ -3,8 +3,8 @@
 use crux_core::testing::AppTester;
 
 mod app {
-    use crux_core::macros::Effect;
     use crux_core::App;
+    use crux_core::{macros::Effect, Command};
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -25,9 +25,17 @@ mod app {
         type Model = String;
         type ViewModel = String;
         type Capabilities = Capabilities;
+        type Effect = Effect;
 
-        fn update(&self, _event: Self::Event, _model: &mut Self::Model, caps: &Self::Capabilities) {
-            caps.render.render()
+        fn update(
+            &self,
+            _event: Self::Event,
+            _model: &mut Self::Model,
+            caps: &Self::Capabilities,
+        ) -> Command<Effect, Event> {
+            caps.render.render();
+
+            Command::done()
         }
 
         fn view(&self, model: &Self::Model) -> Self::ViewModel {

--- a/crux_core/tests/typegen.rs
+++ b/crux_core/tests/typegen.rs
@@ -2,6 +2,7 @@
 mod shared {
     use crux_core::macros::{Effect, Export};
     use crux_core::render::Render;
+    use crux_core::Command;
     use serde::{Deserialize, Serialize};
 
     #[derive(Default)]
@@ -20,7 +21,17 @@ mod shared {
         type Model = ();
         type ViewModel = ViewModel;
         type Capabilities = Capabilities;
-        fn update(&self, _event: Event, _model: &mut Self::Model, _caps: &Capabilities) {}
+        type Effect = Effect;
+
+        fn update(
+            &self,
+            _event: Event,
+            _model: &mut Self::Model,
+            _caps: &Capabilities,
+        ) -> Command<Effect, Event> {
+            Command::done()
+        }
+
         fn view(&self, _model: &Self::Model) -> Self::ViewModel {
             unimplemented!();
         }

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -101,7 +101,7 @@ mod shell {
         Effect(Effect),
     }
 
-    pub(crate) fn run(core: &Core<Effect, App>, event: Event) -> Result<Vec<HttpRequest>> {
+    pub(crate) fn run(core: &Core<App>, event: Event) -> Result<Vec<HttpRequest>> {
         let mut queue: VecDeque<Task> = VecDeque::new();
 
         queue.push_back(Task::Event(event));
@@ -142,7 +142,7 @@ mod shell {
 
 mod tests {
     use crate::{
-        shared::{App, Effect, Event},
+        shared::{App, Event},
         shell::run,
     };
     use anyhow::Result;
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     pub fn test_http() -> Result<()> {
-        let core: Core<Effect, App> = Core::default();
+        let core: Core<App> = Core::default();
 
         let received = run(&core, Event::Get)?;
 
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     pub fn test_http_json() -> Result<()> {
-        let core: Core<Effect, App> = Core::default();
+        let core: Core<App> = Core::default();
 
         let received = run(&core, Event::GetJson)?;
 

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -1,5 +1,5 @@
 mod shared {
-    use crux_core::render::Render;
+    use crux_core::render::{self, Render};
     use crux_core::{macros::Effect, Command};
     use crux_http::Http;
     use serde::{Deserialize, Serialize};
@@ -59,11 +59,13 @@ mod shared {
                     let mut response = response.unwrap();
                     model.status = response.status().into();
                     model.body = response.take_body().unwrap();
-                    caps.render.render()
+
+                    return render::render();
                 }
                 Event::SetJson(response) => {
                     model.json_body = response.unwrap().take_body().unwrap();
-                    caps.render.render()
+
+                    return render::render();
                 }
             }
 
@@ -83,6 +85,7 @@ mod shared {
     }
 
     #[derive(Effect)]
+    #[allow(dead_code)]
     pub(crate) struct Capabilities {
         pub http: Http<Event>,
         pub render: Render<Event>,

--- a/crux_http/tests/with_shell.rs
+++ b/crux_http/tests/with_shell.rs
@@ -1,6 +1,6 @@
 mod shared {
-    use crux_core::macros::Effect;
     use crux_core::render::Render;
+    use crux_core::{macros::Effect, Command};
     use crux_http::Http;
     use serde::{Deserialize, Serialize};
 
@@ -37,8 +37,14 @@ mod shared {
         type ViewModel = ViewModel;
 
         type Capabilities = Capabilities;
+        type Effect = Effect;
 
-        fn update(&self, event: Event, model: &mut Model, caps: &Capabilities) {
+        fn update(
+            &self,
+            event: Event,
+            model: &mut Model,
+            caps: &Capabilities,
+        ) -> Command<Effect, Event> {
             match event {
                 Event::Get => {
                     caps.http.get("http://example.com").send(Event::Set);
@@ -60,6 +66,8 @@ mod shared {
                     caps.render.render()
                 }
             }
+
+            Command::done()
         }
 
         fn view(&self, model: &Self::Model) -> Self::ViewModel {

--- a/crux_http/tests/with_tester.rs
+++ b/crux_http/tests/with_tester.rs
@@ -2,8 +2,8 @@ mod shared {
 
     use std::{cmp::max, collections::HashMap, future::IntoFuture};
 
-    use crux_core::compose::Compose;
     use crux_core::macros::Effect;
+    use crux_core::{compose::Compose, Command};
     use crux_http::Http;
     use futures_util::join;
     use http_types::StatusCode;
@@ -42,8 +42,14 @@ mod shared {
         type ViewModel = ViewModel;
 
         type Capabilities = Capabilities;
+        type Effect = Effect;
 
-        fn update(&self, event: Event, model: &mut Model, caps: &Capabilities) {
+        fn update(
+            &self,
+            event: Event,
+            model: &mut Model,
+            caps: &Capabilities,
+        ) -> Command<Effect, Event> {
             match event {
                 Event::Get => {
                     caps.http
@@ -124,6 +130,8 @@ mod shared {
                 }
                 Event::Set(Err(_)) => {}
             }
+
+            Command::done()
         }
 
         fn view(&self, model: &Self::Model) -> Self::ViewModel {

--- a/crux_http/tests/with_tester.rs
+++ b/crux_http/tests/with_tester.rs
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn get() {
-        let app = AppTester::<App, _>::default();
+        let app = AppTester::<App>::default();
         let mut model = Model::default();
 
         let request = &mut app
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn post() {
-        let app = AppTester::<App, _>::default();
+        let app = AppTester::<App>::default();
         let mut model = Model::default();
 
         let request = &mut app
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn post_form() {
-        let app = AppTester::<App, _>::default();
+        let app = AppTester::<App>::default();
         let mut model = Model::default();
 
         let request = &mut app
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     fn get_post_chain() {
-        let app = AppTester::<App, _>::default();
+        let app = AppTester::<App>::default();
         let mut model = Model::default();
 
         let request = &mut app
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn concurrent_gets() {
-        let app = AppTester::<App, _>::default();
+        let app = AppTester::<App>::default();
         let mut model = Model::default();
 
         let mut requests = app
@@ -350,7 +350,7 @@ mod tests {
 
     #[test]
     fn test_shell_error() {
-        let app = AppTester::<App, _>::default();
+        let app = AppTester::<App>::default();
         let mut model = Model::default();
 
         let request = &mut app

--- a/crux_kv/src/tests.rs
+++ b/crux_kv/src/tests.rs
@@ -142,7 +142,7 @@ pub struct Capabilities {
 
 #[test]
 fn test_get() {
-    let app = AppTester::<App, _>::default();
+    let app = AppTester::<App>::default();
     let mut model = Model::default();
 
     let request = &mut app
@@ -172,7 +172,7 @@ fn test_get() {
 
 #[test]
 fn test_set() {
-    let app = AppTester::<App, _>::default();
+    let app = AppTester::<App>::default();
     let mut model = Model::default();
 
     let request = &mut app
@@ -203,7 +203,7 @@ fn test_set() {
 
 #[test]
 fn test_delete() {
-    let app = AppTester::<App, _>::default();
+    let app = AppTester::<App>::default();
     let mut model = Model::default();
 
     let request = &mut app
@@ -233,7 +233,7 @@ fn test_delete() {
 
 #[test]
 fn test_exists() {
-    let app = AppTester::<App, _>::default();
+    let app = AppTester::<App>::default();
     let mut model = Model::default();
 
     let request = &mut app
@@ -261,7 +261,7 @@ fn test_exists() {
 
 #[test]
 fn test_list_keys() {
-    let app = AppTester::<App, _>::default();
+    let app = AppTester::<App>::default();
     let mut model = Model::default();
 
     let request = &mut app
@@ -294,7 +294,7 @@ fn test_list_keys() {
 
 #[test]
 pub fn test_kv_async() -> Result<()> {
-    let app = AppTester::<App, _>::default();
+    let app = AppTester::<App>::default();
     let mut model = Model::default();
 
     let request = &mut app

--- a/crux_kv/src/tests.rs
+++ b/crux_kv/src/tests.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use crux_core::{macros::Effect, render::Render, testing::AppTester};
+use crux_core::{macros::Effect, render::Render, testing::AppTester, Command};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -44,8 +44,14 @@ impl crux_core::App for App {
     type ViewModel = ViewModel;
 
     type Capabilities = Capabilities;
+    type Effect = Effect;
 
-    fn update(&self, event: Event, model: &mut Model, caps: &Capabilities) {
+    fn update(
+        &self,
+        event: Event,
+        model: &mut Model,
+        caps: &Capabilities,
+    ) -> Command<Effect, Event> {
         let key = "test".to_string();
         match event {
             Event::Get => caps.key_value.get(key, Event::GetResponse),
@@ -115,6 +121,8 @@ impl crux_core::App for App {
                 panic!("Error: {:?}", error);
             }
         }
+
+        Command::done()
     }
 
     fn view(&self, model: &Self::Model) -> Self::ViewModel {

--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -140,6 +140,11 @@ impl ToTokens for EffectStructReceiver {
                             }
                         }
                     }
+                    impl From<crux_core::Request<<#capability<#event> as ::crux_core::capability::Capability<#event>>::Operation>> for #effect_name {
+                        fn from(value: crux_core::Request<<#capability<#event> as ::crux_core::capability::Capability<#event>>::Operation>) -> Self {
+                            Self::#variant(value)
+                        }
+                    }
                 });
             }
         }
@@ -240,7 +245,7 @@ mod tests {
 
         let actual = quote!(#input);
 
-        insta::assert_snapshot!(pretty_print(&actual), @r###"
+        insta::assert_snapshot!(pretty_print(&actual), @r##"
         #[derive(Debug)]
         pub enum Effect {
             Render(
@@ -296,7 +301,20 @@ mod tests {
                 }
             }
         }
-        "###);
+        impl From<
+            crux_core::Request<
+                <Render<Event> as ::crux_core::capability::Capability<Event>>::Operation,
+            >,
+        > for Effect {
+            fn from(
+                value: crux_core::Request<
+                    <Render<Event> as ::crux_core::capability::Capability<Event>>::Operation,
+                >,
+            ) -> Self {
+                Self::Render(value)
+            }
+        }
+        "##);
     }
 
     #[test]
@@ -314,7 +332,7 @@ mod tests {
 
         let actual = quote!(#input);
 
-        insta::assert_snapshot!(pretty_print(&actual), @r###"
+        insta::assert_snapshot!(pretty_print(&actual), @r##"
         #[derive(Debug)]
         pub enum Effect {
             Render(
@@ -378,7 +396,20 @@ mod tests {
                 }
             }
         }
-        "###);
+        impl From<
+            crux_core::Request<
+                <Render<Event> as ::crux_core::capability::Capability<Event>>::Operation,
+            >,
+        > for Effect {
+            fn from(
+                value: crux_core::Request<
+                    <Render<Event> as ::crux_core::capability::Capability<Event>>::Operation,
+                >,
+            ) -> Self {
+                Self::Render(value)
+            }
+        }
+        "##);
     }
 
     #[test]
@@ -399,7 +430,7 @@ mod tests {
 
         let actual = quote!(#input);
 
-        insta::assert_snapshot!(pretty_print(&actual), @r###"
+        insta::assert_snapshot!(pretty_print(&actual), @r##"
         #[derive(Debug)]
         pub enum MyEffect {
             Http(
@@ -505,6 +536,23 @@ mod tests {
                 }
             }
         }
+        impl From<
+            crux_core::Request<
+                <crux_http::Http<
+                    MyEvent,
+                > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+            >,
+        > for MyEffect {
+            fn from(
+                value: crux_core::Request<
+                    <crux_http::Http<
+                        MyEvent,
+                    > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                >,
+            ) -> Self {
+                Self::Http(value)
+            }
+        }
         impl MyEffect {
             pub fn is_key_value(&self) -> bool {
                 if let MyEffect::KeyValue(_) = self { true } else { false }
@@ -530,6 +578,21 @@ mod tests {
                 } else {
                     panic!("not a {} effect", "key_value")
                 }
+            }
+        }
+        impl From<
+            crux_core::Request<
+                <KeyValue<MyEvent> as ::crux_core::capability::Capability<MyEvent>>::Operation,
+            >,
+        > for MyEffect {
+            fn from(
+                value: crux_core::Request<
+                    <KeyValue<
+                        MyEvent,
+                    > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                >,
+            ) -> Self {
+                Self::KeyValue(value)
             }
         }
         impl MyEffect {
@@ -559,6 +622,21 @@ mod tests {
                 }
             }
         }
+        impl From<
+            crux_core::Request<
+                <Platform<MyEvent> as ::crux_core::capability::Capability<MyEvent>>::Operation,
+            >,
+        > for MyEffect {
+            fn from(
+                value: crux_core::Request<
+                    <Platform<
+                        MyEvent,
+                    > as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                >,
+            ) -> Self {
+                Self::Platform(value)
+            }
+        }
         impl MyEffect {
             pub fn is_render(&self) -> bool {
                 if let MyEffect::Render(_) = self { true } else { false }
@@ -582,6 +660,19 @@ mod tests {
                 } else {
                     panic!("not a {} effect", "render")
                 }
+            }
+        }
+        impl From<
+            crux_core::Request<
+                <Render<MyEvent> as ::crux_core::capability::Capability<MyEvent>>::Operation,
+            >,
+        > for MyEffect {
+            fn from(
+                value: crux_core::Request<
+                    <Render<MyEvent> as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                >,
+            ) -> Self {
+                Self::Render(value)
             }
         }
         impl MyEffect {
@@ -609,7 +700,20 @@ mod tests {
                 }
             }
         }
-        "###);
+        impl From<
+            crux_core::Request<
+                <Time<MyEvent> as ::crux_core::capability::Capability<MyEvent>>::Operation,
+            >,
+        > for MyEffect {
+            fn from(
+                value: crux_core::Request<
+                    <Time<MyEvent> as ::crux_core::capability::Capability<MyEvent>>::Operation,
+                >,
+            ) -> Self {
+                Self::Time(value)
+            }
+        }
+        "##);
     }
 
     #[test]

--- a/crux_macros/src/lib.rs
+++ b/crux_macros/src/lib.rs
@@ -33,12 +33,13 @@ use syn::parse_macro_input;
 /// #     type Model = ();
 /// #     type ViewModel = ();
 /// #     type Capabilities = MyCapabilities;
+/// #     type Effect = MyEffect;
 /// #     fn update(
 /// #         &self,
 /// #         _event: Self::Event,
 /// #         _model: &mut Self::Model,
 /// #         _caps: &Self::Capabilities,
-/// #     ) {
+/// #     ) -> crux_core::Command<MyEffect, MyEvent> {
 /// #         unimplemented!()
 /// #     }
 /// #     fn view(&self, _model: &Self::Model) -> Self::ViewModel {

--- a/crux_platform/tests/platform_test.rs
+++ b/crux_platform/tests/platform_test.rs
@@ -1,6 +1,6 @@
 mod shared {
-    use crux_core::macros::Effect;
     use crux_core::render::Render;
+    use crux_core::{macros::Effect, Command};
     use crux_platform::{Platform, PlatformResponse};
     use serde::{Deserialize, Serialize};
 
@@ -28,8 +28,14 @@ mod shared {
         type Model = Model;
         type ViewModel = ViewModel;
         type Capabilities = Capabilities;
+        type Effect = Effect;
 
-        fn update(&self, event: Event, model: &mut Model, caps: &Capabilities) {
+        fn update(
+            &self,
+            event: Event,
+            model: &mut Model,
+            caps: &Capabilities,
+        ) -> Command<Effect, Event> {
             match event {
                 Event::PlatformGet => caps.platform.get(Event::PlatformSet),
                 Event::PlatformSet(platform) => {
@@ -37,6 +43,8 @@ mod shared {
                     caps.render.render()
                 }
             }
+
+            Command::done()
         }
 
         fn view(&self, model: &Self::Model) -> Self::ViewModel {

--- a/crux_platform/tests/platform_test.rs
+++ b/crux_platform/tests/platform_test.rs
@@ -76,7 +76,7 @@ mod shell {
         Response(Outcome),
     }
 
-    pub fn run(core: &Core<Effect, App>) {
+    pub fn run(core: &Core<App>) {
         let mut queue: VecDeque<CoreMessage> = VecDeque::new();
 
         queue.push_back(CoreMessage::Event(Event::PlatformGet));
@@ -106,15 +106,12 @@ mod shell {
 }
 
 mod tests {
-    use crate::{
-        shared::{App, Effect},
-        shell::run,
-    };
+    use crate::{shared::App, shell::run};
     use crux_core::Core;
 
     #[test]
     pub fn test_platform() {
-        let core: Core<Effect, App> = Core::default();
+        let core: Core<App> = Core::default();
 
         run(&core);
 

--- a/crux_time/tests/time_test.rs
+++ b/crux_time/tests/time_test.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "chrono")]
 mod shared {
     use chrono::{DateTime, Utc};
-    use crux_core::macros::Effect;
     use crux_core::render::Render;
+    use crux_core::{macros::Effect, Command};
     use crux_time::{Time, TimeResponse, TimerId};
     use serde::{Deserialize, Serialize};
 
@@ -54,8 +54,14 @@ mod shared {
         type Model = Model;
         type ViewModel = ViewModel;
         type Capabilities = Capabilities;
+        type Effect = Effect;
 
-        fn update(&self, event: Event, model: &mut Model, caps: &Capabilities) {
+        fn update(
+            &self,
+            event: Event,
+            model: &mut Model,
+            caps: &Capabilities,
+        ) -> Command<Effect, Event> {
             match event {
                 Event::Get => caps.time.now(Event::Set),
                 Event::GetAsync => caps.compose.spawn(|ctx| {
@@ -101,6 +107,8 @@ mod shared {
                     caps.time.clear(timer_id);
                 }
             }
+
+            Command::done()
         }
 
         fn view(&self, model: &Self::Model) -> Self::ViewModel {

--- a/crux_time/tests/time_test.rs
+++ b/crux_time/tests/time_test.rs
@@ -153,7 +153,7 @@ mod shell {
         Response(Outcome),
     }
 
-    pub fn run(core: &Core<Effect, App>) {
+    pub fn run(core: &Core<App>) {
         let mut queue: VecDeque<CoreMessage> = VecDeque::new();
 
         queue.push_back(CoreMessage::Event(Event::Get));
@@ -186,7 +186,7 @@ mod shell {
 #[cfg(feature = "chrono")]
 mod tests {
     use crate::{
-        shared::{App, Effect, Event, Model},
+        shared::{App, Event, Model},
         shell::run,
     };
     use chrono::{DateTime, Utc};
@@ -195,7 +195,7 @@ mod tests {
 
     #[test]
     pub fn test_time() {
-        let core: Core<Effect, App> = Core::default();
+        let core: Core<App> = Core::default();
 
         run(&core);
 
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     pub fn test_time_async() {
-        let app = AppTester::<App, _>::default();
+        let app = AppTester::<App>::default();
         let mut model = Model::default();
 
         let request = &mut app
@@ -223,7 +223,7 @@ mod tests {
 
     #[test]
     pub fn test_debounce_timer() {
-        let app = AppTester::<App, _>::default();
+        let app = AppTester::<App>::default();
         let mut model = Model::default();
 
         let request1 = &mut app
@@ -264,7 +264,7 @@ mod tests {
 
     #[test]
     pub fn test_start_debounce_then_clear() {
-        let app = AppTester::<App, _>::default();
+        let app = AppTester::<App>::default();
         let mut model = Model::default();
         let mut debounce = app
             .update(Event::StartDebounce, &mut model)


### PR DESCRIPTION
This makes the necessary changes to make Commands usable with `Core` and `AppTester`.

It makes a fair few breaking changes to type signatures, but all quite mechanical and simple. I'll follow this up with a migration guide which people can follow.