### PR TITLE
improve effect macro and docs

### DIFF
--- a/crux_core/src/capabilities/compose.rs
+++ b/crux_core/src/capabilities/compose.rs
@@ -15,7 +15,7 @@ use futures::Future;
 /// * Any arbitrary graph of effects which depend on each other (or not).
 ///
 /// The compose capability doesn't have any operations it emits to the shell, and type generation fails
-/// on its operation type ([`Never`](crate::capability::Never))). This is difficult for crux to detect
+/// on its operation type ([`Never`]). This is difficult for crux to detect
 /// at the moment. To avoid this problem until a better fix is found, use `#[effect(skip)]` to skip the
 /// generation of an effect variant for the compose capability. For example
 ///

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -152,7 +152,7 @@
 //! ```
 //!
 //! Finally, you will need to set up the type generation for the `Model`, `Message` and `ViewModel` types.
-//! See [typegen] for details.
+//! See [typegen](https://docs.rs/crux_core/latest/crux_core/typegen/index.html) for details.
 //!
 
 pub mod bridge;

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -185,8 +185,12 @@ pub trait App: Default {
     /// ViewModel, typically a `struct` describes the user interface that should be
     /// displayed to the user
     type ViewModel: Serialize;
-    /// Capabilities, typically a `struct`, lists the capabilities used by this application
+    /// Capabilities, usually a `struct`, lists the capabilities used by this application.
+    ///
     /// Typically, Capabilities should contain at least an instance of the built-in [`Render`](crate::render::Render) capability.
+    ///
+    /// Note: this `Capabilities` associated type will be deprecated soon as part of the completion of
+    /// the migration to the new [`Command`](command) API.
     type Capabilities;
     /// Effect, the enum carrying effect requests created by capabilities.
     /// Normally this type is derived from `Capabilities` using the `crux_macros::Effect` derive macro

--- a/docs/src/getting_started/core.md
+++ b/docs/src/getting_started/core.md
@@ -169,10 +169,8 @@ from the
 {{#include ../../../examples/simple_counter/shared/src/app.rs:app}}
 ```
 
-```admonish
-The example uses the new [`effect!`](https://docs.rs/crux_macros/latest/crux_macros/macro.effect.html) macro, which is a bit more ergonomic than the
-`Effect` and `Export` derive macros you may have used on a `Capabilities` type in the past.
-Inside the body of the `effect!` macro invocation we simply declare an enum to represent our effects. The enum has a variant for each effect, which carries the [`Operation`](https://docs.rs/crux_core/latest/crux_core/capability/trait.Operation.html) type.
+```admonish note title="Note the effect! macro"
+Inside the body of the [`effect!`](https://docs.rs/crux_macros/latest/crux_macros/macro.effect.html) macro invocation we declare an enum to represent our effects. The enum has a variant for each effect, which carries the [`Operation`](https://docs.rs/crux_core/latest/crux_core/capability/trait.Operation.html) type.
 
 The macro generates code for:
 - an _actual_ effect enum (where the inner `Operation` type is wrapped with [`crux_core::Request`](https://docs.rs/crux_core/latest/crux_core/struct.Request.html))
@@ -182,6 +180,11 @@ The macro generates code for:
 - code to support the current foreign type generation (that uses `serde-reflection`)
 
 You can also use the `effect!` macro with the [new typegen](https://github.com/redbadger/crux/pull/217).
+```
+
+```admonish warning title="Deprecation of Capabilities associated type"
+Also note that as we near the tail end of the migration to the new [Command API](https://docs.rs/crux_core/latest/crux_core/command/index.html), the `Capabilities` associated type on the `App` trait will be deprecated.
+You'll notice that in the example, above, we can just use the unit type instead of a `Capabilities` struct and ignore the last argument to the update function.
 ```
 
 Make sure everything builds OK

--- a/examples/simple_counter/shared/src/app.rs
+++ b/examples/simple_counter/shared/src/app.rs
@@ -37,14 +37,14 @@ impl App for Counter {
     type Event = Event;
     type Model = Model;
     type ViewModel = ViewModel;
-    type Capabilities = ();
+    type Capabilities = (); // will be deprecated, so use unit type for now
     type Effect = Effect;
 
     fn update(
         &self,
         event: Self::Event,
         model: &mut Self::Model,
-        _caps: &Self::Capabilities,
+        _caps: &(), // will be deprecated, so prefix with underscore for now
     ) -> Command<Effect, Event> {
         match event {
             Event::Increment => model.count += 1,

--- a/examples/simple_counter/shared/src/app.rs
+++ b/examples/simple_counter/shared/src/app.rs
@@ -61,7 +61,7 @@ impl App for Counter {
         }
     }
 }
-// ANCHOR_END: impl_app
+// ANCHOR_END: app
 
 // ANCHOR: test
 #[cfg(test)]


### PR DESCRIPTION
Some very minor tweaks to the `effect!` macro (that includes a better error message), and an update to the `getting started` guide in the book.