### PR TITLE
Effect registration when using `effect!`

### DIFF
--- a/crux_core/src/typegen.rs
+++ b/crux_core/src/typegen.rs
@@ -205,14 +205,13 @@ impl TypeGen {
     /// in the Crux book for more information.
     pub fn register_app<A: App>(&mut self) -> Result
     where
-        A::Capabilities: Export,
+        A::Effect: Export,
         A::Event: Deserialize<'static>,
         A::ViewModel: Deserialize<'static> + 'static,
     {
+        A::Effect::register_types(self)?;
         self.register_type::<A::Event>()?;
         self.register_type::<A::ViewModel>()?;
-
-        A::Capabilities::register_types(self)?;
 
         Ok(())
     }

--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -118,13 +118,15 @@ pub fn effect_impl(input: ItemEnum) -> TokenStream {
         #(#filters)*
 
         #[cfg(feature = "typegen")]
-        pub fn register_effects(generator: &mut ::crux_core::typegen::TypeGen) -> ::crux_core::typegen::Result {
-            use ::crux_core::capability::{Capability, Operation};
-            #(#type_gen)*
-            generator.register_type::<#ffi_enum_ident>()?;
-            generator.register_type::<::crux_core::bridge::Request<#ffi_enum_ident>>()?;
+        impl crux_core::typegen::Export for Effect {
+            fn register_types(generator: &mut ::crux_core::typegen::TypeGen) -> ::crux_core::typegen::Result {
+                use ::crux_core::capability::{Capability, Operation};
+                #(#type_gen)*
+                generator.register_type::<#ffi_enum_ident>()?;
+                generator.register_type::<::crux_core::bridge::Request<#ffi_enum_ident>>()?;
 
-            Ok(())
+                Ok(())
+            }
         }
     }
 }
@@ -185,14 +187,16 @@ mod test {
             }
         }
         #[cfg(feature = "typegen")]
-        pub fn register_effects(
-            generator: &mut ::crux_core::typegen::TypeGen,
-        ) -> ::crux_core::typegen::Result {
-            use ::crux_core::capability::{Capability, Operation};
-            RenderOperation::register_types(generator)?;
-            generator.register_type::<EffectFfi>()?;
-            generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
-            Ok(())
+        impl crux_core::typegen::Export for Effect {
+            fn register_types(
+                generator: &mut ::crux_core::typegen::TypeGen,
+            ) -> ::crux_core::typegen::Result {
+                use ::crux_core::capability::{Capability, Operation};
+                RenderOperation::register_types(generator)?;
+                generator.register_type::<EffectFfi>()?;
+                generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
+                Ok(())
+            }
         }
         "##);
     }
@@ -272,15 +276,17 @@ mod test {
             }
         }
         #[cfg(feature = "typegen")]
-        pub fn register_effects(
-            generator: &mut ::crux_core::typegen::TypeGen,
-        ) -> ::crux_core::typegen::Result {
-            use ::crux_core::capability::{Capability, Operation};
-            RenderOperation::register_types(generator)?;
-            HttpRequest::register_types(generator)?;
-            generator.register_type::<EffectFfi>()?;
-            generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
-            Ok(())
+        impl crux_core::typegen::Export for Effect {
+            fn register_types(
+                generator: &mut ::crux_core::typegen::TypeGen,
+            ) -> ::crux_core::typegen::Result {
+                use ::crux_core::capability::{Capability, Operation};
+                RenderOperation::register_types(generator)?;
+                HttpRequest::register_types(generator)?;
+                generator.register_type::<EffectFfi>()?;
+                generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
+                Ok(())
+            }
         }
         "##);
     }

--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -3,17 +3,18 @@ pub mod platform;
 use std::time::SystemTime;
 
 use chrono::{DateTime, Utc};
-use crux_http::command::Http;
+use crux_http::{command::Http, protocol::HttpRequest};
 use serde::{Deserialize, Serialize};
 
 pub use crux_core::App;
 use crux_core::{
-    render::{self, Render},
+    macros::effect,
+    render::{self, RenderOperation},
     Command,
 };
-use crux_kv::{command::KeyValue, error::KeyValueError};
-use crux_platform::Platform;
-use crux_time::command::Time;
+use crux_kv::{command::KeyValue, error::KeyValueError, KeyValueOperation};
+use crux_platform::PlatformRequest;
+use crux_time::{command::Time, TimeRequest};
 
 const CAT_LOADING_URL: &str = "https://c.tenor.com/qACzaJ1EBVYAAAAd/tenor.gif";
 const FACT_API_URL: &str = "https://catfact.ninja/fact";
@@ -88,30 +89,24 @@ pub struct CatFacts {
     platform: platform::App,
 }
 
