### PR TITLE
NotificationBuilder

### DIFF
--- a/crux_core/src/capabilities/render.rs
+++ b/crux_core/src/capabilities/render.rs
@@ -1,9 +1,12 @@
 //! Built-in capability used to notify the Shell that a UI update is necessary.
 
+use std::future::Future;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
     capability::{CapabilityContext, Operation},
+    command::NotificationBuilder,
     Capability, Command, Request,
 };
 
@@ -67,11 +70,33 @@ impl<Ev> Capability<Ev> for Render<Ev> {
     }
 }
 
-/// Signal the shell that UI should be redrawn. Returns a `Command`.
-pub fn render<Effect, Event>() -> Command<Effect, Event>
+/// Signal to the shell that the UI should be redrawn.
+/// Returns a [`NotificationBuilder`].
+///
+/// ### Examples:
+/// To use in a sync context:
+/// ```no_run
+/// render_builder().into() // or use `render_command()`
+/// ```
+/// To use in an async context:
+/// ```no_run
+/// render_builder().into_future(ctx).await
+/// ```
+pub fn render_builder<Effect, Event>(
+) -> NotificationBuilder<Effect, Event, impl Future<Output = ()>>
 where
     Effect: From<Request<RenderOperation>> + Send + 'static,
     Event: Send + 'static,
 {
     Command::notify_shell(RenderOperation)
+}
+
+/// Signal to the shell that the UI should be redrawn.
+/// Returns a [`Command`].
+pub fn render<Effect, Event>() -> Command<Effect, Event>
+where
+    Effect: From<Request<RenderOperation>> + Send + 'static,
+    Event: Send + 'static,
+{
+    render_builder().into()
 }

--- a/crux_core/src/capabilities/render.rs
+++ b/crux_core/src/capabilities/render.rs
@@ -75,12 +75,21 @@ impl<Ev> Capability<Ev> for Render<Ev> {
 ///
 /// ### Examples:
 /// To use in a sync context:
-/// ```no_run
-/// render_builder().into() // or use `render_command()`
+/// ```
+///# use crux_core::{Command, render::{render_builder, Render, RenderOperation}};
+///# crux_core::macros::effect! {pub enum Effect {Render(RenderOperation)}}
+///# enum Event {None}
+/// let command: Command<Effect, Event> =
+///     render_builder().into(); // or use `render_command()`
 /// ```
 /// To use in an async context:
-/// ```no_run
-/// render_builder().into_future(ctx).await
+/// ```
+///# use crux_core::{Command, render::{render_builder, Render, RenderOperation}};
+///# crux_core::macros::effect! {pub enum Effect {Render(RenderOperation)}}
+///# enum Event {None}
+///# let command: Command<Effect, Event> = Command::new(|ctx| async move {
+/// render_builder().into_future(ctx).await;
+///# });
 /// ```
 pub fn render_builder<Effect, Event>(
 ) -> NotificationBuilder<Effect, Event, impl Future<Output = ()>>

--- a/crux_core/src/command/mod.rs
+++ b/crux_core/src/command/mod.rs
@@ -252,7 +252,7 @@ use futures::{FutureExt as _, Stream, StreamExt as _};
 use slab::Slab;
 use stream::CommandStreamExt as _;
 
-pub use builder::{RequestBuilder, StreamBuilder};
+pub use builder::{NotificationBuilder, RequestBuilder, StreamBuilder};
 pub use context::CommandContext;
 pub use stream::CommandOutput;
 
@@ -378,15 +378,21 @@ where
         Command::new(|ctx| async move { ctx.send_event(event) })
     }
 
-    /// Create a Command which sends a notification to the shell with a provided `operation`.
+    /// Start a creation of a Command which sends a notification to the shell with a provided
+    /// `operation`.
     ///
-    /// This ia synchronous equivalent of [`CommandContext::notify_shell`].
-    pub fn notify_shell<Op>(operation: Op) -> Command<Effect, Event>
+    /// Returns a [`NotificationBuilder`] which can be converted into a Command directly.
+    ///
+    /// In an async context, `NotificationBuilder` can be turned into a future that resolves to the
+    /// operation output type.
+    pub fn notify_shell<Op>(
+        operation: Op,
+    ) -> builder::NotificationBuilder<Effect, Event, impl Future<Output = ()>>
     where
         Op: Operation,
         Effect: From<Request<Op>>,
     {
-        Command::new(|ctx| async move { ctx.notify_shell(operation) })
+        builder::NotificationBuilder::new(|ctx| async move { ctx.notify_shell(operation) })
     }
 
     /// Start a creation of a Command which sends a one-time request to the shell with a provided

