### PR TITLE
chore: update core.md to reference crux 0.12.0

### DIFF
--- a/docs/src/getting_started/core.md
+++ b/docs/src/getting_started/core.md
@@ -57,7 +57,7 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 anyhow = "1.0.95"
-crux_core = "0.11.1"
+crux_core = "0.12.0"
 serde = "1.0.217"
 ```
 


### PR DESCRIPTION
### Summary

* This PR attempts to improve the crux getting started documentation here: https://redbadger.github.io/crux/getting_started/core.html
  * The minor change being made is to update the referenced `crux_core` version to be `0.12.0`, since that was needed to compile the rest of the example code.