-#[cfg_attr(feature = "typegen", derive(crux_core::macros::Export))]
-#[derive(crux_core::macros::Effect)]
-#[allow(unused)]
-pub struct CatFactCapabilities {
-    http: crux_http::Http<Event>,
-    key_value: crux_kv::KeyValue<Event>,
-    platform: Platform<Event>,
-    render: Render<Event>,
-    time: crux_time::Time<Event>,
+effect! {
+    pub enum Effect {
+        Http(HttpRequest),
+        KeyValue(KeyValueOperation),
+        Platform(PlatformRequest),
+        Render(RenderOperation),
+        Time(TimeRequest),
+    }
 }
 
 impl App for CatFacts {
     type Model = Model;
     type Event = Event;
     type ViewModel = ViewModel;
-    type Capabilities = CatFactCapabilities;
+    type Capabilities = ();
     type Effect = Effect;
 
-    fn update(
-        &self,
-        msg: Event,
-        model: &mut Model,
-        _caps: &CatFactCapabilities,
-    ) -> Command<Effect, Event> {
+    fn update(&self, msg: Event, model: &mut Model, _caps: &()) -> Command<Effect, Event> {
         self.update(msg, model)
     }
 

--- a/examples/cat_facts/shared/src/app/platform.rs
+++ b/examples/cat_facts/shared/src/app/platform.rs
@@ -1,8 +1,9 @@
 use crux_core::{
-    render::{self, Render},
+    macros::effect,
+    render::{self, RenderOperation},
     Command,
 };
-use crux_platform::{command::Platform, PlatformResponse};
+use crux_platform::{command::Platform, PlatformRequest, PlatformResponse};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default)]
@@ -19,25 +20,21 @@ pub enum Event {
     Set(PlatformResponse),
 }
 
-#[derive(crux_core::macros::Effect)]
-pub struct Capabilities {
-    pub platform: crux_platform::Platform<Event>,
-    pub render: Render<Event>,
+effect! {
+    pub enum Effect {
+        Platform(PlatformRequest),
+        Render(RenderOperation),
+    }
 }
 
 impl crux_core::App for App {
     type Event = Event;
     type Model = Model;
     type ViewModel = Model;
-    type Capabilities = Capabilities;
+    type Capabilities = ();
     type Effect = Effect;
 
-    fn update(
-        &self,
-        msg: Event,
-        model: &mut Model,
-        _caps: &Capabilities,
-    ) -> Command<Effect, Event> {
+    fn update(&self, msg: Event, model: &mut Model, _caps: &()) -> Command<Effect, Event> {
         self.update(msg, model)
     }
 

--- a/examples/cat_facts/shared_types/build.rs
+++ b/examples/cat_facts/shared_types/build.rs
@@ -9,6 +9,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut gen = TypeGen::new();
 
+    shared::register_effects(&mut gen)?;
     gen.register_app::<CatFacts>()?;
 
     let output_root = PathBuf::from("./generated");

--- a/examples/cat_facts/shared_types/build.rs
+++ b/examples/cat_facts/shared_types/build.rs
@@ -9,7 +9,6 @@ fn main() -> anyhow::Result<()> {
 
     let mut gen = TypeGen::new();
 
-    shared::register_effects(&mut gen)?;
     gen.register_app::<CatFacts>()?;
 
     let output_root = PathBuf::from("./generated");

--- a/examples/counter/shared_types/build.rs
+++ b/examples/counter/shared_types/build.rs
@@ -1,5 +1,5 @@
-use crux_core::{bridge::Request, typegen::TypeGen};
-use shared::{App, EffectFfi};
+use crux_core::typegen::TypeGen;
+use shared::App;
 use std::path::PathBuf;
 
 fn main() -> anyhow::Result<()> {
@@ -7,9 +7,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut gen = TypeGen::new();
 
-    gen.register_type::<EffectFfi>()?;
-    gen.register_type::<Request<EffectFfi>>()?;
-
+    shared::register_effects(&mut gen)?;
     gen.register_app::<App>()?;
 
     let output_root = PathBuf::from("./generated");

--- a/examples/counter/shared_types/build.rs
+++ b/examples/counter/shared_types/build.rs
@@ -7,7 +7,6 @@ fn main() -> anyhow::Result<()> {
 
     let mut gen = TypeGen::new();
 
-    shared::register_effects(&mut gen)?;
     gen.register_app::<App>()?;
 
     let output_root = PathBuf::from("./generated");

--- a/examples/simple_counter/shared_types/build.rs
+++ b/examples/simple_counter/shared_types/build.rs
@@ -1,5 +1,5 @@
-use crux_core::{bridge::Request, typegen::TypeGen};
-use shared::{Counter, EffectFfi};
+use crux_core::typegen::TypeGen;
+use shared::Counter;
 use std::path::PathBuf;
 
 fn main() -> anyhow::Result<()> {
@@ -7,9 +7,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut gen = TypeGen::new();
 
-    gen.register_type::<EffectFfi>()?;
-    gen.register_type::<Request<EffectFfi>>()?;
-
+    shared::register_effects(&mut gen)?;
     gen.register_app::<Counter>()?;
 
     let output_root = PathBuf::from("./generated");

--- a/examples/simple_counter/shared_types/build.rs
+++ b/examples/simple_counter/shared_types/build.rs
@@ -7,7 +7,6 @@ fn main() -> anyhow::Result<()> {
 
     let mut gen = TypeGen::new();
 
-    shared::register_effects(&mut gen)?;
     gen.register_app::<Counter>()?;
 
     let output_root = PathBuf::from("./generated");


### PR DESCRIPTION
This PR moves the `Export` trait implementation from `Capabilities` to `Effect` so that we can call `Effect::register_types` from `register_app`.