### PR TITLE
Error handling in the Bridge

### DIFF
--- a/crux_core/src/bridge/registry.rs
+++ b/crux_core/src/bridge/registry.rs
@@ -3,9 +3,8 @@ use std::sync::Mutex;
 use serde::{Deserialize, Serialize};
 use slab::Slab;
 
-use super::Request;
+use super::{BridgeError, Request};
 use crate::bridge::request_serde::ResolveSerialized;
-use crate::core::ResolveError;
 use crate::Effect;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -53,7 +52,7 @@ impl ResolveRegistry {
         &self,
         id: EffectId,
         body: &mut dyn erased_serde::Deserializer,
-    ) -> Result<(), ResolveError> {
+    ) -> Result<(), BridgeError> {
         let mut registry_lock = self.0.lock().expect("Registry Mutex poisoned");
 
         let entry = registry_lock.get_mut(id.0 as usize);

--- a/crux_core/src/bridge/request_serde.rs
+++ b/crux_core/src/bridge/request_serde.rs
@@ -4,11 +4,14 @@ use crate::{
     Request,
 };
 
+use super::BridgeError;
+
 // used in docs/internals/bridge.md
 // ANCHOR: resolve_serialized
-type ResolveOnceSerialized = Box<dyn FnOnce(&mut dyn erased_serde::Deserializer) + Send>;
+type ResolveOnceSerialized =
+    Box<dyn FnOnce(&mut dyn erased_serde::Deserializer) -> Result<(), BridgeError> + Send>;
 type ResolveManySerialized =
-    Box<dyn FnMut(&mut dyn erased_serde::Deserializer) -> Result<(), ()> + Send>;
+    Box<dyn FnMut(&mut dyn erased_serde::Deserializer) -> Result<(), BridgeError> + Send>;
 
 /// A deserializing version of Resolve
 ///
@@ -27,7 +30,7 @@ impl ResolveSerialized {
     pub(crate) fn resolve(
         &mut self,
         bytes: &mut dyn erased_serde::Deserializer,
-    ) -> Result<(), ResolveError> {
+    ) -> Result<(), BridgeError> {
         match self {
             ResolveSerialized::Never => Err(ResolveError::Never),
             ResolveSerialized::Many(f) => f(bytes).map_err(|_| ResolveError::FinishedMany),
@@ -36,12 +39,13 @@ impl ResolveSerialized {
                 if let ResolveSerialized::Once(f) =
                     std::mem::replace(self, ResolveSerialized::Never)
                 {
-                    f(bytes);
+                    f(bytes)?
                 }
 
                 Ok(())
             }
         }
+        .map_err(BridgeError::ProcessResponse)
     }
 }
 
@@ -63,7 +67,7 @@ where
         let (operation, resolve) = (self.operation, self.resolve);
 
         let resolve = resolve.deserializing(move |deserializer| {
-            erased_serde::deserialize(deserializer).expect("Deserialization failed")
+            erased_serde::deserialize(deserializer).map_err(BridgeError::DeserializeOutput)
         });
 
         (effect(operation), resolve)
@@ -75,18 +79,21 @@ impl<Out> Resolve<Out> {
     /// The `func` argument is a 'deserializer' converting from bytes into the `Out` type.
     fn deserializing<F>(self, mut func: F) -> ResolveSerialized
     where
-        F: (FnMut(&mut dyn erased_serde::Deserializer) -> Out) + Send + Sync + 'static,
+        F: (FnMut(&mut dyn erased_serde::Deserializer) -> Result<Out, BridgeError>)
+            + Send
+            + Sync
+            + 'static,
         Out: 'static,
     {
         match self {
             Resolve::Never => ResolveSerialized::Never,
             Resolve::Once(resolve) => ResolveSerialized::Once(Box::new(move |deser| {
-                let out = func(deser);
-                resolve(out)
+                let out = func(deser)?;
+                Ok(resolve(out))
             })),
             Resolve::Many(resolve) => ResolveSerialized::Many(Box::new(move |deser| {
-                let out = func(deser);
-                resolve(out)
+                let out = func(deser)?;
+                resolve(out).map_err(|_| BridgeError::ProcessResponse(ResolveError::FinishedMany))
             })),
         }
     }

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -104,7 +104,11 @@ where
     // used in docs/internals/runtime.md and docs/internals/bridge.md
     // ANCHOR: resolve
     // ANCHOR: resolve_sig
-    pub fn resolve<Op>(&self, request: &mut Request<Op>, result: Op::Output) -> Vec<A::Effect>
+    pub fn resolve<Op>(
+        &self,
+        request: &mut Request<Op>,
+        result: Op::Output,
+    ) -> Result<Vec<A::Effect>, ResolveError>
     where
         Op: Operation,
         // ANCHOR_END: resolve_sig
@@ -112,7 +116,9 @@ where
         let resolve_result = request.resolve(result);
         debug_assert!(resolve_result.is_ok());
 
-        self.process()
+        resolve_result?;
+
+        Ok(self.process())
     }
     // ANCHOR_END: resolve
 

--- a/crux_core/tests/capability_runtime.rs
+++ b/crux_core/tests/capability_runtime.rs
@@ -234,7 +234,7 @@ mod tests {
 
                     counter += 3;
 
-                    let effs: Vec<Effect> = core.resolve(&mut request, output);
+                    let effs: Vec<Effect> = core.resolve(&mut request, output).expect("to resolve");
 
                     for e in effs {
                         effects.push_back(e)

--- a/crux_core/tests/json_bridge.rs
+++ b/crux_core/tests/json_bridge.rs
@@ -63,7 +63,9 @@ mod tests {
         let mut effects_bytes = vec![];
         let mut result_ser = serde_json::Serializer::new(&mut effects_bytes);
 
-        bridge.process_event(&event, &mut result_ser);
+        bridge
+            .process_event(&event, &mut result_ser)
+            .expect("event should process");
 
         let actual_value: Value = serde_json::from_slice(&effects_bytes).unwrap();
 

--- a/crux_http/tests/capability_with_shell.rs
+++ b/crux_http/tests/capability_with_shell.rs
@@ -128,7 +128,8 @@ mod shell {
 
                         enqueue_effects(
                             &mut queue,
-                            core.resolve(&mut request, HttpResult::Ok(response)),
+                            core.resolve(&mut request, HttpResult::Ok(response))
+                                .expect("effect should resolve"),
                         );
                     }
                 },

--- a/crux_http/tests/command_with_shell.rs
+++ b/crux_http/tests/command_with_shell.rs
@@ -127,7 +127,8 @@ mod shell {
 
                         enqueue_effects(
                             &mut queue,
-                            core.resolve(&mut request, HttpResult::Ok(response)),
+                            core.resolve(&mut request, HttpResult::Ok(response))
+                                .expect("effect should resolve"),
                         );
                     }
                 },

--- a/crux_platform/tests/platform_test.rs
+++ b/crux_platform/tests/platform_test.rs
@@ -86,9 +86,9 @@ mod shell {
 
             let effs = match msg {
                 Some(CoreMessage::Event(m)) => core.process_event(m),
-                Some(CoreMessage::Response(Outcome::Platform(mut request, outcome))) => {
-                    core.resolve(&mut request, outcome)
-                }
+                Some(CoreMessage::Response(Outcome::Platform(mut request, outcome))) => core
+                    .resolve(&mut request, outcome)
+                    .expect("effect should resolve"),
 
                 _ => vec![],
             };

--- a/crux_time/tests/time_test.rs
+++ b/crux_time/tests/time_test.rs
@@ -163,9 +163,9 @@ mod shell {
 
             let effs = match msg {
                 Some(CoreMessage::Event(m)) => core.process_event(m),
-                Some(CoreMessage::Response(Outcome::Time(mut request, instant))) => {
-                    core.resolve(&mut request, TimeResponse::Now { instant })
-                }
+                Some(CoreMessage::Response(Outcome::Time(mut request, instant))) => core
+                    .resolve(&mut request, TimeResponse::Now { instant })
+                    .expect("effect should resolve"),
                 _ => vec![],
             };
 


### PR DESCRIPTION
**This is a breaking change**

It allows serde and resolve errors in the bridge to be caught and inspected, so instead of crashing the core, they can be passed to telemetry, etc.

# to do
- [x] introduce results, errot types etc
- [ ] add tests for the various bridge failures, check the errors provide enough info