### PR TITLE
Fix an executor bug that evicts tasks which wake themselves immediately and drop the waker

### DIFF
--- a/crux_core/src/command/tests/executor.rs
+++ b/crux_core/src/command/tests/executor.rs
@@ -1,0 +1,74 @@
+use std::{future::Future, pin::Pin, task::Poll};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{capability::Operation, Command, Request};
+
+struct ImmediateWake {
+    wake_count: usize,
+}
+
+impl Future for ImmediateWake {
+    type Output = usize;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        if self.wake_count < 1 {
+            Poll::Ready(self.wake_count)
+        } else {
+            self.wake_count -= 1;
+
+            cx.waker().wake_by_ref();
+
+            Poll::Pending
+        }
+    }
+}
+
+#[derive(PartialEq, Debug)]
+enum Event {
+    Count(usize),
+}
+
+#[derive(PartialEq, Clone, Serialize, Deserialize)]
+struct Op;
+
+impl Operation for Op {
+    type Output = usize;
+}
+
+enum Effect {
+    Effect(Request<Op>),
+}
+
+impl From<Request<Op>> for Effect {
+    fn from(value: Request<Op>) -> Self {
+        Effect::Effect(value)
+    }
+}
+
+#[test]
+fn tasks_with_no_more_wakers_are_evicted() {
+    let mut cmd = Command::request_from_shell(Op).then_send(Event::Count);
+
+    let effect = cmd.effects().next().expect("should see effect");
+
+    let Effect::Effect(request) = effect;
+
+    assert!(!cmd.is_done());
+
+    drop(request);
+
+    assert!(cmd.is_done());
+}
+
+#[test]
+fn tasks_which_wake_themselves_and_drop_wakers_are_not_evicted() {
+    let mut cmd = Command::<Effect, Event>::new(|ctx| async move {
+        let count = ImmediateWake { wake_count: 2 }.await;
+        ctx.send_event(Event::Count(count));
+    });
+
+    assert_eq!(cmd.events().next(), Some(Event::Count(0)));
+
+    assert!(cmd.is_done());
+}

--- a/crux_core/src/command/tests/mod.rs
+++ b/crux_core/src/command/tests/mod.rs
@@ -4,5 +4,6 @@ mod cancellation;
 mod capability_api;
 mod combinators;
 mod composition;
+mod executor;
 
 mod integration;


### PR DESCRIPTION
This fixes a subtle bug which can drop longer-running tasks to aggressively, when they return `Pending` from poll, but have already marked themselves ready and dropped the waker.

To handle the exception, I had to slightly rework how we process the ready queue, adding an explicit buffer which can be scanned for the id of a task which is suspended with no wakers, to see if it's also ready.