### PR TITLE
`crux_time` API w.r.t `TimerId`

### DIFF
--- a/crux_time/src/command.rs
+++ b/crux_time/src/command.rs
@@ -217,6 +217,12 @@ impl PartialEq<CompletedTimerHandle> for TimerHandle {
     }
 }
 
+impl PartialEq<TimerHandle> for CompletedTimerHandle {
+    fn eq(&self, other: &TimerHandle) -> bool {
+        self.timer_id == other.timer_id
+    }
+}
+
 impl From<TimerHandle> for CompletedTimerHandle {
     fn from(value: TimerHandle) -> Self {
         Self {

--- a/crux_time/src/command.rs
+++ b/crux_time/src/command.rs
@@ -14,7 +14,7 @@ use crate::{get_timer_id, TimeRequest, TimeResponse, TimerId};
 
 /// Result of the timer run. Timers can either run to completion or be cleared early.
 #[derive(Debug, PartialEq, Eq)]
-pub enum TimerStatus {
+pub enum TimerOutcome {
     /// Timer completed successfully.
     Completed(CompletedTimerHandle),
     /// Timer was cleared early.
@@ -48,7 +48,7 @@ where
     pub fn notify_at(
         system_time: SystemTime,
     ) -> (
-        RequestBuilder<Effect, Event, impl Future<Output = TimerStatus>>,
+        RequestBuilder<Effect, Event, impl Future<Output = TimerOutcome>>,
         TimerHandle,
     ) {
         let timer_id = get_timer_id();
@@ -82,7 +82,7 @@ where
                             panic!("InstantArrived with unexpected timer ID");
                         }
 
-                        TimerStatus::Completed(completed_handle)
+                        TimerOutcome::Completed(completed_handle)
                     },
                     cleared = receiver => {
                         // The Err variant would mean the sender was dropped,
@@ -101,7 +101,7 @@ where
                             panic!("Cleared with unexpected timer ID");
                         }
 
-                        TimerStatus::Cleared
+                        TimerOutcome::Cleared
                     }
                 }
             }
@@ -115,7 +115,7 @@ where
     pub fn notify_after(
         duration: Duration,
     ) -> (
-        RequestBuilder<Effect, Event, impl Future<Output = TimerStatus>>,
+        RequestBuilder<Effect, Event, impl Future<Output = TimerOutcome>>,
         TimerHandle,
     ) {
         let timer_id = get_timer_id();
@@ -144,7 +144,7 @@ where
                         panic!("InstantArrived with unexpected timer ID");
                     }
 
-                    TimerStatus::Completed(completed_handle)
+                    TimerOutcome::Completed(completed_handle)
                 }
                 cleared = receiver => {
                     // The Err variant would mean the sender was dropped,
@@ -163,7 +163,7 @@ where
                         panic!("Cleared with unexpected timer ID");
                     }
 
-                    TimerStatus::Cleared
+                    TimerOutcome::Cleared
                 }
             }
         });
