### PR TITLE
fix(crux_cli): Add support for Mutex<T> and Instant types in formatter

### DIFF
--- a/crux_cli/src/codegen/formatter.rs
+++ b/crux_cli/src/codegen/formatter.rs
@@ -407,6 +407,20 @@ impl From<&Type> for Format {
                                     )
                                 }
                             }
+                            "Mutex" => {
+                                // Mutex<T> is just a thread-safe wrapper, extract the inner type
+                                match args.first() {
+                                    Some(GenericArg::Type(ref type_)) => type_.into(),
+                                    Some(other) => {
+                                        panic!("Mutex<T> expects a type parameter, got: {other:?}")
+                                    }
+                                    None => panic!("Mutex<T> requires exactly one type parameter"),
+                                }
+                            }
+                            "Instant" => {
+                                // Instant represents a point in time, serialize as u64 (milliseconds)
+                                Format::U64
+                            }
                             _ => Format::TypeName(name),
                         },
                         GenericArgs::Parenthesized {


### PR DESCRIPTION
- Mutex<T> is handled like other smart pointers (Box, Arc, Rc) - extracts inner type
- Instant is serialized as u64 (milliseconds since epoch)

This fixes TypeScript compilation errors when these types are used in the API.