### PR TITLE
crux_core command docs wip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,7 @@ dependencies = [
  "crux_core",
  "crux_http",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,7 @@ name = "doctest_support"
 version = "0.1.0"
 dependencies = [
  "crux_core",
+ "crux_http",
  "serde",
 ]
 

--- a/crux_core/src/bridge/mod.rs
+++ b/crux_core/src/bridge/mod.rs
@@ -111,7 +111,7 @@ where
 /// A bridge with a user supplied serializer
 ///
 /// This is exactly the same as [`Bridge`], except instead of using the default
-/// bincode serialization, you can provide your own [`Serializer`].
+/// bincode serialization, you can provide your own [`Serializer`](::serde::ser::Serializer).
 ///
 /// **Warning**: the support for custom serialization is **experimental** and
 /// does not have a corresponding type generation support - you will need

--- a/crux_core/src/command/builder.rs
+++ b/crux_core/src/command/builder.rs
@@ -57,7 +57,7 @@ where
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # use crux_core::{Command, Request};
     /// # use crux_core::capability::Operation;
     /// # use serde::{Deserialize, Serialize};
@@ -146,7 +146,7 @@ where
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # use crux_core::{Command, Request};
     /// # use crux_core::capability::Operation;
     /// # use serde::{Deserialize, Serialize};
@@ -284,7 +284,7 @@ where
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # use crux_core::{Command, Request};
     /// # use crux_core::capability::Operation;
     /// # use serde::{Deserialize, Serialize};
@@ -373,7 +373,7 @@ where
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```
     /// # use crux_core::{Command, Request};
     /// # use crux_core::capability::Operation;
     /// # use serde::{Deserialize, Serialize};

--- a/crux_core/src/command/tests/async_effects.rs
+++ b/crux_core/src/command/tests/async_effects.rs
@@ -43,7 +43,7 @@ enum Event {
 
 #[test]
 fn effects_execute_in_sequence() {
-    let mut cmd: Command<Effect, Event> = Command::new(|ctx| async move {
+    let mut cmd = Command::new(|ctx| async move {
         let output = ctx.request_from_shell(AnOperation::One).await;
         ctx.send_event(Event::Completed(output));
         let output = ctx.request_from_shell(AnOperation::Two).await;
@@ -85,7 +85,7 @@ fn effects_execute_in_sequence() {
 
 #[test]
 fn effects_execute_in_parallel() {
-    let mut cmd: Command<Effect, Event> = Command::new(|ctx| async move {
+    let mut cmd = Command::new(|ctx| async move {
         let (first, second) = join!(
             ctx.request_from_shell(AnOperation::One),
             ctx.request_from_shell(AnOperation::Two)
@@ -126,7 +126,7 @@ fn effects_execute_in_parallel() {
 
 #[test]
 fn effects_race() {
-    let mut cmd: Command<Effect, Event> = Command::new(|ctx| async move {
+    let mut cmd = Command::new(|ctx| async move {
         select! {
             output = ctx.request_from_shell(AnOperation::One).fuse() => ctx.send_event(Event::Completed(output)),
             output = ctx.request_from_shell(AnOperation::Two).fuse() => ctx.send_event(Event::Completed(output)),
@@ -174,7 +174,7 @@ fn effects_can_spawn_communicating_tasks() {
     // the first task continues until an ::Abort resolution is sent
     // the second continues until it can't read from the channel
 
-    let mut cmd: Command<Effect, Event> = Command::new(|ctx| async move {
+    let mut cmd = Command::new(|ctx| async move {
         let (tx, rx) = async_channel::unbounded();
 
         ctx.spawn(|ctx| async move {

--- a/crux_core/src/command/tests/combinators.rs
+++ b/crux_core/src/command/tests/combinators.rs
@@ -79,7 +79,7 @@ fn then() {
 
 #[test]
 fn chaining() {
-    let mut cmd: Command<Effect, Event> = Command::request_from_shell(AnOperation::More([3, 4]))
+    let mut cmd = Command::request_from_shell(AnOperation::More([3, 4]))
         .then_request(|first| {
             let AnOperationOutput::Other(first) = first else {
                 // TODO: how do I bail quietly here?
@@ -122,7 +122,7 @@ fn chaining() {
 
 #[test]
 fn long_chain_support() {
-    let mut cmd: Command<Effect, Event> = Command::request_from_shell(AnOperation::More([3, 4]))
+    let mut cmd = Command::request_from_shell(AnOperation::More([3, 4]))
         .then_request(|first| {
             let AnOperationOutput::Other(first) = first else {
                 // TODO: how do I bail quietly here?
@@ -380,7 +380,7 @@ fn complex_concurrency() {
 
 #[test]
 fn concurrency_mixing_streams_and_requests() {
-    let mut cmd: Command<Effect, Event> = Command::all([
+    let mut cmd = Command::all([
         Command::stream_from_shell(AnOperation::One)
             .then_request(|out| {
                 let AnOperationOutput::Other([a, b]) = out else {
@@ -540,7 +540,7 @@ fn stream_followed_by_a_stream() {
 
 #[test]
 fn chaining_with_mapping() {
-    let mut cmd: Command<Effect, Event> = Command::request_from_shell(AnOperation::More([3, 4]))
+    let mut cmd = Command::request_from_shell(AnOperation::More([3, 4]))
         .map(|first| {
             let AnOperationOutput::Other(first) = first else {
                 // TODO: how do I bail quietly here?
@@ -586,7 +586,7 @@ fn chaining_with_mapping() {
 
 #[test]
 fn stream_mapping_and_chaining() {
-    let mut cmd: Command<Effect, Event> = Command::stream_from_shell(AnOperation::One)
+    let mut cmd = Command::stream_from_shell(AnOperation::One)
         .map(|out| {
             let AnOperationOutput::Other([a, b]) = out else {
                 panic!("Bad output");

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -194,7 +194,7 @@ pub trait App: Default {
 
     /// Update method defines the transition from one `model` state to another in response to an `event`.
     ///
-    /// `update` may mutate the `model` and returns a [`Command`](crate::command::Command) describing
+    /// `update` may mutate the `model` and returns a [`Command`] describing
     /// the managed side-effects to perform as a result of the `event`. Commands can be constructed by capabilities
     /// and combined to run sequentially or concurrently. If migrating from previous version of crux, you
     /// can return `Command::done()` for compatibility.

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -22,7 +22,7 @@
 //! * Shell - the native side of the app on each platform handling UI and executing side effects
 //!
 //! * App - the main module of the core containing the application logic, especially model changes
-//!   and side-effects triggered by events. App can be composed from modules, each resembling a smaller, simpler app.
+//!   and side-effects triggered by events. An App can delegate to child apps, mapping Events and Effects.
 //!
 //! * Event - main input for the core, typically triggered by user interaction in the UI
 //!
@@ -34,7 +34,11 @@
 //!   interaction with the host platform. Updating the UI is considered an effect.
 //!
 //! * Capability - A user-friendly API used to request effects and provide events that should be dispatched
-//!   when the effect is completed. For example, a HTTP client is a capability.
+//!   when an effect is completed. For example, a HTTP client is a capability.
+//!
+//! * Command - A description of a side-effect to be executed by the shell. Commands can be combined
+//!   (synchronously with combinators, or asynchronously with Rust async) to run
+//!   sequentially or concurrently, or any combination thereof.
 //!
 //! Below is a minimal example of a Crux-based application Core:
 //!

--- a/crux_http/src/command.rs
+++ b/crux_http/src/command.rs
@@ -39,7 +39,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<String>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -66,7 +66,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -91,7 +91,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -117,7 +117,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -143,7 +143,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -168,7 +168,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -194,7 +194,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -219,7 +219,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -244,7 +244,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -269,7 +269,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # use http_types::Method;
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
@@ -293,7 +293,7 @@ where
 ///
 /// # Examples
 ///
-/// ```no_run
+/// ```
 /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
 /// # #[derive(crux_core::macros::Effect)]
 /// # #[allow(unused)]
@@ -340,7 +340,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -361,7 +361,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -387,7 +387,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -416,7 +416,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # use serde::{Deserialize, Serialize};
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
@@ -447,7 +447,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -470,7 +470,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -499,7 +499,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # use std::collections::HashMap;
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
@@ -524,7 +524,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # use serde::{Deserialize, Serialize};
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
@@ -562,7 +562,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Vec<u8>>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -614,7 +614,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<String>>) }
     /// # #[derive(crux_core::macros::Effect)]
     /// # #[allow(unused)]