@@ -231,7 +231,7 @@ mod tests {
 
     use crux_core::Request;
 
-    use super::{Time, TimerStatus};
+    use super::{Time, TimerOutcome};
     use crate::{TimeRequest, TimeResponse};
 
     enum Effect {
@@ -246,7 +246,7 @@ mod tests {
 
     #[derive(Debug, PartialEq)]
     enum Event {
-        Elapsed(TimerStatus),
+        Elapsed(TimerOutcome),
     }
 
     #[test]
@@ -281,7 +281,7 @@ mod tests {
 
         let event = cmd.events().next();
 
-        assert!(matches!(event, Some(Event::Elapsed(TimerStatus::Cleared))));
+        assert!(matches!(event, Some(Event::Elapsed(TimerOutcome::Cleared))));
     }
 
     #[test]
@@ -310,7 +310,7 @@ mod tests {
 
         assert!(matches!(
             event,
-            Some(Event::Elapsed(TimerStatus::Completed(_)))
+            Some(Event::Elapsed(TimerOutcome::Completed(_)))
         ));
     }
 }

--- a/crux_time/src/command.rs
+++ b/crux_time/src/command.rs
@@ -124,12 +124,25 @@ impl PartialEq for TimerHandle {
     }
 }
 
+impl PartialEq<TimerId> for TimerHandle {
+    fn eq(&self, other: &TimerId) -> bool {
+        self.timer_id == *other
+    }
+}
+
+impl PartialEq<TimerHandle> for TimerId {
+    fn eq(&self, other: &TimerHandle) -> bool {
+        *self == other.timer_id
+    }
+}
+
 impl TimerHandle {
-    /// Clear the associated timer request. The original task will resolve
-    /// with `TimeResponse::Cleared`
-    /// and the shell will be notified that the timer has been cleared
-    /// with `TimeRequest::Cleared { id }`,
-    /// so it can clean up associated resources
+    /// Clear the associated timer request.
+    /// The shell will be notified that the timer has been cleared
+    /// with `TimeRequest::Clear { id }`,
+    /// so it can clean up associated resources.
+    /// The original task will resolve
+    /// with `TimeResponse::Cleared { id }`.
     pub fn clear(self) {
         let _ = self.abort.send(self.timer_id);
     }

--- a/crux_time/src/command.rs
+++ b/crux_time/src/command.rs
@@ -142,7 +142,6 @@ where
                         duration: duration.into()
                     }
                 ).fuse() => {
-
                     let TimeResponse::DurationElapsed { id } = response else {
                         panic!("Unexpected response to TimeRequest::NotifyAt");
                     };

--- a/crux_time/src/command.rs
+++ b/crux_time/src/command.rs
@@ -13,7 +13,7 @@ use futures::{
 use crate::{get_timer_id, TimeRequest, TimeResponse, TimerId};
 
 /// Result of the timer run. Timers can either run to completion or be cleared early.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TimerOutcome {
     /// Timer completed successfully.
     Completed(CompletedTimerHandle),
@@ -192,7 +192,7 @@ impl TimerHandle {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CompletedTimerHandle {
     timer_id: TimerId,
 }

--- a/crux_time/src/command.rs
+++ b/crux_time/src/command.rs
@@ -12,9 +12,12 @@ use futures::{
 
 use crate::{get_timer_id, TimeRequest, TimeResponse, TimerId};
 
+/// Result of the timer run. Timers can either run to completion or be cleared early.
 #[derive(Debug, PartialEq, Eq)]
 pub enum TimerStatus {
+    /// Timer completed successfully.
     Completed(CompletedTimerHandle),
+    /// Timer was cleared early.
     Cleared,
 }
 

--- a/crux_time/tests/cancellation.rs
+++ b/crux_time/tests/cancellation.rs
@@ -143,14 +143,13 @@ fn cancellation_of_a_started_timer() {
     };
     assert_eq!(cancel_id, TIMER_ID);
 
-    // note, the shell does _not_ need to respond to say it has cleaned up,
-    // but if it does, the core should ignore it, as it has already been cancelled...
+    // the shell can respond to say it has cleaned up
     let response = TimeResponse::Cleared { id: TIMER_ID };
     request.resolve(response).unwrap();
 
     // ...no effects
     assert!(cmd1.effects().next().is_none());
-    // ...but one event with an error to say it is already cleared,
+    // ...and one event with an error to say it is already cleared,
     assert_eq!(
         cmd1.events().next().unwrap(),
         Event::Stop(Err(TimerError::Cleared))

--- a/crux_time/tests/cancellation.rs
+++ b/crux_time/tests/cancellation.rs
@@ -1,0 +1,128 @@
+use std::time::Duration;
+
+use crux_core::{App, Command, Request};
+use crux_time::{
+    command::{Time, TimerHandle},
+    TimeRequest, TimeResponse, TimerId,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Event {
+    Start,
+    Tick(TimeResponse),
+    Cancel(TimerId),
+}
+
+pub enum Effect {
+    Time(Request<TimeRequest>),
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum EffectFfi {
+    Time(TimeRequest),
+}
+
+impl crux_core::Effect for Effect {
+    type Ffi = EffectFfi;
+    fn serialize(self) -> (Self::Ffi, crux_core::bridge::ResolveSerialized) {
+        match self {
+            Effect::Time(request) => request.serialize(EffectFfi::Time),
+        }
+    }
+}
+
+impl From<Request<TimeRequest>> for Effect {
+    fn from(value: Request<TimeRequest>) -> Self {
+        Self::Time(value)
+    }
+}
+
+#[derive(Default)]
+struct Model {
+    timer_handle: Option<TimerHandle>,
+    ticks: u32,
+}
+
+#[derive(Default)]
+struct Timer;
+
+impl App for Timer {
+    type Event = Event;
+    type Model = Model;
+    type ViewModel = ();
+    type Capabilities = ();
+    type Effect = Effect;
+
+    fn update(
+        &self,
+        event: Self::Event,
+        model: &mut Self::Model,
+        _caps: &Self::Capabilities,
+    ) -> Command<Self::Effect, Self::Event> {
+        match event {
+            Event::Start => {
+                let (request, handle) = Time::notify_after(Duration::from_secs(1));
+                model.timer_handle = Some(handle);
+                request.then_send(Event::Tick)
+            }
+            Event::Tick(response) => {
+                let TimeResponse::DurationElapsed { id: _ } = response else {
+                    panic!("Unexpected response");
+                };
+                model.ticks += 1;
+                Command::done()
+            }
+            Event::Cancel(id) => {
+                if let Some(handle) = model.timer_handle.take() {
+                    if id == handle {
+                        println!("Timer cancelled");
+                        handle.clear();
+                    }
+                }
+                Command::done()
+            }
+        }
+    }
+
+    fn view(&self, _model: &Self::Model) -> Self::ViewModel {}
+}
+
+#[test]
+fn ticking_timer_can_be_cancelled() {
+    let app = Timer::default();
+    let mut model = Model::default();
+
+    const TIMER_ID: TimerId = TimerId(1);
+
+    // start the timer
+    let mut cmd1 = app.update(Event::Start, &mut model, &());
+
+    let effect = cmd1.effects().next().unwrap();
+
+    let Effect::Time(request) = effect;
+    assert_eq!(
+        request.operation,
+        TimeRequest::NotifyAfter {
+            id: TIMER_ID,
+            duration: crux_time::Duration::from_secs(1)
+        }
+    );
+
+    // cancel the timer
+    let mut cmd2 = app.update(Event::Cancel(TIMER_ID), &mut model, &());
+    assert!(cmd2.effects().next().is_none());
+
+    // the first command should resolve with a TimeRequest::Clear
+    let effect = cmd1.effects().next();
+
+    let Some(Effect::Time(request)) = effect else {
+        panic!("should get an effect");
+    };
+
+    let cancel_id = match &request.operation {
+        TimeRequest::Clear { id } => id.clone(),
+        _ => panic!("expected a Clear"),
+    };
+    assert_eq!(cancel_id, TIMER_ID);
+}

--- a/crux_time/tests/cancellation.rs
+++ b/crux_time/tests/cancellation.rs
@@ -88,7 +88,7 @@ impl App for Timer {
 
 #[test]
 fn ticking_timer_can_be_cancelled() {
-    let app = Timer::default();
+    let app = Timer;
     let mut model = Model::default();
 
     const TIMER_ID: TimerId = TimerId(1);
@@ -119,7 +119,7 @@ fn ticking_timer_can_be_cancelled() {
     };
 
     let cancel_id = match &request.operation {
-        TimeRequest::Clear { id } => id.clone(),
+        TimeRequest::Clear { id } => *id,
         _ => panic!("expected a Clear"),
     };
     assert_eq!(cancel_id, TIMER_ID);

--- a/examples/bridge_echo/Cargo.lock
+++ b/examples/bridge_echo/Cargo.lock
@@ -421,7 +421,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crux_core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "darling",
  "proc-macro-error",

--- a/examples/cat_facts/Cargo.lock
+++ b/examples/cat_facts/Cargo.lock
@@ -387,7 +387,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crux_core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "crux_kv"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "crux_platform"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "crux_core",
  "serde",
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "crux_time"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "crux_core",

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -981,7 +981,7 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crux_core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1019,7 +1019,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "darling",
  "proc-macro-error",

--- a/examples/hello_world/Cargo.lock
+++ b/examples/hello_world/Cargo.lock
@@ -201,7 +201,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crux_core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -261,15 +261,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.99",
-]
-
-[[package]]
-name = "erased-discriminant"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a6df962265a53221f29081896c412ef325c17fa7d638cd9578febe53d3c82c"
-dependencies = [
- "typeid",
 ]
 
 [[package]]
@@ -785,11 +776,10 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.29.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec51f7c5180dff94df5ee82f9bcbac59e8d6690c8bcbebd98a73977592bd5f2"
+checksum = "8309fc8d475cf5884e92a463b3a003d433684335be19c3f739af0451b027254b"
 dependencies = [
- "anyhow",
  "heck 0.3.3",
  "include_dir",
  "phf",
@@ -800,15 +790,13 @@ dependencies = [
 
 [[package]]
 name = "serde-reflection"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bef77b40d103fda6c10d29c21f5c78c980e8570e1a290a648a9ff5011f96e1"
+checksum = "5b6798a64289ff550d8d79847467789a5fd30b42c9c406a4d6dc0bc9b567e55c"
 dependencies = [
- "erased-discriminant",
  "once_cell",
  "serde",
  "thiserror 1.0.69",
- "typeid",
 ]
 
 [[package]]

--- a/examples/notes/Cargo.lock
+++ b/examples/notes/Cargo.lock
@@ -263,7 +263,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crux_core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "crux_kv"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "darling",
  "proc-macro-error",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "crux_time"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "crux_core",
  "futures",

--- a/examples/notes/shared/src/app.rs
+++ b/examples/notes/shared/src/app.rs
@@ -8,7 +8,7 @@ use crux_core::{
     App, Command,
 };
 use crux_kv::{command::KeyValue, error::KeyValueError};
-use crux_time::command::{CompletedTimerHandle, Time, TimerError, TimerHandle};
+use crux_time::command::{Time, TimerHandle, TimerOutcome};
 use serde::{Deserialize, Serialize};
 
 use crate::capabilities::pub_sub::PubSub;
@@ -34,7 +34,7 @@ pub enum Event {
 
     // events local to the core
     #[serde(skip)]
-    EditTimerElapsed(Result<CompletedTimerHandle, TimerError>),
+    EditTimerElapsed(TimerOutcome),
     #[serde(skip)]
     Written(Result<Option<Vec<u8>>, KeyValueError>),
     #[serde(skip)]
@@ -212,10 +212,10 @@ impl NoteEditor {
 
                 render::render()
             }
-            Event::EditTimerElapsed(Ok(_)) => {
+            Event::EditTimerElapsed(TimerOutcome::Completed(_)) => {
                 KeyValue::set("note".to_string(), model.note.save()).then_send(Event::Written)
             }
-            Event::EditTimerElapsed(Err(_)) => Command::done(),
+            Event::EditTimerElapsed(TimerOutcome::Cleared) => Command::done(),
             Event::Written(_) => {
                 // FIXME assuming successful write
                 Command::done()

--- a/examples/notes/shared/src/app.rs
+++ b/examples/notes/shared/src/app.rs
@@ -212,12 +212,10 @@ impl NoteEditor {
 
                 render::render()
             }
-            Event::EditTimerElapsed(response) => match response {
-                Ok(_) => {
-                    KeyValue::set("note".to_string(), model.note.save()).then_send(Event::Written)
-                }
-                _ => Command::done(),
-            },
+            Event::EditTimerElapsed(Ok(_)) => {
+                KeyValue::set("note".to_string(), model.note.save()).then_send(Event::Written)
+            }
+            Event::EditTimerElapsed(Err(_)) => Command::done(),
             Event::Written(_) => {
                 // FIXME assuming successful write
                 Command::done()
@@ -346,7 +344,7 @@ mod editing_tests {
 
         let view = app.view(&model);
 
-        assert_eq!(view.text, "hello".to_string());
+        assert_eq!(view.text, "hello");
         assert_eq!(view.cursor, TextCursor::Position(5));
     }
 
@@ -365,7 +363,7 @@ mod editing_tests {
 
         let view = app.view(&model);
 
-        assert_eq!(view.text, "hello".to_string());
+        assert_eq!(view.text, "hello");
         assert_eq!(view.cursor, TextCursor::Selection(2..5));
     }
 
@@ -384,7 +382,7 @@ mod editing_tests {
 
         let view = app.view(&model);
 
-        assert_eq!(view.text, "hell to the lo".to_string());
+        assert_eq!(view.text, "hell to the lo");
         assert_eq!(view.cursor, TextCursor::Position(12));
     }
 
@@ -405,7 +403,7 @@ mod editing_tests {
 
         let view = app.view(&model);
 
-        assert_eq!(view.text, "helter skelter".to_string());
+        assert_eq!(view.text, "helter skelter");
         assert_eq!(view.cursor, TextCursor::Position(14));
     }
     // ANCHOR_END: replaces_selection_and_renders
@@ -425,7 +423,7 @@ mod editing_tests {
 
         let view = app.view(&model);
 
-        assert_eq!(view.text, "hi, yo".to_string());
+        assert_eq!(view.text, "hi, yo");
         assert_eq!(view.cursor, TextCursor::Position(5));
     }
 
@@ -447,7 +445,7 @@ mod editing_tests {
 
         let view = app.view(&model);
 
-        assert_eq!(view.text, "hey, just saying hello".to_string());
+        assert_eq!(view.text, "hey, just saying hello");
         assert_eq!(view.cursor, TextCursor::Position(18));
     }
 
@@ -466,7 +464,7 @@ mod editing_tests {
 
         let view = app.view(&model);
 
-        assert_eq!(view.text, "hllo".to_string());
+        assert_eq!(view.text, "hllo");
         assert_eq!(view.cursor, TextCursor::Position(1));
     }
 
@@ -485,7 +483,7 @@ mod editing_tests {
 
         let view = app.view(&model);
 
-        assert_eq!(view.text, "helo".to_string());
+        assert_eq!(view.text, "helo");
         assert_eq!(view.cursor, TextCursor::Position(2));
     }
 
@@ -504,7 +502,7 @@ mod editing_tests {
 
         let view = app.view(&model);
 
-        assert_eq!(view.text, "heo".to_string());
+        assert_eq!(view.text, "heo");
         assert_eq!(view.cursor, TextCursor::Position(2));
     }
 
@@ -523,7 +521,7 @@ mod editing_tests {
 
         let view = app.view(&model);
 
-        assert_eq!(view.text, "heo".to_string());
+        assert_eq!(view.text, "heo");
         assert_eq!(view.cursor, TextCursor::Position(2));
     }
 
@@ -544,7 +542,7 @@ mod editing_tests {
 
         let view = app.view(&model);
 
-        assert_eq!(view.text, "Hello 🙌🏻🥳🙌🏻 world.".to_string());
+        assert_eq!(view.text, "Hello 🙌🏻🥳🙌🏻 world.");
         assert_eq!(view.cursor, TextCursor::Position(13));
     }
 }
@@ -865,7 +863,7 @@ mod sync_tests {
         let alice_view = alice.view();
         let bob_view = bob.view();
 
-        assert_eq!(alice_view.text, "Hello world".to_string());
+        assert_eq!(alice_view.text, "Hello world");
         assert_eq!(alice_view.text, bob_view.text);
     }
 
@@ -891,7 +889,7 @@ mod sync_tests {
         let alice_view = alice.view();
         let bob_view = bob.view();
 
-        assert_eq!(alice_view.text, "Hello world".to_string());
+        assert_eq!(alice_view.text, "Hello world");
         assert_eq!(alice_view.text, bob_view.text);
     }
 
@@ -924,7 +922,7 @@ mod sync_tests {
         let alice_view = alice.view();
         let bob_view = bob.view();
 
-        assert_eq!(alice_view.text, "Hello dear world!".to_string());
+        assert_eq!(alice_view.text, "Hello dear world!");
         assert_eq!(alice_view.text, bob_view.text);
     }
 
@@ -977,7 +975,7 @@ mod sync_tests {
         let alice_view = alice.view();
         let bob_view = bob.view();
 
-        assert_eq!(alice_view.text, "Hello world!".to_string());
+        assert_eq!(alice_view.text, "Hello world!");
         assert_eq!(alice_view.text, bob_view.text);
     }
 
@@ -1006,7 +1004,7 @@ mod sync_tests {
         let alice_view = alice.view();
         let bob_view = bob.view();
 
-        assert_eq!(alice_view.text, "Hello dear world".to_string());
+        assert_eq!(alice_view.text, "Hello dear world");
         assert_eq!(alice_view.text, bob_view.text);
     }
 }

--- a/examples/notes/shared/src/app.rs
+++ b/examples/notes/shared/src/app.rs
@@ -8,10 +8,7 @@ use crux_core::{
     App, Command,
 };
 use crux_kv::{command::KeyValue, error::KeyValueError};
-use crux_time::{
-    command::{Time, TimerHandle},
-    TimeResponse,
-};
+use crux_time::command::{CompletedTimerHandle, Time, TimerError, TimerHandle};
 use serde::{Deserialize, Serialize};
 
 use crate::capabilities::pub_sub::PubSub;
@@ -23,7 +20,7 @@ use self::note::EditObserver;
 #[derive(Default)]
 pub struct NoteEditor;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug)]
 pub enum Event {
     // events from the shell
     Open,
@@ -34,9 +31,10 @@ pub enum Event {
     Backspace,
     Delete,
     ReceiveChanges(Vec<u8>),
-    EditTimer(TimeResponse),
 
     // events local to the core
+    #[serde(skip)]
+    EditTimerElapsed(Result<CompletedTimerHandle, TimerError>),
     #[serde(skip)]
     Written(Result<Option<Vec<u8>>, KeyValueError>),
     #[serde(skip)]
@@ -214,8 +212,8 @@ impl NoteEditor {
 
                 render::render()
             }
-            Event::EditTimer(response) => match response {
-                TimeResponse::DurationElapsed { id: _ } => {
+            Event::EditTimerElapsed(response) => match response {
+                Ok(_) => {
                     KeyValue::set("note".to_string(), model.note.save()).then_send(Event::Written)
                 }
                 _ => Command::done(),
@@ -258,7 +256,7 @@ fn restart_timer(current_handle: &mut Option<TimerHandle>) -> Command<Effect, Ev
     let duration = Duration::from_millis(EDIT_TIMER);
     let (notify_after, handle) = Time::notify_after(duration);
     current_handle.replace(handle);
-    notify_after.then_send(Event::EditTimer)
+    notify_after.then_send(Event::EditTimerElapsed)
 }
 
 struct CursorObserver {
@@ -702,52 +700,43 @@ mod save_load_tests {
         assert_ne!(first_id, second_id);
 
         assert!(requests.next().is_none());
+        drop(requests); // so we can use cmd2 later
 
         // Time passes
-
         start_request
-            .resolve(TimeResponse::DurationElapsed { id: second_id })
+            .resolve(crux_time::TimeResponse::DurationElapsed { id: second_id })
             .unwrap();
 
-        // One more edit. Should result in a timer, but not in cancellation
-        let mut cmd3 = app.update(Event::Backspace, &mut model);
-        let mut timer_requests = cmd3.effects().filter_map(Effect::into_timer);
+        // send the elapsed event back into the app
+        let event = cmd2.events().next().unwrap();
+        let mut cmd3 = app.update(event, &mut model);
 
-        let start_request = timer_requests.next().unwrap();
-        let third_id = match &start_request.operation {
-            TimeRequest::NotifyAfter { id, duration: _ } => id.clone(),
-            _ => panic!("expected a NotifyAfter"),
-        };
-        assert!(timer_requests.next().is_none());
-
-        assert_ne!(third_id, second_id);
-    }
-    // ANCHOR_END: starts_a_timer_after_an_edit
-
-    #[test]
-    fn saves_document_when_typing_stops() {
-        let app = NoteEditor::default();
-
-        let mut model = Model {
-            note: Note::with_text("hello"),
-            cursor: TextCursor::Position(5),
-            timer: None,
-        };
-
-        let mut cmd = app.update(
-            Event::EditTimer(TimeResponse::DurationElapsed { id: TimerId(1) }),
-            &mut model,
-        );
-        let write_request = cmd.effects().find_map(Effect::into_key_value).unwrap();
-
+        // we should see an effect to save the note
+        let mut effects = cmd3.effects();
+        let save = effects.next().unwrap().expect_key_value();
         assert_eq!(
-            write_request.operation,
+            save.operation,
             KeyValueOperation::Set {
                 key: "note".to_string(),
-                value: model.note.save().into()
+                value: model.note.save().into(),
+            }
+        );
+
+        // One more edit. Should result in a new timer
+        let mut cmd4 = app.update(Event::Backspace, &mut model);
+        let mut effects = cmd4.effects();
+
+        let _publish = effects.next().unwrap().expect_pub_sub();
+        let timer = effects.next().unwrap().expect_timer();
+        assert_eq!(
+            timer.operation,
+            TimeRequest::NotifyAfter {
+                id: TimerId(3),
+                duration: crux_time::Duration::from_millis(1000)
             }
         );
     }
+    // ANCHOR_END: starts_a_timer_after_an_edit
 }
 
 #[cfg(test)]
@@ -822,7 +811,7 @@ mod sync_tests {
 
                 if let Some(cmd) = self.command.as_mut() {
                     for event in cmd.events().collect::<Vec<_>>() {
-                        self.update(event.clone());
+                        self.update(event);
                     }
                 }
             }

--- a/examples/simple_counter/Cargo.lock
+++ b/examples/simple_counter/Cargo.lock
@@ -483,7 +483,7 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crux_core"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -501,7 +501,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "darling",
  "proc-macro-error",


### PR DESCRIPTION
- [x] test cancellation with app, in order to explore API improvements
- [x] expose `TimerHandle` internally rather than `TimerId`