### PR TITLE
Allow ShellRequest future to be polled many times after the request is dropped.

### DIFF
--- a/crux_time/src/command.rs
+++ b/crux_time/src/command.rs
@@ -316,4 +316,18 @@ mod tests {
             Some(Event::Elapsed(TimerOutcome::Completed(_)))
         ));
     }
+
+    #[test]
+    fn dropping_a_timer_request_while_holding_a_handle_and_polling() {
+        let (cmd, handle) = Time::notify_after(Duration::from_secs(2));
+        let mut cmd = cmd.then_send(Event::Elapsed);
+
+        let effect: Effect = cmd.effects().next().expect("Expected an effect!");
+
+        drop(effect);
+        assert!(!cmd.is_done());
+
+        drop(handle);
+        assert!(cmd.is_done());
+    }
 }

--- a/crux_time/src/command.rs
+++ b/crux_time/src/command.rs
@@ -153,6 +153,9 @@ where
                     // so this branch of the select will
                     // never run for the Err case
                     let cleared_id = cleared.unwrap();
+                    if cleared_id != timer_id {
+                        unreachable!("Cleared with the wrong ID");
+                    }
 
                     // Follow up by asking the shell to clear the timer
                     let TimeResponse::Cleared { id } = ctx.request_from_shell(TimeRequest::Clear { id: cleared_id }).await else {
@@ -160,7 +163,7 @@ where
                     };
 
                     if id != cleared_id {
-                        panic!("Cleared with unexpected timer ID");
+                        panic!("Cleared resolved with unexpected timer ID");
                     }
 
                     TimerOutcome::Cleared


### PR DESCRIPTION
This one is quite hard to explain.

`ShellRequest` is constructed on top of a `ShellStream`, and we use [`StreamFuture` from futures](https://docs.rs/futures/latest/futures/prelude/stream/struct.StreamFuture.html) to represent this. 

The peculiar thing about `ShellRequest` is that it panics if it's polled again after it returned Ready. Logically, this shouldn't happen in our case - the stream is actually a future, it will resolve at most once. The problem is the "at most" part. If it never resolves and the shell side of it (the `Request`) is cleaned up, the channel underneath closes and the stream terminates without ever producing a value. 

In this case `ShellRequest` returns `Pending` when polled, and is immdiately discovered by the check for wakers - there are no more wakers and the task is evicted. Unfortunately in the case of timer requests, there's also the cancelation handle holding another waker for the task, and so it survives.

If we then poll it, we attempt to poll the `StreamFuture` again and panic. The solution is to create a fresh `StreamFuture` every time we get polled in such scenario. 