### PR TITLE
update ServerSentEvents capability in examples to command

### DIFF
--- a/examples/counter/shared/src/app.rs
+++ b/examples/counter/shared/src/app.rs
@@ -1,4 +1,3 @@
-use crate::capabilities::sse::ServerSentEvents;
 use chrono::{serde::ts_milliseconds_option::deserialize as ts_milliseconds_option, DateTime, Utc};
 use crux_core::{
     render::{self, Render},
@@ -7,6 +6,8 @@ use crux_core::{
 use crux_http::command::Http;
 use serde::{Deserialize, Serialize};
 use url::Url;
+
+use crate::sse::ServerSentEvents;
 
 const API_URL: &str = "https://crux-counter.fly.dev";
 
@@ -118,8 +119,7 @@ impl crux_core::App for App {
             Event::StartWatch => {
                 let base = Url::parse(API_URL).unwrap();
                 let url = base.join("/sse").unwrap();
-                caps.sse.get_json(url, Event::Update);
-                Command::done()
+                ServerSentEvents::get_json(url, Event::Update)
             }
         }
     }


### PR DESCRIPTION
Updates the `ServerSentEvents` capability in the `counter` example to use the new `Command` API. 

Note that during the migration phase, this capability has to also be compatible with the old API so that `#[derive(Effect)]` can generate the relevant `Effect` enum variant. As we move past the migration, capabilities will become vanilla structs that have no special meaning in Crux and effectively just become `Command` generators. At this point we can simplify this capability, removing the `CapabilityContext`.