### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Viktor Charypar"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Crux: Cross-platform app development in Rust"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10