### PR TITLE
Experiment: Allow Core to be wrapped in a middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,6 +367,7 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "crux_http",
+ "crux_kv",
  "crux_macros",
  "crux_time",
  "doctest_support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "crux_macros",
  "crux_time",
  "doctest_support",
+ "either",
  "erased-serde",
  "futures",
  "rand 0.8.5",
@@ -553,6 +554,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "encode_unicode"

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = "2.0.11"
 # So I've left them 0.26.0 and 0.4.0 respectively.
 serde-generate = { version = "0.26.0", optional = true }
 serde-reflection = { version = "0.4.0", optional = true }
+either = "1.13.0"
 
 [dev-dependencies]
 assert_fs = "1.1.2"

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -41,6 +41,7 @@ assert_matches = "1.5"
 async-channel = "2.3"
 crux_http = { path = "../crux_http" }
 crux_time = { path = "../crux_time" }
+crux_kv = { path = "../crux_kv" }
 doctest_support = { path = "../doctest_support" }
 serde = { version = "1.0.217", features = ["derive"] }
 static_assertions = "1.1"

--- a/crux_core/src/core/middleware.rs
+++ b/crux_core/src/core/middleware.rs
@@ -1,0 +1,61 @@
+use super::Core;
+
+/// Implement Middleware for a type which wraps the [`Core`] and modifies its behaviour in some way.
+/// This allows this new type to still be wrapped in a [`Bridge`], which is  generic over an
+/// implementation of `Middleware`.
+///
+/// Middleware gets to adapt the incoming Events, the outgoing Effect requests, and the returned view model.
+///
+/// Specifically, this is useful to provide Rust-side implementations of capabilities when they exist,
+/// and are easily portable for the target platforms, so that they don't have to be implemented in the
+/// shell several times.
+pub trait Middleware {
+    type App: crate::App;
+
+    /// Process an event. The middleware may capture or modify the incoming events. Note that these are
+    /// only the events originating outside the core, any internal events will be sent back to th app
+    /// by the `Core` directly
+    fn process_event(
+        &self,
+        event: <Self::App as crate::App>::Event,
+    ) -> impl Iterator<Item = <Self::App as crate::App>::Effect>;
+
+    /// Process any unfinished effects tasks and return any resulting effect requests.
+    ///
+    /// Implementations are expected to call this method after resolving any effect requests to advance
+    /// the effects runtime.
+    ///
+    /// # Discussion
+    ///
+    /// The trait does not provide a `resolve_effect` method, because doing so would require middleware to hold
+    /// original Requests in their original form. As an example, the Bridge does not do this - instead, it converts
+    /// the Request into a similar type working with Serializers instead of values. The Core technically does not
+    /// require the original Request in order to proceed, the requests just needs to be resolved first, the
+    /// `Core` API is more of a convenience.
+    ///
+    // FIXME: This will generally just forward down, is there a way to provide a default implementation...?
+    fn process_effects(&self) -> impl Iterator<Item = <Self::App as crate::App>::Effect>;
+
+    /// Return the view model from the app. This gives the middleware a chance to modify the view model
+    /// on the way out
+    fn view(&self) -> <Self::App as crate::App>::ViewModel;
+}
+
+impl<A: crate::App> Middleware for Core<A> {
+    type App = A;
+
+    fn process_event(
+        &self,
+        event: <Self::App as crate::App>::Event,
+    ) -> impl Iterator<Item = <Self::App as crate::App>::Effect> {
+        self.process_event(event)
+    }
+
+    fn process_effects(&self) -> impl Iterator<Item = <Self::App as crate::App>::Effect> {
+        self.process()
+    }
+
+    fn view(&self) -> <Self::App as crate::App>::ViewModel {
+        self.view()
+    }
+}

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -171,7 +171,7 @@ pub use self::{
     capabilities::*,
     capability::{Capability, WithContext},
     command::Command,
-    core::{Core, Effect, Request},
+    core::{Core, Effect, Middleware, Request},
 };
 pub use crux_macros as macros;
 