--- a/crux_core/src/command/tests/basic_effects.rs
+++ b/crux_core/src/command/tests/basic_effects.rs
@@ -41,7 +41,7 @@ fn done_can_be_created() {
 
 #[test]
 fn notify_can_be_created_with_an_operation() {
-    let mut cmd: Command<Effect, Event> = Command::notify_shell(AnOperation);
+    let mut cmd: Command<Effect, Event> = Command::notify_shell(AnOperation).into();
 
     assert!(!cmd.is_done());
 
@@ -52,7 +52,7 @@ fn notify_can_be_created_with_an_operation() {
 
 #[test]
 fn notify_effect_can_be_inspected() {
-    let mut cmd: Command<_, Event> = Command::notify_shell(AnOperation);
+    let mut cmd: Command<Effect, Event> = Command::notify_shell(AnOperation).into();
 
     let effects = cmd.effects().next();
 

--- a/crux_core/tests/json_bridge.rs
+++ b/crux_core/tests/json_bridge.rs
@@ -1,5 +1,5 @@
 mod app {
-    use crux_core::render::{self, Render};
+    use crux_core::render::{render, Render};
     use crux_core::{macros::Effect, Command};
     use crux_http::command::Http;
     use serde::{Deserialize, Serialize};
@@ -29,7 +29,7 @@ mod app {
             _caps: &Capabilities,
         ) -> Command<Effect, Event> {
             match event {
-                Event::Trigger => render::render(),
+                Event::Trigger => render(),
                 Event::Get => Http::get("http://example.com/")
                     .build()
                     .then_send(|_| Event::Trigger),

--- a/crux_core/tests/testing.rs
+++ b/crux_core/tests/testing.rs
@@ -3,8 +3,7 @@
 use crux_core::testing::AppTester;
 
 mod app {
-    use crux_core::{macros::Effect, Command};
-    use crux_core::{render, App};
+    use crux_core::{macros::Effect, render::render, App, Command};
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -34,7 +33,7 @@ mod app {
             _model: &mut Self::Model,
             _caps: &Self::Capabilities,
         ) -> Command<Effect, Event> {
-            render::render()
+            render()
         }
 
         fn view(&self, model: &Self::Model) -> Self::ViewModel {

--- a/crux_http/tests/capability_with_shell.rs
+++ b/crux_http/tests/capability_with_shell.rs
@@ -1,5 +1,5 @@
 mod shared {
-    use crux_core::render::{self, Render};
+    use crux_core::render::{render, Render};
     use crux_core::{macros::Effect, Command};
     use crux_http::Http;
     use serde::{Deserialize, Serialize};
@@ -48,28 +48,30 @@ mod shared {
             match event {
                 Event::Get => {
                     caps.http.get("http://example.com").send(Event::Set);
+
+                    Command::done()
                 }
                 Event::GetJson => {
                     caps.http
                         .get("http://example.com")
                         .expect_json::<String>()
                         .send(Event::SetJson);
+
+                    Command::done()
                 }
                 Event::Set(response) => {
                     let mut response = response.unwrap();
                     model.status = response.status().into();
                     model.body = response.take_body().unwrap();
 
-                    return render::render();
+                    render()
                 }
                 Event::SetJson(response) => {
                     model.json_body = response.unwrap().take_body().unwrap();
 
-                    return render::render();
+                    render()
                 }
             }
-
-            Command::done()
         }
 
         fn view(&self, model: &Self::Model) -> Self::ViewModel {

--- a/crux_http/tests/command_with_shell.rs
+++ b/crux_http/tests/command_with_shell.rs
@@ -1,7 +1,7 @@
 mod shared {
     use crux_core::{
         macros::Effect,
-        render::{self, Render},
+        render::{render, Render},
         Command,
     };
     use crux_http::command::Http;
@@ -61,12 +61,12 @@ mod shared {
                     model.status = response.status().into();
                     model.body = response.take_body().unwrap();
 
-                    render::render()
+                    render()
                 }
                 Event::SetJson(response) => {
                     model.json_body = response.unwrap().take_body().unwrap();
 
-                    render::render()
+                    render()
                 }
             }
         }

--- a/examples/notes/shared/src/app.rs
+++ b/examples/notes/shared/src/app.rs
@@ -127,7 +127,7 @@ impl NoteEditor {
                     }
                 };
 
-                let publish = PubSub::publish(change.bytes().to_vec());
+                let publish = PubSub::publish(change.bytes().to_vec()).into();
 
                 let len = text.chars().count();
                 let idx = match &model.cursor {
@@ -147,7 +147,7 @@ impl NoteEditor {
                 model.cursor = TextCursor::Position(idx);
 
                 let mut change = model.note.splice_text(from, to - from, &text);
-                let publish = PubSub::publish(change.bytes().to_vec());
+                let publish = PubSub::publish(change.bytes().to_vec()).into();
 
                 Command::all(vec![
                     publish,
@@ -193,7 +193,7 @@ impl NoteEditor {
                 };
 
                 model.cursor = TextCursor::Position(new_index);
-                let publish = PubSub::publish(change.bytes().to_vec());
+                let publish = PubSub::publish(change.bytes().to_vec()).into();
 
                 Command::all(vec![
                     publish,

--- a/examples/notes/shared/src/capabilities/pub_sub.rs
+++ b/examples/notes/shared/src/capabilities/pub_sub.rs
@@ -1,9 +1,11 @@
+use std::future::Future;
+
 use futures::Stream;
 use serde::{Deserialize, Serialize};
 
 use crux_core::{
     capability::{CapabilityContext, Operation},
-    command::StreamBuilder,
+    command::{NotificationBuilder, StreamBuilder},
     Command, Request,
 };
 
@@ -42,7 +44,9 @@ where
         Command::stream_from_shell(PubSubOperation::Subscribe).map(|Message(data)| data)
     }
 
-    pub fn publish<Effect>(data: Vec<u8>) -> Command<Effect, Event>
+    pub fn publish<Effect>(
+        data: Vec<u8>,
+    ) -> NotificationBuilder<Effect, Event, impl Future<Output = ()>>
     where
         Effect: From<Request<PubSubOperation>> + Send + 'static,
     {


### PR DESCRIPTION
**Breaking Change**: Command API changed — `notify_shell` now returns `NotificationBuilder`, instead of `Command`

Adds `NotificationBuilder` which has symmetry with `RequestBuilder` and `StreamBuilder`, but without continuations. This is useful where you need to notify the shell from an async context. There is also now a `From` implementation to convert the builder into a command. 

Updated the `Render` capability accordingly. 

Note: it is recommended to implement capabilities in terms of builders rather than commands, so that they can be used in both sync and async contexts. However, `render::render()` currently returns a command, so we kept it that way to minimise breakages, and instead introduced `render::render_builder()` to return a builder.