### PR TITLE
Request handle

### DIFF
--- a/crux_core/src/bridge/request_serde.rs
+++ b/crux_core/src/bridge/request_serde.rs
@@ -62,13 +62,11 @@ where
         F: FnOnce(Op) -> Eff,
     {
         // FIXME should Eff be bound as `Serializable`?
-        let (operation, resolve) = (self.operation, self.resolve);
-
-        let resolve = resolve.deserializing(move |deserializer| {
+        let handle = self.handle.deserializing(move |deserializer| {
             erased_serde::deserialize(deserializer).map_err(BridgeError::DeserializeOutput)
         });
 
-        (effect(operation), resolve)
+        (effect(self.operation), handle)
     }
 }
 

--- a/crux_core/src/bridge/request_serde.rs
+++ b/crux_core/src/bridge/request_serde.rs
@@ -1,6 +1,6 @@
 use crate::{
     capability::Operation,
-    core::{Resolve, ResolveError},
+    core::{RequestHandle, ResolveError},
     Request,
 };
 
@@ -72,7 +72,7 @@ where
     }
 }
 
-impl<Out> Resolve<Out> {
+impl<Out> RequestHandle<Out> {
     /// Convert this Resolve into a version which deserializes from bytes, consuming it.
     /// The `func` argument is a 'deserializer' converting from bytes into the `Out` type.
     fn deserializing<F>(self, mut func: F) -> ResolveSerialized
@@ -84,13 +84,13 @@ impl<Out> Resolve<Out> {
         Out: 'static,
     {
         match self {
-            Resolve::Never => ResolveSerialized::Never,
-            Resolve::Once(resolve) => ResolveSerialized::Once(Box::new(move |deser| {
+            RequestHandle::Never => ResolveSerialized::Never,
+            RequestHandle::Once(resolve) => ResolveSerialized::Once(Box::new(move |deser| {
                 let out = func(deser)?;
                 resolve(out);
                 Ok(())
             })),
-            Resolve::Many(resolve) => ResolveSerialized::Many(Box::new(move |deser| {
+            RequestHandle::Many(resolve) => ResolveSerialized::Many(Box::new(move |deser| {
                 let out = func(deser)?;
                 resolve(out).map_err(|()| BridgeError::ProcessResponse(ResolveError::FinishedMany))
             })),

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -6,12 +6,10 @@ use std::sync::RwLock;
 
 pub use effect::Effect;
 pub use request::Request;
-pub use resolve::ResolveError;
-
-pub(crate) use resolve::Resolve;
+pub use resolve::{RequestHandle, Resolvable, ResolveError};
 
 use crate::capability::CommandSpawner;
-use crate::capability::{self, channel::Receiver, Operation, ProtoContext, QueuingExecutor};
+use crate::capability::{self, channel::Receiver, ProtoContext, QueuingExecutor};
 use crate::{App, WithContext};
 
 /// The Crux core. Create an instance of this type with your App type as the type parameter
@@ -113,14 +111,12 @@ where
     // used in docs/internals/runtime.md and docs/internals/bridge.md
     // ANCHOR: resolve
     // ANCHOR: resolve_sig
-    pub fn resolve<Op>(
+    pub fn resolve<Output>(
         &self,
-        request: &mut Request<Op>,
-        result: Op::Output,
+        request: &mut impl Resolvable<Output>,
+        result: Output,
     ) -> Result<Vec<A::Effect>, ResolveError>
-    where
-        Op: Operation,
-        // ANCHOR_END: resolve_sig
+// ANCHOR_END: resolve_sig
     {
         let resolve_result = request.resolve(result);
         debug_assert!(resolve_result.is_ok());

--- a/crux_core/src/core/request.rs
+++ b/crux_core/src/core/request.rs
@@ -26,7 +26,7 @@ where
 {
     /// Resolve the request with the given output.
     /// # Errors
-    /// Returns an error if the request cannot be resolved.
+    /// Returns an error if the request does not expect to be resolved.
     pub fn resolve(&mut self, output: Op::Output) -> Result<(), ResolveError> {
         self.handle.resolve(output)
     }

--- a/crux_core/src/core/resolve.rs
+++ b/crux_core/src/core/resolve.rs
@@ -23,6 +23,12 @@ pub trait Resolvable<Output> {
 
 impl<Output> Resolvable<Output> for RequestHandle<Output> {
     fn resolve(&mut self, output: Output) -> Result<(), ResolveError> {
+        self.resolve(output)
+    }
+}
+
+impl<Output> RequestHandle<Output> {
+    pub fn resolve(&mut self, output: Output) -> Result<(), ResolveError> {
         match self {
             RequestHandle::Never => Err(ResolveError::Never),
             RequestHandle::Many(f) => f(output).map_err(|()| ResolveError::FinishedMany),

--- a/crux_core/src/core/resolve.rs
+++ b/crux_core/src/core/resolve.rs
@@ -7,21 +7,28 @@ type ResolveMany<Out> = Box<dyn Fn(Out) -> Result<(), ()> + Send>;
 
 /// Resolve is a callback used to resolve an effect request and continue
 /// one of the capability Tasks running on the executor.
-pub(crate) enum Resolve<Out> {
+pub enum RequestHandle<Out> {
     Never,
     Once(ResolveOnce<Out>),
     Many(ResolveMany<Out>),
 }
 // ANCHOR_END: resolve
 
-impl<Out> Resolve<Out> {
-    pub fn resolve(&mut self, output: Out) -> Result<(), ResolveError> {
+pub trait Resolvable<Output> {
+    /// Resolve the request with the given output.
+    /// # Errors
+    /// Returns an error if the request is not expected to be resolved.
+    fn resolve(&mut self, output: Output) -> Result<(), ResolveError>;
+}
+
+impl<Output> Resolvable<Output> for RequestHandle<Output> {
+    fn resolve(&mut self, output: Output) -> Result<(), ResolveError> {
         match self {
-            Resolve::Never => Err(ResolveError::Never),
-            Resolve::Many(f) => f(output).map_err(|()| ResolveError::FinishedMany),
-            Resolve::Once(_) => {
+            RequestHandle::Never => Err(ResolveError::Never),
+            RequestHandle::Many(f) => f(output).map_err(|()| ResolveError::FinishedMany),
+            RequestHandle::Once(_) => {
                 // The resolve has been used, turn it into a Never
-                if let Resolve::Once(f) = std::mem::replace(self, Resolve::Never) {
+                if let RequestHandle::Once(f) = std::mem::replace(self, RequestHandle::Never) {
                     f(output);
                 }
 

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -171,7 +171,7 @@ use serde::Serialize;
 pub use capabilities::*;
 pub use capability::{Capability, WithContext};
 pub use command::Command;
-pub use core::{Core, Effect, Request, ResolveError};
+pub use core::{Core, Effect, Request, Resolvable, ResolveError};
 pub use crux_macros as macros;
 
 /// Implement [`App`] on your type to make it into a Crux app. Use your type implementing [`App`]

--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -7,7 +7,7 @@ use crate::{
         channel::Receiver, executor_and_spawner, CommandSpawner, Operation, ProtoContext,
         QueuingExecutor,
     },
-    Command, Request, WithContext,
+    Command, Request, Resolvable, WithContext,
 };
 
 /// `AppTester` is a simplified execution environment for Crux apps for use in
@@ -86,10 +86,10 @@ where
     /// # Errors
     ///
     /// Errors if the request cannot (or should not) be resolved.
-    pub fn resolve<Op: Operation>(
+    pub fn resolve<Output>(
         &self,
-        request: &mut Request<Op>,
-        value: Op::Output,
+        request: &mut impl Resolvable<Output>,
+        value: Output,
     ) -> Result<Update<App::Effect, App::Event>> {
         request.resolve(value)?;
 

--- a/crux_time/tests/cancellation.rs
+++ b/crux_time/tests/cancellation.rs
@@ -115,16 +115,16 @@ fn cancellation_of_a_started_timer() {
 
     // ...however, the _first_ command resolves with a TimeRequest::Clear
     // so that the shell can clean up
-    let Effect::Time(mut request) = cmd1.effects().next().unwrap();
-    let cancel_id = match &request.operation {
-        TimeRequest::Clear { id } => *id,
-        _ => panic!("expected a Clear"),
+    let (operation, mut handle) = cmd1.effects().next().unwrap().expect_time().split();
+
+    let TimeRequest::Clear { id } = operation else {
+        panic!("expected a Clear");
     };
-    assert_eq!(cancel_id, TIMER_ID);
+    assert_eq!(id, TIMER_ID);
 
     // the shell then responds, to say it has cleaned up
     let response = TimeResponse::Cleared { id: TIMER_ID };
-    request.resolve(response).unwrap();
+    handle.resolve(response).unwrap();
 
     // ...no effects
     assert!(cmd1.effects().next().is_none());

--- a/examples/counter-next/shared/src/app.rs
+++ b/examples/counter-next/shared/src/app.rs
@@ -162,11 +162,11 @@ mod tests {
         let mut cmd = app.update(Event::Get, &mut model, &());
 
         // the app should emit an HTTP request to fetch the counter
-        let mut request = cmd.effects().next().unwrap().expect_http();
+        let (operation, mut request) = cmd.effects().next().unwrap().expect_http().split();
 
         // and the request should be a GET to the correct URL
         assert_eq!(
-            &request.operation,
+            &operation,
             &HttpRequest::get("https://crux-counter.fly.dev/").build()
         );
 

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -703,9 +703,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3042,22 +3042,28 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3352,6 +3358,16 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -5055,9 +5071,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "c3f27698fc5799d2a281528a908bd874973953ca2e7bc2311637e10c263c723b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5080,23 +5096,22 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
@@ -5192,15 +5207,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -6525,9 +6531,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6670,6 +6676,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
+dependencies = [
+ "bitflags 2.9.0",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]

--- a/examples/counter/cli/Cargo.toml
+++ b/examples/counter/cli/Cargo.toml
@@ -11,11 +11,11 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 anyhow.workspace = true
-clap = { version = "4.5.38", features = ["derive"] }
+clap = { version = "4.5.39", features = ["derive"] }
 crossbeam-channel = "0.5.15"
 futures = "0.3"
-reqwest = { version = "0.12.15", features = ["stream"] }
+reqwest = { version = "0.12.17", features = ["stream"] }
 shared = { path = "../shared" }
-tokio = { version = "1.45.0", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.45.1", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/examples/counter/shared/src/app.rs
+++ b/examples/counter/shared/src/app.rs
@@ -157,12 +157,12 @@ mod tests {
         let mut cmd = app.update(Event::Get, &mut model, &());
 
         // the app should emit an HTTP request to fetch the counter
-        let mut request = cmd.effects().next().unwrap().expect_http();
+        let (operation, mut request) = cmd.effects().next().unwrap().expect_http().split();
 
         // and the request should be a GET to the correct URL
         assert_eq!(
-            &request.operation,
-            &HttpRequest::get("https://crux-counter.fly.dev/").build()
+            operation,
+            HttpRequest::get("https://crux-counter.fly.dev/").build()
         );
 
         // resolve the request with a simulated response from the web API

--- a/examples/counter/tauri/src-tauri/Cargo.toml
+++ b/examples/counter/tauri/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ tauri-build = { version = "2.2.0", features = [] }
 [dependencies]
 anyhow.workspace = true
 futures = "0.3.31"
-reqwest = { version = "0.12.15", features = ["stream"] }
+reqwest = { version = "0.12.17", features = ["stream"] }
 shared = { path = "../../shared" }
 tauri = { version = "2.5.1", features = [] }
 
@@ -29,6 +29,6 @@ custom-protocol = ["tauri/custom-protocol"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(mobile)',
-    'cfg(desktop)',
+  'cfg(mobile)',
+  'cfg(desktop)',
 ] }


### PR DESCRIPTION
fixes: #374

Following conversation on #369, change the `resolve` API on `Core` to accept a `RequestHandle`, which is a new name for what's currently called `Resolve`. 

For backwards compatibility, we update the API to be generic over an impl of `Resolvable` trait implemented on both `Request<Op>` and `RequestHandle<Out>`.

- [x] Rename `Resolve` to `RequestHandle` and make the type public
- [x] Introduce a `Resolvable` trait and implement it on `Request` and `RequestHandle`
- [x] Change `Core::resolve` to accept an implementation of the trait
- [x] Add a `Request::split(self) -> (Op, RequestHandle<Op::Out>)` API to `Request`