--- a/crux_core/tests/capability_runtime.rs
+++ b/crux_core/tests/capability_runtime.rs
@@ -217,7 +217,7 @@ mod tests {
     fn fetches_a_tree() {
         let core: Core<MyApp> = Core::new();
 
-        let mut effects: VecDeque<Effect> = core.process_event(Event::Fetch).into();
+        let mut effects: VecDeque<Effect> = core.process_event(Event::Fetch).collect();
 
         let mut counter: usize = 1;
 
@@ -234,7 +234,7 @@ mod tests {
 
                     counter += 3;
 
-                    let effs: Vec<Effect> = core.resolve(&mut request, output);
+                    let effs: Vec<Effect> = core.resolve(&mut request, output).collect();
 
                     for e in effs {
                         effects.push_back(e)
@@ -262,7 +262,7 @@ mod tests {
         let core: Core<MyApp> = Core::new();
 
         // Spawns the task
-        core.process_event(Event::Fetch);
+        let _ = core.process_event(Event::Fetch);
 
         drop(core);
     }

--- a/crux_core/tests/in_memory_kv.rs
+++ b/crux_core/tests/in_memory_kv.rs
@@ -1,0 +1,335 @@
+mod app {
+    use crux_core::{render::render, Command};
+    use crux_kv::{command::KeyValue, error::KeyValueError};
+    use crux_macros::Effect;
+    use serde::Serialize;
+
+    use crate::middlware::EffectWithKV;
+
+    #[derive(Default)]
+    pub struct TestApp;
+
+    #[derive(Serialize)]
+    pub enum Event {
+        Set {
+            key: String,
+            value: String,
+        },
+        Show {
+            key: String,
+        },
+
+        #[serde(skip)]
+        ValueSet,
+        ValueReceived(String, Result<Option<Vec<u8>>, KeyValueError>),
+    }
+
+    #[derive(Default, Clone, Serialize)]
+    pub struct Model {
+        pub current_key: Option<String>,
+        pub current_value: Option<String>,
+    }
+
+    #[derive(Effect)]
+    #[allow(unused)]
+    pub struct Capabilities {
+        kv: crux_kv::KeyValue<Event>,
+        render: crux_core::render::Render<Event>,
+    }
+
+    // Allow the middleware to unpick the Effect
+    impl EffectWithKV for Effect {
+        fn into_kv(self) -> Option<crux_core::Request<crux_kv::KeyValueOperation>> {
+            self.into_kv()
+        }
+
+        fn is_kv(&self) -> bool {
+            self.is_kv()
+        }
+    }
+
+    impl crux_core::App for TestApp {
+        type Event = Event;
+
+        type Model = Model;
+
+        type ViewModel = Model;
+
+        type Capabilities = Capabilities;
+
+        type Effect = Effect;
+
+        fn update(
+            &self,
+            event: Self::Event,
+            model: &mut Self::Model,
+            _caps: &Self::Capabilities,
+        ) -> crux_core::Command<Effect, Event> {
+            match event {
+                Event::Set { key, value } => {
+                    KeyValue::set(key, value.into()).then_send(|_| Event::ValueSet)
+                }
+                Event::Show { key } => {
+                    KeyValue::get(key.clone()).then_send(|r| Event::ValueReceived(key, r))
+                }
+                Event::ValueSet => Command::done(),
+                Event::ValueReceived(key, Ok(Some(bytes))) => {
+                    if let Ok(value) = String::from_utf8(bytes) {
+                        model.current_key = Some(key);
+                        model.current_value = Some(value);
+                    }
+
+                    render()
+                }
+                Event::ValueReceived(_key, Err(_)) | Event::ValueReceived(_key, Ok(None)) => {
+                    model.current_key = None;
+                    model.current_value = None;
+
+                    render()
+                }
+            }
+        }
+
+        fn view(&self, model: &Self::Model) -> Self::ViewModel {
+            model.clone()
+        }
+    }
+}
+
+mod middlware {
+    use std::{
+        collections::{HashMap, VecDeque},
+        sync::{Arc, Mutex},
+    };
+
+    use crux_core::{App, Middleware, Request};
+    use crux_kv::{
+        error::KeyValueError, value::Value, KeyValueOperation, KeyValueResponse, KeyValueResult,
+    };
+
+    #[derive(Default, Clone)]
+    struct Storage(Arc<Mutex<HashMap<String, Vec<u8>>>>);
+
+    impl Storage {
+        fn process_kv_operation(&self, operation: KeyValueOperation) -> KeyValueResult {
+            match operation {
+                KeyValueOperation::Get { key } => match self.0.lock() {
+                    Err(_) => KeyValueResult::Err {
+                        error: KeyValueError::Io {
+                            message: "Could not acquire KV store lock".to_string(),
+                        },
+                    },
+                    Ok(store) => match store.get(&key) {
+                        Some(value) => KeyValueResult::Ok {
+                            response: KeyValueResponse::Get {
+                                value: Value::Bytes(value.clone()),
+                            },
+                        },
+                        None => KeyValueResult::Ok {
+                            response: KeyValueResponse::Get { value: Value::None },
+                        },
+                    },
+                },
+                KeyValueOperation::Set { key, value } => match self.0.lock() {
+                    Err(_) => KeyValueResult::Err {
+                        error: KeyValueError::Io {
+                            message: "Could not acquire KV store lock".to_string(),
+                        },
+                    },
+                    Ok(mut store) => match store.insert(key, value) {
+                        Some(previous_value) => KeyValueResult::Ok {
+                            response: KeyValueResponse::Set {
+                                previous: Value::Bytes(previous_value),
+                            },
+                        },
+                        None => KeyValueResult::Ok {
+                            response: KeyValueResponse::Set {
+                                previous: Value::None,
+                            },
+                        },
+                    },
+                },
+
+                // Skip the rest, this is a demo implementation
+                _ => unimplemented!(),
+            }
+        }
+    }
+
+    pub struct InMemoryKv<Core: crux_core::Middleware> {
+        store: Storage,
+        core: Core,
+    }
+
+    pub trait EffectWithKV {
+        fn is_kv(&self) -> bool;
+
+        fn into_kv(self) -> Option<Request<KeyValueOperation>>;
+    }
+
+    // This is a special iterator which skips and queues up KV effects, until the previous iterator runs out,
+    // then pulls of the queue and processes the KV effect, and reads the new iterator in the same way
+    struct QueueKV<'core, Core>
+    where
+        Core: Middleware,
+    {
+        kv_requests: VecDeque<Request<KeyValueOperation>>,
+        inner: Option<Box<dyn Iterator<Item = <<Core as Middleware>::App as App>::Effect> + 'core>>,
+        store: Storage,
+        core: &'core Core,
+    }
+
+    impl<'core, Core> Iterator for QueueKV<'core, Core>
+    where
+        Core: Middleware,
+        <<Core as Middleware>::App as App>::Effect: EffectWithKV,
+    {
+        type Item = <<Core as Middleware>::App as App>::Effect;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            loop {
+                if let Some(effects) = &mut self.inner {
+                    if let Some(effect) = effects.next() {
+                        if effect.is_kv() {
+                            let Some(kv_request) = effect.into_kv() else {
+                                unreachable!();
+                            };
+
+                            self.kv_requests.push_back(kv_request);
+                        } else {
+                            return Some(effect);
+                        }
+                    }
+                }
+
+                // Pull the next request, process it and swap the inner iterator for the
+                // follow up effects
+                if let Some(mut kv_request) = self.kv_requests.pop_front() {
+                    let mut operation = KeyValueOperation::Get {
+                        key: "".to_string(),
+                    };
+                    std::mem::swap(&mut kv_request.operation, &mut operation);
+
+                    let result = self.store.process_kv_operation(operation);
+
+                    kv_request.resolve(result).expect("to resolve");
+
+                    let follow_ups = self.core.process_effects();
+
+                    self.inner = Some(Box::new(follow_ups));
+                } else {
+                    // Nothing more to do
+                    return None;
+                }
+            }
+        }
+    }
+
+    impl<Core: Middleware> InMemoryKv<Core>
+    where
+        <<Core as crux_core::Middleware>::App as crux_core::App>::Effect: EffectWithKV,
+    {
+        pub fn new(core: Core) -> Self {
+            Self {
+                store: Default::default(),
+                core,
+            }
+        }
+
+        fn process_kv<'a>(
+            &'a self,
+            effects: impl Iterator<Item = <<Core as Middleware>::App as App>::Effect> + 'a,
+        ) -> QueueKV<'a, Core>
+        where
+            <Core::App as crux_core::App>::Effect: EffectWithKV,
+        {
+            QueueKV {
+                kv_requests: VecDeque::new(),
+                inner: Some(Box::new(effects)),
+                store: self.store.clone(),
+                core: &self.core,
+            }
+        }
+    }
+
+    impl<Core: Middleware> crux_core::Middleware for InMemoryKv<Core>
+    where
+        <Core::App as crux_core::App>::Effect: EffectWithKV,
+    {
+        type App = <Core as Middleware>::App;
+
+        fn process_event(
+            &self,
+            event: <Self::App as crux_core::App>::Event,
+        ) -> impl Iterator<Item = <Self::App as crux_core::App>::Effect> {
+            self.process_kv(self.core.process_event(event))
+        }
+
+        fn process_effects(&self) -> impl Iterator<Item = <Self::App as crux_core::App>::Effect> {
+            self.process_kv(self.core.process_effects())
+        }
+
+        fn view(&self) -> <Self::App as crux_core::App>::ViewModel {
+            self.core.view()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        app::{Effect, Event, TestApp},
+        middlware::InMemoryKv,
+    };
+    use crux_core::{Core, Middleware};
+
+    #[test]
+    fn kv_gets_processed() {
+        let core = InMemoryKv::new(Core::<TestApp>::new());
+
+        // Nothing shown
+
+        let view = core.view();
+        assert_eq!(view.current_key, None);
+        assert_eq!(view.current_value, None);
+
+        let mut effects = core.process_event(Event::Set {
+            key: "captain".to_string(),
+            value: "Jean-Luc Picard".to_string(),
+        });
+
+        let effect = effects.next();
+        assert!(effect.is_none());
+
+        // Still nothing shown
+
+        let view = core.view();
+        assert_eq!(view.current_key, None);
+        assert_eq!(view.current_value, None);
+
+        let mut effects = core.process_event(Event::Set {
+            key: "first-officer".to_string(),
+            value: "William T. Riker".to_string(),
+        });
+
+        assert!(effects.next().is_none());
+
+        // Still nothing shown
+
+        let view = core.view();
+        assert_eq!(view.current_key, None);
+        assert_eq!(view.current_value, None);
+
+        let mut effects = core.process_event(Event::Show {
+            key: "captain".to_string(),
+        });
+
+        assert!(matches!(effects.next(), Some(Effect::Render(_))));
+
+        // Correct value shown, KV must have worked!
+
+        let view = core.view();
+        assert_eq!(view.current_key, Some("captain".to_string()));
+        assert_eq!(view.current_value, Some("Jean-Luc Picard".to_string()));
+    }
+}

--- a/crux_core/tests/json_bridge.rs
+++ b/crux_core/tests/json_bridge.rs
@@ -42,11 +42,11 @@ mod app {
 }
 
 mod core {
-    use crux_core::bridge::BridgeWithSerializer;
+    use crux_core::{bridge::BridgeWithSerializer, Core};
 
     use crate::app::App;
 
-    pub type Bridge = BridgeWithSerializer<App>;
+    pub type Bridge = BridgeWithSerializer<Core<App>>;
 }
 
 mod tests {

--- a/crux_http/tests/capability_with_shell.rs
+++ b/crux_http/tests/capability_with_shell.rs
@@ -138,8 +138,8 @@ mod shell {
         Ok(received)
     }
 
-    fn enqueue_effects(queue: &mut VecDeque<Task>, effects: Vec<Effect>) {
-        queue.append(&mut effects.into_iter().map(Task::Effect).collect())
+    fn enqueue_effects(queue: &mut VecDeque<Task>, effects: impl Iterator<Item = Effect>) {
+        queue.append(&mut effects.map(Task::Effect).collect())
     }
 }
 

--- a/crux_http/tests/command_with_shell.rs
+++ b/crux_http/tests/command_with_shell.rs
@@ -137,7 +137,7 @@ mod shell {
         Ok(received)
     }
 
-    fn enqueue_effects(queue: &mut VecDeque<Task>, effects: Vec<Effect>) {
+    fn enqueue_effects(queue: &mut VecDeque<Task>, effects: impl Iterator<Item = Effect>) {
         queue.append(&mut effects.into_iter().map(Task::Effect).collect())
     }
 }

--- a/crux_platform/tests/platform_test.rs
+++ b/crux_platform/tests/platform_test.rs
@@ -85,9 +85,9 @@ mod shell {
             let msg = queue.pop_front();
 
             let effs = match msg {
-                Some(CoreMessage::Event(m)) => core.process_event(m),
+                Some(CoreMessage::Event(m)) => core.process_event(m).collect(),
                 Some(CoreMessage::Response(Outcome::Platform(mut request, outcome))) => {
-                    core.resolve(&mut request, outcome)
+                    core.resolve(&mut request, outcome).collect()
                 }
 
                 _ => vec![],

--- a/crux_time/tests/time_test.rs
+++ b/crux_time/tests/time_test.rs
@@ -162,10 +162,10 @@ mod shell {
             let msg = queue.pop_front();
 
             let effs = match msg {
-                Some(CoreMessage::Event(m)) => core.process_event(m),
-                Some(CoreMessage::Response(Outcome::Time(mut request, instant))) => {
-                    core.resolve(&mut request, TimeResponse::Now { instant })
-                }
+                Some(CoreMessage::Event(m)) => core.process_event(m).collect(),
+                Some(CoreMessage::Response(Outcome::Time(mut request, instant))) => core
+                    .resolve(&mut request, TimeResponse::Now { instant })
+                    .collect(),
                 _ => vec![],
             };
 


### PR DESCRIPTION
This is a bit work in progress, but it's a start of a potential approach to allowing "hybrid" shells - part written in Rust, part written in Kotlin/Swift/TypeScript... 

The main change is an introduction of a `crux_core::Middleware` trait, which is implemented by the `Core` and expected by the `Bridge` to be implemented by the provided core type. This allows middlewares to be inserted between the Bridge and the Core. Because the middleware may stack up, I've also switched the Core to return an iterator over effects, to avoid unnecessary allocations in case the middleware chain ends up long.

As part of the experiment I've implemented a Key-Value capability using a HashMap for the storage, which catches the KV effects and resolves them against the store. It turns out it's pretty involved, because resolving he effects may produce follow up effects which need to also be potentially processed and so on, creating a mutually recursive loop. 

Doing that with existing iterators turned out quite difficult, so I've resorted to an odd specialised queueing FlatMap sort of thing, which seems like it might be a beginning of some more helpful abstraction.

I'll keep this open for now so that folks can experiment and see how it works out for them and we can iterate on it before we land on something solid.

Note that this would be a breaking change, so I'd like us to get it right, rather than releasing five breaking iterations 😓 