### PR TITLE
Update tests in the counter example to not use AppTester

### DIFF
--- a/docs/src/getting_started/core.md
+++ b/docs/src/getting_started/core.md
@@ -56,9 +56,9 @@ keywords = ["crux", "crux_core", "cross-platform-ui", "ffi", "wasm"]
 rust-version = "1.66"
 
 [workspace.dependencies]
-anyhow = "1.0.86"
-crux_core = "0.8"
-serde = "1.0.203"
+anyhow = "1.0.95"
+crux_core = "0.11.1"
+serde = "1.0.217"
 ```
 
 The library's manifest, at `/shared/Cargo.toml`, should look something like the


### PR DESCRIPTION
Once the migration to the new command API is complete, the app's update function will no longer require capabilities as a parameter. This PR updates the counter example's update function to defer to our _own_ update function, which matches the signature that the App trait will soon require.

We can now test the app directly, rather than relying on the `AppTester` (which will be deprecated).