### PR TITLE
Command support in crux_kv and tweaks and fixes to the Command API to enable the capability migration

### DIFF
--- a/crux_core/src/command/builder.rs
+++ b/crux_core/src/command/builder.rs
@@ -33,6 +33,13 @@ where
         RequestBuilder { make_task }
     }
 
+    pub fn map<F, U>(self, map: F) -> RequestBuilder<Effect, Event, impl Future<Output = U>>
+    where
+        F: FnOnce(T) -> U + Send + 'static,
+    {
+        RequestBuilder::new(|ctx| self.into_future(ctx.clone()).map(map))
+    }
+
     /// Chain another [`RequestBuilder`] to run after completion of this one,
     /// passing the result to the provided closure `make_next_builder`.
     ///
@@ -251,6 +258,13 @@ where
         StreamBuilder {
             make_stream: make_task,
         }
+    }
+
+    pub fn map<F, U>(self, map: F) -> StreamBuilder<Effect, Event, impl Stream<Item = U>>
+    where
+        F: FnMut(T) -> U + Send + 'static,
+    {
+        StreamBuilder::new(|ctx| self.into_stream(ctx.clone()).map(map))
     }
 
     /// Chain a [`RequestBuilder`] to run after completion of this [`StreamBuilder`],

--- a/crux_core/src/command/mod.rs
+++ b/crux_core/src/command/mod.rs
@@ -51,6 +51,7 @@ use futures::{FutureExt as _, Stream, StreamExt as _};
 use slab::Slab;
 use stream::CommandStreamExt as _;
 
+pub use builder::{RequestBuilder, StreamBuilder};
 pub use stream::CommandOutput;
 
 use crate::capability::Operation;

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -153,12 +153,12 @@
 
 pub mod bridge;
 pub mod capability;
+pub mod command;
 pub mod testing;
 #[cfg(feature = "typegen")]
 pub mod typegen;
 
 mod capabilities;
-mod command;
 mod core;
 
 use serde::Serialize;

--- a/crux_kv/src/command.rs
+++ b/crux_kv/src/command.rs
@@ -4,13 +4,19 @@ use std::{future::Future, marker::PhantomData};
 
 use crux_core::{command::RequestBuilder, Command, Request};
 
-use super::{KeyValueOperation, KeyValueResult};
+use crate::error::KeyValueError;
+
+use super::KeyValueOperation;
 
 pub struct KeyValue<Effect, Event> {
     // Allow the impl to declare trait bounds once. Thanks rustc
     effect: PhantomData<Effect>,
     event: PhantomData<Event>,
 }
+
+type StatusResult = Result<bool, KeyValueError>;
+type DataResult = Result<Option<Vec<u8>>, KeyValueError>;
+type ListResult = Result<(Vec<String>, u64), KeyValueError>;
 
 impl<Effect, Event> KeyValue<Effect, Event>
 where
@@ -19,39 +25,44 @@ where
 {
     pub fn get(
         key: impl Into<String>,
-    ) -> RequestBuilder<Effect, Event, impl Future<Output = KeyValueResult>> {
+    ) -> RequestBuilder<Effect, Event, impl Future<Output = DataResult>> {
         Command::request_from_shell(KeyValueOperation::Get { key: key.into() })
+            .map(|kv_result| kv_result.unwrap_get())
     }
 
     pub fn set(
         key: impl Into<String>,
         value: Vec<u8>,
-    ) -> RequestBuilder<Effect, Event, impl Future<Output = KeyValueResult>> {
+    ) -> RequestBuilder<Effect, Event, impl Future<Output = DataResult>> {
         Command::request_from_shell(KeyValueOperation::Set {
             key: key.into(),
             value,
         })
+        .map(|kv_result| kv_result.unwrap_set())
     }
 
     pub fn delete(
         key: impl Into<String>,
-    ) -> RequestBuilder<Effect, Event, impl Future<Output = KeyValueResult>> {
+    ) -> RequestBuilder<Effect, Event, impl Future<Output = DataResult>> {
         Command::request_from_shell(KeyValueOperation::Delete { key: key.into() })
+            .map(|kv_result| kv_result.unwrap_delete())
     }
 
     pub fn exists(
         key: impl Into<String>,
-    ) -> RequestBuilder<Effect, Event, impl Future<Output = KeyValueResult>> {
+    ) -> RequestBuilder<Effect, Event, impl Future<Output = StatusResult>> {
         Command::request_from_shell(KeyValueOperation::Exists { key: key.into() })
+            .map(|kv_result| kv_result.unwrap_exists())
     }
 
     pub fn list_keys(
         prefix: impl Into<String>,
         cursor: u64,
-    ) -> RequestBuilder<Effect, Event, impl Future<Output = KeyValueResult>> {
+    ) -> RequestBuilder<Effect, Event, impl Future<Output = ListResult>> {
         Command::request_from_shell(KeyValueOperation::ListKeys {
             prefix: prefix.into(),
             cursor,
         })
+        .map(|kv_result| kv_result.unwrap_list_keys())
     }
 }

