### PR TITLE
add .query() method to protocol::HttpRequestBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_qs 0.10.1",
  "thiserror 2.0.12",
  "url",
  "web-sys",
@@ -1162,7 +1163,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
- "serde_qs",
+ "serde_qs 0.8.5",
  "serde_urlencoded",
  "url",
 ]
@@ -2230,6 +2231,17 @@ name = "serde_qs"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cac3f1e2ca2fe333923a1ae72caca910b98ed0630bb35ef6f8c8517d6e81afa"
 dependencies = [
  "percent-encoding",
  "serde",

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = "1.0.140"
 thiserror = "2.0.12"
 url = "2.5.4"
 web-sys = { optional = true, version = "0.3.77", features = ["TextDecoder"] }
+serde_qs = "0.10.1"
 
 [dev-dependencies]
 assert_fs = "1.1.2"

--- a/crux_http/src/error.rs
+++ b/crux_http/src/error.rs
@@ -43,6 +43,12 @@ impl From<url::ParseError> for HttpError {
     }
 }
 
+impl From<serde_qs::Error> for HttpError {
+    fn from(e: serde_qs::Error) -> Self {
+        HttpError::Json(e.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -473,4 +473,41 @@ mod tests {
             }
         );
     }
+
+    #[test]
+    fn test_http_request_query_with_url_with_existing_query_params() {
+        #[derive(Serialize, Deserialize)]
+        struct QueryParams {
+            name: String,
+            email: String,
+        }
+
+        let query = QueryParams {
+            name: "John Doe".to_string(),
+            email: "john@example.com".to_string(),
+        };
+
+        let mut builder = HttpRequestBuilder {
+            method: Some("GET".to_string()),
+            url: Some("https://example.com?foo=bar".to_string()),
+            headers: Some(vec![]),
+            body: Some(vec![]),
+        };
+
+        builder
+            .query(&query)
+            .expect("should serialize query params");
+        let req = builder.build();
+
+        assert_eq!(
+            req,
+            HttpRequest {
+                method: "GET".to_string(),
+                url: "https://example.com?foo=bar&name=John+Doe&email=john%40example.com"
+                    .to_string(),
+                headers: vec![],
+                body: vec![],
+            }
+        );
+    }
 }

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -87,6 +87,20 @@ impl HttpRequestBuilder {
         self
     }
 
+    pub fn query(&mut self, query: &impl Serialize) -> crate::Result<&mut Self> {
+        let query_string = serde_qs::to_string(query)?;
+        println!("query_string: {}", query_string);
+        if let Some(url) = &mut self.url {
+            if url.contains('?') {
+                url.push('&');
+            } else {
+                url.push('?');
+            }
+            url.push_str(&query_string);
+        }
+        Ok(self)
+    }
+
     pub fn json(&mut self, body: impl serde::Serialize) -> &mut Self {
         self.body = Some(serde_json::to_vec(&body).unwrap());
         self
@@ -233,6 +247,7 @@ impl From<HttpResponse> for crate::ResponseAsync {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::{Deserialize, Serialize};
 
     #[test]
     fn test_http_request_get() {
@@ -341,5 +356,121 @@ mod tests {
                 r#"HttpRequest { method: "POST", url: "http://example.com", body: <binary data - 4 bytes> }"#
             );
         }
+    }
+
+    #[test]
+    fn test_http_request_query() {
+        #[derive(Serialize, Deserialize)]
+        struct QueryParams {
+            page: u32,
+            limit: u32,
+            search: String,
+        }
+
+        let query = QueryParams {
+            page: 2,
+            limit: 10,
+            search: "test".to_string(),
+        };
+
+        let mut builder = HttpRequestBuilder {
+            method: Some("GET".to_string()),
+            url: Some("https://example.com".to_string()),
+            headers: Some(vec![HttpHeader {
+                name: "foo".to_string(),
+                value: "bar".to_string(),
+            }]),
+            body: Some(vec![]),
+        };
+
+        builder
+            .query(&query)
+            .expect("should serialize query params");
+        let req = builder.build();
+
+        assert_eq!(
+            req,
+            HttpRequest {
+                method: "GET".to_string(),
+                url: "https://example.com?page=2&limit=10&search=test".to_string(),
+                headers: vec![HttpHeader {
+                    name: "foo".to_string(),
+                    value: "bar".to_string(),
+                }],
+                body: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_http_request_query_with_special_chars() {
+        #[derive(Serialize, Deserialize)]
+        struct QueryParams {
+            name: String,
+            email: String,
+        }
+
+        let query = QueryParams {
+            name: "John Doe".to_string(),
+            email: "john@example.com".to_string(),
+        };
+
+        let mut builder = HttpRequestBuilder {
+            method: Some("GET".to_string()),
+            url: Some("https://example.com".to_string()),
+            headers: Some(vec![]),
+            body: Some(vec![]),
+        };
+
+        builder
+            .query(&query)
+            .expect("should serialize query params with special chars");
+        let req = builder.build();
+
+        assert_eq!(
+            req,
+            HttpRequest {
+                method: "GET".to_string(),
+                url: "https://example.com?name=John+Doe&email=john%40example.com".to_string(),
+                headers: vec![],
+                body: vec![],
+            }
+        );
+    }
+
+    #[test]
+    fn test_http_request_query_with_empty_values() {
+        #[derive(Serialize, Deserialize)]
+        struct QueryParams {
+            empty: String,
+            none: Option<String>,
+        }
+
+        let query = QueryParams {
+            empty: "".to_string(),
+            none: None,
+        };
+
+        let mut builder = HttpRequestBuilder {
+            method: Some("GET".to_string()),
+            url: Some("https://example.com".to_string()),
+            headers: Some(vec![]),
+            body: Some(vec![]),
+        };
+
+        builder
+            .query(&query)
+            .expect("should serialize query params with empty values");
+        let req = builder.build();
+
+        assert_eq!(
+            req,
+            HttpRequest {
+                method: "GET".to_string(),
+                url: "https://example.com?empty=".to_string(),
+                headers: vec![],
+                body: vec![],
+            }
+        );
     }
 }


### PR DESCRIPTION
Introduces query on protocol::HttpRequestBuilder

The `crux_http` library has a query method to create query strings on `command::RequestBuilder`, but when writing tests for a crux core application

we would do something like 

```rust
let mut request = cmd.effects().next().unwrap().expect_http();

let expected_url = format!(
    "{}?lat={}&lon={}&appid={}",
    WEATHER_URL, lat_lng.0, lat_lng.1, API_KEY
);


// Before the changes in this PR
assert_eq!(&request.operation, &HttpRequest::get(expected_url).build());

// After the changes in the PR expose a query method
assert_eq!(
    &request.operation, // If we had query strings, the URL would already have it appended
    &HttpRequest::get(API_URL)
        // .query doesn't exist here as this is Protocol::HttpRequestBuilder. So we would have to format a string as an alternative for the meantime
        .query(&CurrentQueryString {
            lat: lat_lng.0.to_string(),
            lon: lat_lng.1.to_string(),
            appid: API_KEY,
        })
        .expect("could not serialize query string")
        .build()
);
```

Using `serde_qs` instead of `serde_urlencoded` as:
 - http_types uses it under the hood for .query on command::RequestBuilder
 - support abitrarily nested structs encoded in arbitrary orders