### PR TITLE
fix(crux_cli): Handle built-in crates and add f32/f64 primitive support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,13 +326,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-util-schemas"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 1.0.69",
+ "toml 0.8.20",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7835cfc6135093070e95eb2b53e5d9b5c403dc3a6be6040ee026270aa82502"
+dependencies = [
+ "camino",
+ "cargo-platform 0.2.0",
+ "cargo-util-schemas",
  "semver",
  "serde",
  "serde_json",
@@ -381,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -391,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -508,7 +548,7 @@ dependencies = [
  "anyhow",
  "ascent",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "clap",
  "convert_case",
  "env_logger",
@@ -1141,7 +1181,7 @@ checksum = "b59852737bb6ccfe90e37408dfefd968b23bfd14daf30406d49ee46b4763e64a"
 dependencies = [
  "ahash",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "cfg-if",
  "debug-ignore",
  "fixedbitset 0.5.7",
@@ -1668,6 +1708,15 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking"
@@ -2296,6 +2345,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2347,6 +2417,15 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2566,10 +2645,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -2578,6 +2672,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -2607,13 +2703,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "uniffi"
 version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd1d240101ba3b9d7532ae86d9cb64d9a7ff63e13a2b7b9e94a32a601d8233"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "uniffi_bindgen",
  "uniffi_core",
  "uniffi_macros",
@@ -2629,7 +2731,7 @@ dependencies = [
  "anyhow",
  "askama",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "fs-err",
  "glob",
  "goblin",
@@ -2639,7 +2741,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap 0.16.2",
- "toml",
+ "toml 0.5.11",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -2684,7 +2786,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.101",
- "toml",
+ "toml 0.5.11",
  "uniffi_meta",
 ]
 
@@ -3078,7 +3180,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.20.0",
  "clap",
  "human-repr",
  "ignore",

--- a/crux_cli/Cargo.toml
+++ b/crux_cli/Cargo.toml
@@ -18,7 +18,7 @@ anyhow.workspace = true
 ascent = "0.8.0"
 camino = "1.1.9"
 cargo_metadata = "=0.19"
-clap = { version = "4.5.38", features = ["derive", "env"] }
+clap = { version = "4.5.39", features = ["derive", "env"] }
 convert_case = "0.8.0"
 env_logger = "0.11.8"
 guppy = "0.17.18"

--- a/crux_cli/codegen.fish
+++ b/crux_cli/codegen.fish
@@ -15,5 +15,8 @@ cargo build
 pushd $argv[1]
 RUST_LOG=info ../../target/debug/crux codegen \
     --crate-name shared \
-    --out-dir ./shared/generated
+    --out-dir ./shared/generated \
+    --java com.crux.example.counter.shared \
+    --swift SharedTypes \
+    --typescript shared_types
 popd

--- a/crux_cli/src/codegen/formatter.rs
+++ b/crux_cli/src/codegen/formatter.rs
@@ -396,6 +396,8 @@ impl From<&Type> for Format {
                 "u32" => Format::U32,
                 "u64" => Format::U64,
                 "u128" => Format::U128,
+                "f32" => Format::F32,
+                "f64" => Format::F64,
                 s => panic!("need to implement primitive {s}"),
             },
             Type::FunctionPointer(_function_pointer) => todo!(),

--- a/crux_cli/src/codegen/formatter.rs
+++ b/crux_cli/src/codegen/formatter.rs
@@ -368,6 +368,26 @@ impl From<&Type> for Format {
                                     _ => todo!(),
                                 }
                             }
+                            "HashMap" | "BTreeMap" => {
+                                // Handle HashMap<K, V> and BTreeMap<K, V>
+                                if args.len() >= 2 {
+                                    let key_format = match args.get(0) {
+                                        Some(GenericArg::Type(ref type_)) => type_.into(),
+                                        _ => todo!(),
+                                    };
+                                    let value_format = match args.get(1) {
+                                        Some(GenericArg::Type(ref type_)) => type_.into(),
+                                        _ => todo!(),
+                                    };
+                                    Format::Map {
+                                        key: Box::new(key_format),
+                                        value: Box::new(value_format),
+                                    }
+                                } else {
+                                    // Fallback to TypeName if not enough args
+                                    Format::TypeName(name)
+                                }
+                            }
                             _ => Format::TypeName(name),
                         },
                         GenericArgs::Parenthesized {

--- a/crux_cli/src/codegen/formatter.rs
+++ b/crux_cli/src/codegen/formatter.rs
@@ -360,6 +360,14 @@ impl From<&Type> for Format {
                                 };
                                 Format::Seq(Box::new(format))
                             }
+                            "Box" => {
+                                // Box<T> is semantically equivalent to T for serialization
+                                // since Box is just a heap allocation wrapper
+                                match args.first() {
+                                    Some(GenericArg::Type(ref type_)) => type_.into(),
+                                    _ => todo!(),
+                                }
+                            }
                             _ => Format::TypeName(name),
                         },
                         GenericArgs::Parenthesized {

--- a/crux_cli/src/codegen/formatter.rs
+++ b/crux_cli/src/codegen/formatter.rs
@@ -348,7 +348,11 @@ impl From<&Type> for Format {
                             "Option" => {
                                 let format = match args.first() {
                                     Some(GenericArg::Type(ref type_)) => type_.into(),
-                                    _ => todo!(),
+                                    Some(other) => panic!(
+                                        "Option<T> expects a type parameter, got: {:?}",
+                                        other
+                                    ),
+                                    None => panic!("Option<T> requires exactly one type parameter"),
                                 };
                                 Format::Option(Box::new(format))
                             }
@@ -356,7 +360,11 @@ impl From<&Type> for Format {
                             "Vec" => {
                                 let format = match args.first() {
                                     Some(GenericArg::Type(ref type_)) => type_.into(),
-                                    _ => todo!(),
+                                    Some(other) => panic!(
+                                        "Vec<T> expects a type parameter, got: {:?}",
+                                        other
+                                    ),
+                                    None => panic!("Vec<T> requires exactly one type parameter"),
                                 };
                                 Format::Seq(Box::new(format))
                             }
@@ -365,7 +373,11 @@ impl From<&Type> for Format {
                                 // since Box is just a heap allocation wrapper
                                 match args.first() {
                                     Some(GenericArg::Type(ref type_)) => type_.into(),
-                                    _ => todo!(),
+                                    Some(other) => panic!(
+                                        "Box<T> expects a type parameter, got: {:?}",
+                                        other
+                                    ),
+                                    None => panic!("Box<T> requires exactly one type parameter"),
                                 }
                             }
                             "HashMap" | "BTreeMap" => {
@@ -373,19 +385,30 @@ impl From<&Type> for Format {
                                 if args.len() >= 2 {
                                     let key_format = match args.get(0) {
                                         Some(GenericArg::Type(ref type_)) => type_.into(),
-                                        _ => todo!(),
+                                        Some(other) => panic!(
+                                            "{}<K, V> expects type parameter for K, got: {:?}",
+                                            name, other
+                                        ),
+                                        None => unreachable!("Already checked args.len() >= 2"),
                                     };
                                     let value_format = match args.get(1) {
                                         Some(GenericArg::Type(ref type_)) => type_.into(),
-                                        _ => todo!(),
+                                        Some(other) => panic!(
+                                            "{}<K, V> expects type parameter for V, got: {:?}",
+                                            name, other
+                                        ),
+                                        None => unreachable!("Already checked args.len() >= 2"),
                                     };
                                     Format::Map {
                                         key: Box::new(key_format),
                                         value: Box::new(value_format),
                                     }
                                 } else {
-                                    // Fallback to TypeName if not enough args
-                                    Format::TypeName(name)
+                                    panic!(
+                                        "{} requires exactly two type parameters <K, V>, got {} parameters",
+                                        name,
+                                        args.len()
+                                    )
                                 }
                             }
                             _ => Format::TypeName(name),

--- a/crux_cli/src/codegen/formatter.rs
+++ b/crux_cli/src/codegen/formatter.rs
@@ -335,6 +335,7 @@ fn make_request() -> ContainerFormat {
 }
 
 impl From<&Type> for Format {
+    #[allow(clippy::too_many_lines)]
     fn from(type_: &Type) -> Self {
         match type_ {
             Type::ResolvedPath(path) => {
@@ -348,10 +349,9 @@ impl From<&Type> for Format {
                             "Option" => {
                                 let format = match args.first() {
                                     Some(GenericArg::Type(ref type_)) => type_.into(),
-                                    Some(other) => panic!(
-                                        "Option<T> expects a type parameter, got: {:?}",
-                                        other
-                                    ),
+                                    Some(other) => {
+                                        panic!("Option<T> expects a type parameter, got: {other:?}")
+                                    }
                                     None => panic!("Option<T> requires exactly one type parameter"),
                                 };
                                 Format::Option(Box::new(format))
@@ -360,10 +360,9 @@ impl From<&Type> for Format {
                             "Vec" => {
                                 let format = match args.first() {
                                     Some(GenericArg::Type(ref type_)) => type_.into(),
-                                    Some(other) => panic!(
-                                        "Vec<T> expects a type parameter, got: {:?}",
-                                        other
-                                    ),
+                                    Some(other) => {
+                                        panic!("Vec<T> expects a type parameter, got: {other:?}")
+                                    }
                                     None => panic!("Vec<T> requires exactly one type parameter"),
                                 };
                                 Format::Seq(Box::new(format))
@@ -373,29 +372,26 @@ impl From<&Type> for Format {
                                 // since Box is just a heap allocation wrapper
                                 match args.first() {
                                     Some(GenericArg::Type(ref type_)) => type_.into(),
-                                    Some(other) => panic!(
-                                        "Box<T> expects a type parameter, got: {:?}",
-                                        other
-                                    ),
+                                    Some(other) => {
+                                        panic!("Box<T> expects a type parameter, got: {other:?}")
+                                    }
                                     None => panic!("Box<T> requires exactly one type parameter"),
                                 }
                             }
                             "HashMap" | "BTreeMap" => {
                                 // Handle HashMap<K, V> and BTreeMap<K, V>
                                 if args.len() >= 2 {
-                                    let key_format = match args.get(0) {
+                                    let key_format = match args.first() {
                                         Some(GenericArg::Type(ref type_)) => type_.into(),
                                         Some(other) => panic!(
-                                            "{}<K, V> expects type parameter for K, got: {:?}",
-                                            name, other
+                                            "{name}<K, V> expects type parameter for K, got: {other:?}"
                                         ),
                                         None => unreachable!("Already checked args.len() >= 2"),
                                     };
                                     let value_format = match args.get(1) {
                                         Some(GenericArg::Type(ref type_)) => type_.into(),
                                         Some(other) => panic!(
-                                            "{}<K, V> expects type parameter for V, got: {:?}",
-                                            name, other
+                                            "{name}<K, V> expects type parameter for V, got: {other:?}"
                                         ),
                                         None => unreachable!("Already checked args.len() >= 2"),
                                     };

--- a/crux_cli/src/codegen/mod.rs
+++ b/crux_cli/src/codegen/mod.rs
@@ -95,12 +95,15 @@ where
         if previous.contains_key(&crate_name) {
             continue;
         }
-        
+
         // Skip built-in Rust crates that don't have manifests
-        if matches!(crate_name.as_str(), "std" | "core" | "alloc" | "proc_macro" | "test") {
+        if matches!(
+            crate_name.as_str(),
+            "std" | "core" | "alloc" | "proc_macro" | "test"
+        ) {
             continue;
         }
-        
+
         let crate_ = load(&crate_name)?;
 
         filter.process(&crate_name, &crate_);

--- a/crux_cli/src/codegen/mod.rs
+++ b/crux_cli/src/codegen/mod.rs
@@ -95,6 +95,12 @@ where
         if previous.contains_key(&crate_name) {
             continue;
         }
+        
+        // Skip built-in Rust crates that don't have manifests
+        if matches!(crate_name.as_str(), "std" | "core" | "alloc" | "proc_macro" | "test") {
+            continue;
+        }
+        
         let crate_ = load(&crate_name)?;
 
         filter.process(&crate_name, &crate_);

--- a/examples/counter-next/Cargo.lock
+++ b/examples/counter-next/Cargo.lock
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -531,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,8 +11,8 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-cargo_metadata = "0.19.2"
-clap = { version = "4.5.38", features = ["derive"] }
+cargo_metadata = "0.20.0"
+clap = { version = "4.5.39", features = ["derive"] }
 human-repr = "1.1.0"
 ignore = "0.4.23"
 xshell = "0.2.7"


### PR DESCRIPTION
- Skip built-in Rust crates (std, core, alloc, proc_macro, test) that don't have manifests
- Add support for f32 and f64 primitive types in codegen formatter
- Fixes 'unknown crate alloc/std' and 'need to implement primitive f32/f64' errors