### PR TITLE
update guide for hello world

### DIFF
--- a/examples/hello_world/shared/src/app.rs
+++ b/examples/hello_world/shared/src/app.rs
@@ -1,10 +1,15 @@
 // ANCHOR: app
-
 use crux_core::{
-    render::{render, Render},
+    macros::effect,
+    render::{render, RenderOperation},
     App, Command,
 };
 use serde::{Deserialize, Serialize};
+
+#[effect]
+pub enum Effect {
+    Render(RenderOperation),
+}
 
 #[derive(Serialize, Deserialize)]
 pub enum Event {
@@ -19,49 +24,29 @@ pub struct ViewModel {
     data: String,
 }
 
-#[derive(crux_core::macros::Effect)]
-#[allow(unused)]
-pub struct Capabilities {
-    render: Render<Event>,
-}
-
 #[derive(Default)]
 pub struct Hello;
 
 impl App for Hello {
+    type Effect = Effect;
     type Event = Event;
     type Model = Model;
     type ViewModel = ViewModel;
-    type Capabilities = Capabilities;
-    type Effect = Effect;
+    type Capabilities = (); // will be deprecated, so use unit type for now
 
     fn update(
         &self,
         _event: Self::Event,
         _model: &mut Self::Model,
-        _caps: &Self::Capabilities,
+        _caps: &(), // will be deprecated, so prefix with underscore for now
     ) -> Command<Effect, Event> {
-        // we no longer use the capabilities directly, but they are passed in
-        // until the migration to managed effects with `Command` is complete
-        // (at which point the capabilities will be removed from the `update`
-        // signature). Until then we delegate to our own `update` method so that
-        // we can test the app without needing to use AppTester.
-        self.update(_event, _model)
+        render()
     }
 
     fn view(&self, _model: &Self::Model) -> Self::ViewModel {
         ViewModel {
             data: "Hello World".to_string(),
         }
-    }
-}
-
-impl Hello {
-    // note: this function can be moved into the `App` trait implementation, above,
-    // once the `App` trait has been updated (as the final part of the migration
-    // to managed effects with `Command`).
-    fn update(&self, _event: Event, _model: &mut Model) -> Command<Effect, Event> {
-        render()
     }
 }
 
@@ -74,11 +59,11 @@ mod tests {
 
     #[test]
     fn hello_says_hello_world() {
-        let hello = Hello::default();
+        let hello = Hello;
         let mut model = Model;
 
         // Call 'update' and request effects
-        let mut cmd = hello.update(Event::None, &mut model);
+        let mut cmd = hello.update(Event::None, &mut model, &());
 
         // Check update asked us to `Render`
         cmd.expect_one_effect().expect_render();


### PR DESCRIPTION
This updates the ["Hello World" page](https://redbadger.github.io/crux/guide/hello_world.html) in the development guide section of the book to be compatible with the `#[effect]` macro.

It also updates the `hello-world` example, from which code snippets are drawn.