### PR TITLE
crux_core: Add a way to take out the operation from a request

### DIFF
--- a/crux_core/src/core/request.rs
+++ b/crux_core/src/core/request.rs
@@ -1,9 +1,22 @@
-use std::fmt::{self, Debug};
+use std::{
+    fmt::{self, Debug},
+    marker::PhantomData,
+};
 
 use crate::{
     capability::Operation,
     core::resolve::{Resolve, ResolveError},
 };
+
+/// A type that act like an operation `T`.
+///
+/// See [`Request::take_operation`] for details.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PhantomOperation<T: Operation>(PhantomData<T>);
+
+impl<T: Operation> Operation for PhantomOperation<T> {
+    type Output = T::Output;
+}
 
 /// Request represents an effect request from the core to the shell.
 ///
@@ -64,6 +77,18 @@ where
     pub fn resolve(&mut self, output: Op::Output) -> Result<(), ResolveError> {
         self.resolve.resolve(output)
     }
+
+    /// Take the operation from the request leaving an [`PhantomOperation<Op>`]
+    /// value in its place.
+    pub fn take_operation(self) -> (Op, Request<PhantomOperation<Op>>) {
+        (
+            self.operation,
+            Request {
+                operation: PhantomOperation(PhantomData),
+                resolve: self.resolve,
+            },
+        )
+    }
 }
 
 impl<Op> fmt::Debug for Request<Op>
@@ -72,5 +97,31 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Request").field(&self.operation).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Request;
+    use crate::capability::Operation;
+
+    #[test]
+    fn test_take_operation() {
+        #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+        pub struct TestOperation;
+
+        #[derive(Debug, serde::Deserialize)]
+        pub struct TestOutput;
+
+        impl Operation for TestOperation {
+            type Output = TestOutput;
+        }
+
+        let request = Request::resolves_never(TestOperation);
+
+        let (operation, mut request) = request.take_operation();
+        let _ = request.resolve(TestOutput);
+
+        assert_eq!(operation, TestOperation);
     }
 }


### PR DESCRIPTION
This is useful for Operation types that don't implement Default, as for the one that do
```rust
let operation = std::mem::take(request.operation);
```
already fulfill the use.

For example today with the crux_kv Operation type
```rust
let mut operation = KeyValueOperation::Get {
    key: "".to_string(),
};
std::mem::swap(&mut request.operation, &mut operation);
```
is needed to take out the operation, with this commit it can be written with
```rust
let (operation, request) = request.take_operation();
```