@@ -640,7 +640,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// # use serde::{Deserialize, Serialize};
     /// # enum Event { ReceiveResponse(crux_http::Result<crux_http::Response<Slideshow>>) }
     /// # #[derive(crux_core::macros::Effect)]

--- a/doctest_support/Cargo.toml
+++ b/doctest_support/Cargo.toml
@@ -15,5 +15,8 @@ crux_core = { path = "../crux_core" }
 crux_http = { path = "../crux_http" }
 serde = { version = "1.0", features = ["derive"] }
 
+[dev-dependencies]
+serde_json = "1.0"
+
 [lints]
 workspace = true

--- a/doctest_support/Cargo.toml
+++ b/doctest_support/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 crux_core = { path = "../crux_core" }
+crux_http = { path = "../crux_http" }
 serde = { version = "1.0", features = ["derive"] }
 
 [lints]

--- a/doctest_support/src/lib.rs
+++ b/doctest_support/src/lib.rs
@@ -1,4 +1,35 @@
 //! This is support code for doc tests
+
+pub mod command {
+    use crux_core::{capability::Operation, Request};
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, PartialEq, Clone, Serialize)]
+    pub struct AnOperation;
+    #[derive(Debug, PartialEq, Deserialize)]
+    pub struct AnOperationOutput;
+
+    impl Operation for AnOperation {
+        type Output = AnOperationOutput;
+    }
+
+    pub enum Effect {
+        AnEffect(Request<AnOperation>),
+    }
+
+    impl From<Request<AnOperation>> for Effect {
+        fn from(request: Request<AnOperation>) -> Self {
+            Self::AnEffect(request)
+        }
+    }
+
+    #[derive(Debug, PartialEq)]
+    pub enum Event {
+        Start,
+        Completed(AnOperationOutput),
+    }
+}
+
 pub mod compose {
     pub mod capabilities {
         pub mod capability_one {

--- a/doctest_support/src/lib.rs
+++ b/doctest_support/src/lib.rs
@@ -5,9 +5,16 @@ pub mod command {
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, PartialEq, Clone, Serialize)]
-    pub struct AnOperation;
+    pub enum AnOperation {
+        One(u8),
+        Two(u8),
+    }
+
     #[derive(Debug, PartialEq, Deserialize)]
-    pub struct AnOperationOutput;
+    pub enum AnOperationOutput {
+        One(u8),
+        Two(u8),
+    }
 
     impl Operation for AnOperation {
         type Output = AnOperationOutput;
@@ -27,6 +34,7 @@ pub mod command {
     pub enum Event {
         Start,
         Completed(AnOperationOutput),
+        Aborted,
     }
 }
 

--- a/doctest_support/src/lib.rs
+++ b/doctest_support/src/lib.rs
@@ -22,6 +22,8 @@ pub mod command {
 
     pub enum Effect {
         AnEffect(Request<AnOperation>),
+        Http(Request<crux_http::protocol::HttpRequest>),
+        Render(Request<crux_core::render::RenderOperation>),
     }
 
     impl From<Request<AnOperation>> for Effect {
@@ -30,11 +32,31 @@ pub mod command {
         }
     }
 
+    impl From<Request<crux_http::protocol::HttpRequest>> for Effect {
+        fn from(request: Request<crux_http::protocol::HttpRequest>) -> Self {
+            Self::Http(request)
+        }
+    }
+
+    impl From<Request<crux_core::render::RenderOperation>> for Effect {
+        fn from(request: Request<crux_core::render::RenderOperation>) -> Self {
+            Self::Render(request)
+        }
+    }
+
+    #[derive(Debug, PartialEq, Deserialize)]
+    pub struct Post {
+        pub url: String,
+        pub title: String,
+        pub body: String,
+    }
+
     #[derive(Debug, PartialEq)]
     pub enum Event {
         Start,
         Completed(AnOperationOutput),
         Aborted,
+        GotPost(Result<crux_http::Response<Post>, crux_http::HttpError>),
     }
 }
 

--- a/doctest_support/src/lib.rs
+++ b/doctest_support/src/lib.rs
@@ -44,7 +44,7 @@ pub mod command {
         }
     }
 
-    #[derive(Debug, PartialEq, Deserialize)]
+    #[derive(Debug, PartialEq, Deserialize, Serialize)]
     pub struct Post {
         pub url: String,
         pub title: String,
@@ -57,6 +57,62 @@ pub mod command {
         Completed(AnOperationOutput),
         Aborted,
         GotPost(Result<crux_http::Response<Post>, crux_http::HttpError>),
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use crux_http::{
+            command::Http,
+            protocol::{HttpRequest, HttpResponse, HttpResult},
+            testing::ResponseBuilder,
+        };
+
+        use crate::command::{Effect, Event, Post};
+
+        #[test]
+        fn http_post() {
+            const API_URL: &str = "https://example.com/api/posts";
+
+            // Create a command to post a new Post to API_URL
+            // and then dispatch an event with the result
+            let mut cmd = Http::post(API_URL)
+                .body(serde_json::json!({"title":"New Post", "body":"Hello!"}))
+                .expect_json()
+                .build()
+                .then_send(Event::GotPost);
+
+            // Check the effect is an HTTP request ...
+            let effect = cmd.effects().next().unwrap();
+            let Effect::Http(mut request) = effect else {
+                panic!("Expected a HTTP effect")
+            };
+
+            // ... and the request is a POST to API_URL
+            assert_eq!(
+                &request.operation,
+                &HttpRequest::post(API_URL)
+                    .header("content-type", "application/json")
+                    .body(r#"{"body":"Hello!","title":"New Post"}"#)
+                    .build()
+            );
+
+            // Resolve the request with a successful response
+            let body = Post {
+                url: API_URL.to_string(),
+                title: "New Post".to_string(),
+                body: "Hello!".to_string(),
+            };
+            request
+                .resolve(HttpResult::Ok(HttpResponse::ok().json(&body).build()))
+                .expect("Resolve should succeed");
+
+            // Check the event is a GotPost event with the successful response
+            let actual = cmd.events().next().unwrap();
+            let expected = Event::GotPost(Ok(ResponseBuilder::ok().body(body).build()));
+            assert_eq!(actual, expected);
+
+            assert!(cmd.is_done());
+        }
     }
 }
 


### PR DESCRIPTION
Improves API docs for the `crux_core::command` module, giving examples of some of the different ways in which `Command`s can be used.