### PR TITLE
Android build fixups / documentation

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -30,6 +30,7 @@
 1. [Testing](./guide/testing.md)
 1. [Interface between core and shell](./guide/message_interface.md)
 1. [Composable Applications](./guide/composing.md)
+1. [Android minify](./guide/android-apk-shrink.md)
 
 # Internals
 

--- a/docs/src/guide/android-apk-shrink.md
+++ b/docs/src/guide/android-apk-shrink.md
@@ -27,7 +27,8 @@ buildTypes {
     }
 }
 ```
-just enabling this feature will break your app aa it will remove a lot of the
+
+Just enabling this feature will break your app as it will remove a lot of the
 shared lib we depend on, to prevent this amend the `proguard-rules.pro` file to contain
 the following
 
@@ -56,10 +57,11 @@ the following
   public protected *;
 }
 ```
-If the above results in a crash at runtime you will need to expand the rules to
-include more functions/classes, bellow is a set of links that can help with
-understanding these rules.
-https://developer.android.com/build/shrink-code#keep-code
-https://www.guardsquare.com/manual/configuration/examples
-https://gendignoux.com/blog/2022/10/24/rust-library-android.html#shrinking-and-testing-the-release-apk
 
+If the above results in a crash at runtime you will need to expand the rules to
+include more functions/classes, below is a set of links that can help with
+understanding these rules.
+
+<https://developer.android.com/build/shrink-code#keep-code>
+<https://www.guardsquare.com/manual/configuration/examples>
+<https://gendignoux.com/blog/2022/10/24/rust-library-android.html#shrinking-and-testing-the-release-apk>

