### PR TITLE
crux_core/testing: Add track_caller to resolve_to_event_then_update

### DIFF
--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -96,6 +96,7 @@ where
     ///
     /// This helper is useful for the common case where  one expects the effect to resolve
     /// to exactly one event, which should then be run by the app.
+    #[track_caller]
     pub fn resolve_to_event_then_update<Op: Operation>(
         &self,
         request: &mut Request<Op>,


### PR DESCRIPTION
This allow to show the caller location in in panic messages. In practice it means that panic messages will point the the user test code instead of crux testing code.