--- a/crux_kv/src/command.rs
+++ b/crux_kv/src/command.rs
@@ -1,0 +1,57 @@
+//! The Command based API for crux_kv
+
+use std::{future::Future, marker::PhantomData};
+
+use crux_core::{command::RequestBuilder, Command, Request};
+
+use super::{KeyValueOperation, KeyValueResult};
+
+pub struct KeyValue<Effect, Event> {
+    // Allow the impl to declare trait bounds once. Thanks rustc
+    effect: PhantomData<Effect>,
+    event: PhantomData<Event>,
+}
+
+impl<Effect, Event> KeyValue<Effect, Event>
+where
+    Effect: Send + From<Request<KeyValueOperation>> + 'static,
+    Event: Send + 'static,
+{
+    pub fn get(
+        key: impl Into<String>,
+    ) -> RequestBuilder<Effect, Event, impl Future<Output = KeyValueResult>> {
+        Command::request_from_shell(KeyValueOperation::Get { key: key.into() })
+    }
+
+    pub fn set(
+        key: impl Into<String>,
+        value: Vec<u8>,
+    ) -> RequestBuilder<Effect, Event, impl Future<Output = KeyValueResult>> {
+        Command::request_from_shell(KeyValueOperation::Set {
+            key: key.into(),
+            value,
+        })
+    }
+
+    pub fn delete(
+        key: impl Into<String>,
+    ) -> RequestBuilder<Effect, Event, impl Future<Output = KeyValueResult>> {
+        Command::request_from_shell(KeyValueOperation::Delete { key: key.into() })
+    }
+
+    pub fn exists(
+        key: impl Into<String>,
+    ) -> RequestBuilder<Effect, Event, impl Future<Output = KeyValueResult>> {
+        Command::request_from_shell(KeyValueOperation::Exists { key: key.into() })
+    }
+
+    pub fn list_keys(
+        prefix: impl Into<String>,
+        cursor: u64,
+    ) -> RequestBuilder<Effect, Event, impl Future<Output = KeyValueResult>> {
+        Command::request_from_shell(KeyValueOperation::ListKeys {
+            prefix: prefix.into(),
+            cursor,
+        })
+    }
+}

--- a/crux_kv/src/lib.rs
+++ b/crux_kv/src/lib.rs
@@ -420,5 +420,7 @@ impl KeyValueResult {
     }
 }
 
+pub mod command;
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
This adds a new module called`command` to `crux_kv` which provides KV command builder constructors.

Because KV presents a different interface to the core than the protocol it has with the shell, it needs to do post-processing_ on the results. I took the opportunity to add `.map` to `RequestBuilder` and `StreamBuilder`. I also made some missed out parts of this API public in `crux_core`. 

This should put is in a good place to tackle more complicated capabilities.

**note**: this will require a patch release of `crux_core` and therefore a patch release of `crux_kv` (and potentially all capabilities - haven't thought about that too hard)