--- a/docs/src/guide/android-apk-shrink.md
+++ b/docs/src/guide/android-apk-shrink.md
@@ -1,0 +1,65 @@
+# Reduce APK size on Android
+
+## Enable cargo release
+
+The biggest reduction in the APK size comes from changing the `profile = "debug"`
+to `profile = "release"` in the `shared/build.gradle` file
+
+There is no need to set a release profile on the `typeGen` or `bindGen`
+
+
+## Android minify
+
+
+The following is more experimental and may take some trial and error to work.
+
+[Enable minify](https://developer.android.com/studio/build/shrink-code)
+in release mode in `app/build.gradle`
+```diff
+buildTypes {
+    release {
+-        minifyEnabled false
++        minifyEnabled true
+        proguardFiles {
+            getDefaultProguardFile('proguard-android-optimize.txt')
+            'proguard-rules.pro'
+        }
+    }
+}
+```
+just enabling this feature will break your app aa it will remove a lot of the
+shared lib we depend on, to prevent this amend the `proguard-rules.pro` file to contain
+the following
+
+```
+# There were a number of methods found in com.sun.jna that glued the android to
+# the Rust the below is the most simplified way I could keep everything in
+-keep class com.sun.**{
+    static *; # put this in the below and the app breaks :D
+}
+-keep public class com.sun.jna.** {
+    public final *;
+    private protected *;
+}
+-keep class com.sun.jna.* {
+  public protected *;
+  public void read();
+  public final *;
+  * getTypeInfo() ;
+}
+
+
+# we want to keep all the shared library for conveiance.
+# if you have some ios/other non android shared lib functions you may find it
+# benifitial to exclude them here
+-keep class <shared app package name>.** {
+  public protected *;
+}
+```
+If the above results in a crash at runtime you will need to expand the rules to
+include more functions/classes, bellow is a set of links that can help with
+understanding these rules.
+https://developer.android.com/build/shrink-code#keep-code
+https://www.guardsquare.com/manual/configuration/examples
+https://gendignoux.com/blog/2022/10/24/rust-library-android.html#shrinking-and-testing-the-release-apk
+

--- a/examples/bridge_echo/Android/shared/build.gradle
+++ b/examples/bridge_echo/Android/shared/build.gradle
@@ -56,6 +56,7 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 cargo {
     module = "../.."
     libname = "shared"
+    profile = "debug"
     // these are the four recommended targets for Android that will ensure your library works on all mainline android devices
     // make sure you have included the rust toolchain for each of these targets: \
     // `rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android`

--- a/examples/bridge_echo/Android/shared/build.gradle
+++ b/examples/bridge_echo/Android/shared/build.gradle
@@ -74,7 +74,7 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks.named("compileDebugKotlin") {
+        tasks.named("preBuild") {
             it.dependsOn(tasks.named("typesGen"), tasks.named("bindGen"))
         }
         tasks.named("generate${productFlavor}${buildType}Assets") {

--- a/examples/bridge_echo/Android/shared/build.gradle
+++ b/examples/bridge_echo/Android/shared/build.gradle
@@ -80,8 +80,22 @@ afterEvaluate {
         tasks.named("generate${productFlavor}${buildType}Assets") {
             it.dependsOn(tasks.named("cargoBuild"))
         }
+
+        // The below dependsOn is needed till https://github.com/mozilla/rust-android-gradle/issues/85 is resolved this fix was got from #118
+        tasks.withType(com.nishtahir.CargoBuildTask).forEach { buildTask ->
+              tasks.withType(com.android.build.gradle.tasks.MergeSourceSetFolders).configureEach {
+                  it.inputs.dir(new File(new File(buildDir, "rustJniLibs"), buildTask.toolchain.folder))
+                  it.dependsOn(buildTask)
+              }
+          }
     }
 }
+// The below dependsOn is needed till https://github.com/mozilla/rust-android-gradle/issues/85 is resolved this fix was got from #118
+tasks.matching { it.name.matches(/merge.*JniLibFolders/) }.configureEach {
+    it.inputs.dir(new File(buildDir, "rustJniLibs/android"))
+    it.dependsOn("cargoBuild")
+}
+
 tasks.register('bindGen', Exec) {
     def outDir = "${projectDir}/../../shared_types/generated/java"
     workingDir "../../"

--- a/examples/cat_facts/Android/shared/build.gradle
+++ b/examples/cat_facts/Android/shared/build.gradle
@@ -73,7 +73,7 @@ afterEvaluate {
         }
         def buildType = "${variant.buildType.name.capitalize()}"
 
-        tasks.named("compileDebugKotlin") {
+        tasks.named("preBuild") {
             it.dependsOn(tasks.named("typesGen"), tasks.named("bindGen"))
         }
 

--- a/examples/cat_facts/Android/shared/build.gradle
+++ b/examples/cat_facts/Android/shared/build.gradle
@@ -80,7 +80,20 @@ afterEvaluate {
         tasks.named("generate${productFlavor}${buildType}Assets") {
             it.dependsOn(tasks.named("cargoBuild"))
         }
+
+        // The below dependsOn is needed till https://github.com/mozilla/rust-android-gradle/issues/85 is resolved this fix was got from #118
+        tasks.withType(com.nishtahir.CargoBuildTask).forEach { buildTask ->
+              tasks.withType(com.android.build.gradle.tasks.MergeSourceSetFolders).configureEach {
+                  it.inputs.dir(new File(new File(buildDir, "rustJniLibs"), buildTask.toolchain.folder))
+                  it.dependsOn(buildTask)
+              }
+          }
     }
+}
+// The below dependsOn is needed till https://github.com/mozilla/rust-android-gradle/issues/85 is resolved this fix was got from #118
+tasks.matching { it.name.matches(/merge.*JniLibFolders/) }.configureEach {
+    it.inputs.dir(new File(buildDir, "rustJniLibs/android"))
+    it.dependsOn("cargoBuild")
 }
 
 tasks.register('bindGen', Exec) {

--- a/examples/cat_facts/Android/shared/build.gradle
+++ b/examples/cat_facts/Android/shared/build.gradle
@@ -54,6 +54,7 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 cargo {
     module = "../.."
     libname = "shared"
+    profile = "debug"
     // these are the four recommended targets for Android that will ensure your library works on all mainline android devices
     // make sure you have included the rust toolchain for each of these targets: \
     // `rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android`

--- a/examples/counter/Android/shared/build.gradle
+++ b/examples/counter/Android/shared/build.gradle
@@ -55,6 +55,7 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 cargo {
     module = "../.."
     libname = "shared"
+    profile = "debug"
     // these are the four recommended targets for Android that will ensure your library works on all mainline android devices
     // make sure you have included the rust toolchain for each of these targets: \
     // `rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android`

--- a/examples/counter/Android/shared/build.gradle
+++ b/examples/counter/Android/shared/build.gradle
@@ -74,7 +74,7 @@ afterEvaluate {
         }
         def buildType = "${variant.buildType.name.capitalize()}"
 
-        tasks.named("compileDebugKotlin") {
+        tasks.named("preBuild") {
             it.dependsOn(tasks.named("typesGen"), tasks.named("bindGen"))
         }
 

--- a/examples/counter/Android/shared/build.gradle
+++ b/examples/counter/Android/shared/build.gradle
@@ -81,8 +81,22 @@ afterEvaluate {
         tasks.named("generate${productFlavor}${buildType}Assets") {
             it.dependsOn(tasks.named("cargoBuild"))
         }
+
+        // The below dependsOn is needed till https://github.com/mozilla/rust-android-gradle/issues/85 is resolved this fix was got from #118
+        tasks.withType(com.nishtahir.CargoBuildTask).forEach { buildTask ->
+              tasks.withType(com.android.build.gradle.tasks.MergeSourceSetFolders).configureEach {
+                  it.inputs.dir(new File(new File(buildDir, "rustJniLibs"), buildTask.toolchain.folder))
+                  it.dependsOn(buildTask)
+              }
+          }
     }
 }
+// The below dependsOn is needed till https://github.com/mozilla/rust-android-gradle/issues/85 is resolved this fix was got from #118
+tasks.matching { it.name.matches(/merge.*JniLibFolders/) }.configureEach {
+    it.inputs.dir(new File(buildDir, "rustJniLibs/android"))
+    it.dependsOn("cargoBuild")
+}
+
 
 tasks.register('bindGen', Exec) {
     def outDir = "${projectDir}/../../shared_types/generated/java"

--- a/examples/simple_counter/Android/shared/build.gradle
+++ b/examples/simple_counter/Android/shared/build.gradle
@@ -57,6 +57,7 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 cargo {
     module = "../.."
     libname = "shared"
+    profile = "debug"
     // these are the four recommended targets for Android that will ensure your library works on all mainline android devices
     // make sure you have included the rust toolchain for each of these targets: \
     // `rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android`

--- a/examples/simple_counter/Android/shared/build.gradle
+++ b/examples/simple_counter/Android/shared/build.gradle
@@ -76,7 +76,7 @@ afterEvaluate {
         }
         def buildType = "${variant.buildType.name.capitalize()}"
 
-        tasks.named("compileDebugKotlin") {
+        tasks.named("preBuild") {
             it.dependsOn(tasks.named("typesGen"), tasks.named("bindGen"))
         }
 

--- a/examples/simple_counter/Android/shared/build.gradle
+++ b/examples/simple_counter/Android/shared/build.gradle
@@ -83,7 +83,20 @@ afterEvaluate {
         tasks.named("generate${productFlavor}${buildType}Assets") {
             it.dependsOn(tasks.named("cargoBuild"))
         }
+
+        // The below dependsOn is needed till https://github.com/mozilla/rust-android-gradle/issues/85 is resolved this fix was got from #118
+        tasks.withType(com.nishtahir.CargoBuildTask).forEach { buildTask ->
+              tasks.withType(com.android.build.gradle.tasks.MergeSourceSetFolders).configureEach {
+                  it.inputs.dir(new File(new File(buildDir, "rustJniLibs"), buildTask.toolchain.folder))
+                  it.dependsOn(buildTask)
+              }
+          }
     }
+}
+// The below dependsOn is needed till https://github.com/mozilla/rust-android-gradle/issues/85 is resolved this fix was got from #118
+tasks.matching { it.name.matches(/merge.*JniLibFolders/) }.configureEach {
+    it.inputs.dir(new File(buildDir, "rustJniLibs/android"))
+    it.dependsOn("cargoBuild")
 }
 
 tasks.register('bindGen', Exec) {

--- a/templates/simple_counter/Android/shared/build.gradle
+++ b/templates/simple_counter/Android/shared/build.gradle
@@ -73,7 +73,7 @@ afterEvaluate {
         }
         def buildType = "${variant.buildType.name.capitalize()}"
 
-        tasks.named("compileDebugKotlin") {
+        tasks.named("preBuild") {
             it.dependsOn(tasks.named("typesGen"), tasks.named("bindGen"))
         }
 

--- a/templates/simple_counter/Android/shared/build.gradle
+++ b/templates/simple_counter/Android/shared/build.gradle
@@ -57,6 +57,7 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 cargo {
     module = "../.."
     libname = "shared"
+    profile = "debug"
     // these are the four recommended targets for Android that will ensure your library works on all mainline android devices
     // make sure you have included the rust toolchain for each of these targets: \
     // `rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android`

--- a/templates/simple_counter/Android/shared/build.gradle
+++ b/templates/simple_counter/Android/shared/build.gradle
@@ -80,8 +80,22 @@ afterEvaluate {
         tasks.named("generate${productFlavor}${buildType}Assets") {
             it.dependsOn(tasks.named("cargoBuild"))
         }
+
+        // The below dependsOn is needed till https://github.com/mozilla/rust-android-gradle/issues/85 is resolved this fix was got from #118
+        tasks.withType(com.nishtahir.CargoBuildTask).forEach { buildTask ->
+              tasks.withType(com.android.build.gradle.tasks.MergeSourceSetFolders).configureEach {
+                  it.inputs.dir(new File(new File(buildDir, "rustJniLibs"), buildTask.toolchain.folder))
+                  it.dependsOn(buildTask)
+              }
+          }
     }
 }
+// The below dependsOn is needed till https://github.com/mozilla/rust-android-gradle/issues/85 is resolved this fix was got from #118
+tasks.matching { it.name.matches(/merge.*JniLibFolders/) }.configureEach {
+    it.inputs.dir(new File(buildDir, "rustJniLibs/android"))
+    it.dependsOn("cargoBuild")
+}
+
 
 tasks.register('bindGen', Exec) {
     def outDir = "${projectDir}/../../shared_types/generated/java"


### PR DESCRIPTION
This is kinda 3 issues in 1, happy to break them up if wanted

1. Slight tweak in when type and bind gen happen
    - Fairly confident this has no negative side effects
2. Added workaround for the gradle plugin
    - I'm a bit unsure if we want to add workarounds to the examples or not 
3. Started documenting shrinking the APK for android builds
    - Probably want to reword most of it to fit, i also haven't got round to building the docs myself so i may have linked it wrong in summery