### PR TITLE
Avoid creating deep recursive calls with Command::and

### DIFF
--- a/crux_core/src/command/tests/async_effects.rs
+++ b/crux_core/src/command/tests/async_effects.rs
@@ -235,3 +235,19 @@ fn effects_can_spawn_communicating_tasks() {
 
     assert!(cmd.is_done());
 }
+
+#[test]
+fn tasks_can_be_spawned_on_existing_effects() {
+    let mut cmd: Command<Effect, Event> = Command::done();
+
+    assert!(cmd.is_done());
+    assert!(cmd.effects().next().is_none());
+
+    cmd.spawn(|ctx| async move {
+        ctx.request_from_shell(AnOperation::One).await;
+    });
+
+    // Command is not done any more
+    assert!(!cmd.is_done());
+    assert!(cmd.effects().next().is_some());
+}

--- a/crux_core/src/command/tests/combinators.rs
+++ b/crux_core/src/command/tests/combinators.rs
@@ -225,6 +225,27 @@ fn and() {
 }
 
 #[test]
+fn and_doesnt_blow_the_stack() {
+    let mut cmd: Command<Effect, Event> = Command::done();
+
+    for _ in 1..2000 {
+        cmd = cmd.and(Command::done());
+    }
+
+    // Polling the task should work
+    let _ = cmd.effects();
+}
+
+#[test]
+fn all_doesnt_blow_the_stack() {
+    let commands: Vec<Command<Effect, Event>> = (1..2000).map(|_| Command::done()).collect();
+    let mut cmd = Command::all(commands);
+
+    // Polling the task should work
+    let _ = cmd.effects();
+}
+
+#[test]
 fn all() {
     let cmd_one = Command::request_from_shell(AnOperation::One).then_send(Event::Completed);
     let cmd_two = Command::request_from_shell(AnOperation::Two).then_send(Event::Completed);


### PR DESCRIPTION
Previous implementation of Command::and would create a cons-list shaped structure when folding over a list of commands with `.and`. This change makes it effectively equivalent to creating the folded list with `::all` by wrapping the `other` command in `.and` to be hosted on `self`s pair of channels, and spawning it in `self`.

As a side effect, this also adds a `spawn` API on a mutable command instance. Being pretty much equivalent with `Command::new` in what it can do, I think this can be public, but I could be talked out of that :).

There are potentially other similar optimisations in other places which wrap existing commands in new commands rather than merging them.