### PR TITLE
feat(crux_core): add `then_notify` and `build` methods to `*Builder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,13 +1175,14 @@ dependencies = [
 
 [[package]]
 name = "guppy"
-version = "0.17.18"
+version = "0.17.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b59852737bb6ccfe90e37408dfefd968b23bfd14daf30406d49ee46b4763e64a"
+checksum = "81dfbb4e91461d20334e04ea276ec826d62f4509ccd641db47d4ae15277dbb03"
 dependencies = [
  "ahash",
  "camino",
- "cargo_metadata 0.19.2",
+ "cargo-util-schemas",
+ "cargo_metadata 0.20.0",
  "cfg-if",
  "debug-ignore",
  "fixedbitset 0.5.7",

--- a/crux_cli/Cargo.toml
+++ b/crux_cli/Cargo.toml
@@ -21,7 +21,7 @@ cargo_metadata = "=0.19"
 clap = { version = "4.5.39", features = ["derive", "env"] }
 convert_case = "0.8.0"
 env_logger = "0.11.8"
-guppy = "0.17.18"
+guppy = "0.17.19"
 heck = "0.5.0"
 iter_tools = "0.29.0"
 lazy-regex = "3.4.1"

--- a/crux_core/src/command/builder.rs
+++ b/crux_core/src/command/builder.rs
@@ -39,6 +39,13 @@ where
         let make_task = self.make_task;
         make_task(ctx)
     }
+
+    /// Convert the [`NotificationBuilder`] into a [`Command`] to use in an sync context
+    pub fn build(self) -> Command<Effect, Event> {
+        Command::new(|ctx| async move {
+            self.into_future(ctx.clone()).await;
+        })
+    }
 }
 
 impl<Effect, Event, Task> From<NotificationBuilder<Effect, Event, Task>> for Command<Effect, Event>
@@ -78,6 +85,101 @@ where
         F: FnOnce(T) -> U + Send + 'static,
     {
         RequestBuilder::new(|ctx| self.into_future(ctx.clone()).map(map))
+    }
+
+    /// Chain a [`NotificationBuilder`] to run after completion of this one,
+    /// passing the result to the provided closure `make_next_builder`.
+    ///
+    /// The returned value of the closure must be a `NotificationBuilder`, which
+    /// can represent the notification to be sent before the composed future
+    /// is finished.
+    ///
+    /// If you want to chain a request, use [`Self::then_request`] instead.
+    /// If you want to chain a subscription, use [`Self::then_stream`] instead.
+    ///
+    /// The closure `make_next_builder` is only run *after* successful completion
+    /// of the `self` future.
+    ///
+    /// Note that this function consumes the receiving `RequestBuilder`
+    /// and returns a [`NotificationBuilder`] that represents the composition.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use crux_core::{Command, Request};
+    /// # use crux_core::capability::Operation;
+    /// # use serde::{Deserialize, Serialize};
+    /// # #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+    /// # enum AnOperation {
+    /// #     Request(u8),
+    /// #     Notify,
+    /// # }
+    /// #
+    /// # #[derive(Debug, PartialEq, Deserialize)]
+    /// # enum AnOperationOutput {
+    /// #     Response(String),
+    /// # }
+    /// #
+    /// # impl Operation for AnOperation {
+    /// #     type Output = AnOperationOutput;
+    /// # }
+    /// #
+    /// # #[derive(Debug)]
+    /// # enum Effect {
+    /// #     AnEffect(Request<AnOperation>),
+    /// # }
+    /// #
+    /// # impl From<Request<AnOperation>> for Effect {
+    /// #     fn from(request: Request<AnOperation>) -> Self {
+    /// #         Self::AnEffect(request)
+    /// #     }
+    /// # }
+    /// #
+    /// # #[derive(Debug, PartialEq)]
+    /// # enum Event {
+    /// #     Response(AnOperationOutput),
+    /// # }
+    /// let mut cmd: Command<Effect, Event> =
+    ///     Command::request_from_shell(AnOperation::Request(10))
+    ///     .then_notify(|response| {
+    ///         let AnOperationOutput::Response(_response) = response else {
+    ///             panic!("Invalid output!")
+    ///         };
+    ///
+    ///         // possibly do something with the response
+    ///
+    ///         Command::notify_shell(AnOperation::Notify)
+    ///     })
+    ///     .build();
+    ///
+    /// let effect = cmd.effects().next().unwrap();
+    /// let Effect::AnEffect(mut request) = effect;
+    ///
+    /// assert_eq!(request.operation, AnOperation::Request(10));
+    ///
+    /// request
+    ///     .resolve(AnOperationOutput::Response("ten".to_string()))
+    ///     .expect("should work");
+    ///
+    /// assert!(cmd.events().next().is_none());
+    /// let effect = cmd.effects().next().unwrap();
+    /// let Effect::AnEffect(request) = effect;
+    ///
+    /// assert_eq!(request.operation, AnOperation::Notify);
+    /// assert!(cmd.is_done());
+    /// ```
+    pub fn then_notify<F, NextTask>(
+        self,
+        make_next_builder: F,
+    ) -> NotificationBuilder<Effect, Event, impl Future<Output = ()>>
+    where
+        F: FnOnce(T) -> NotificationBuilder<Effect, Event, NextTask> + Send + 'static,
+        NextTask: Future<Output = ()> + Send + 'static,
+    {
+        NotificationBuilder::new(|ctx| {
+            self.into_future(ctx.clone())
+                .then(|out| make_next_builder(out).into_future(ctx))
+        })
     }
 
     /// Chain another [`RequestBuilder`] to run after completion of this one,
@@ -259,7 +361,7 @@ where
         })
     }
 
-    /// Convert the request builder into a future to use in an async context
+    /// Convert the [`RequestBuilder`] into a future to use in an async context
     #[must_use]
     pub fn into_future(self, ctx: CommandContext<Effect, Event>) -> Task {
         let make_task = self.make_task;
@@ -275,6 +377,21 @@ where
         Command::new(|ctx| async move {
             let out = self.into_future(ctx.clone()).await;
             ctx.send_event(event(out));
+        })
+    }
+
+    /// Convert the [`RequestBuilder`] into a [`Command`] to use in an sync context
+    ///
+    /// Note: You might be looking for [`then_send`](Self::then_send)
+    /// instead, which will send the output back into the app with an event.
+    ///
+    /// The command created in this function will *ignore* the output
+    /// of the request so may not be very useful.
+    /// It might be useful when using a 3rd party capability and you don't
+    /// care about the request's response.
+    pub fn build(self) -> Command<Effect, Event> {
+        Command::new(|ctx| async move {
+            self.into_future(ctx.clone()).await;
         })
     }
 }
@@ -503,11 +620,29 @@ where
         })
     }
 
-    /// Convert the stream builder into a stream to use in an async context
+    /// Convert the [`StreamBuilder`] into a stream to use in an async context
     #[must_use]
     pub fn into_stream(self, ctx: CommandContext<Effect, Event>) -> Task {
         let make_stream = self.make_stream;
 
         make_stream(ctx)
+    }
+
+    /// Convert the [`StreamBuilder`] into a [`Command`] to use in an sync context
+    ///
+    /// Note: You might be looking for [`then_send`](Self::then_send)
+    /// instead, which will send each item in the stream back into the
+    /// app with an event.
+    ///
+    /// The command created in this function will *ignore* the output
+    /// of the stream so may not be very useful.
+    /// It may be useful when using a 3rd party capability and you don't
+    /// care about the stream output.
+    pub fn build(self) -> Command<Effect, Event> {
+        Command::new(|ctx| async move {
+            let mut stream = pin!(self.into_stream(ctx.clone()));
+
+            while (stream.next().await).is_some() {}
+        })
     }
 }

--- a/examples/counter-next/Cargo.lock
+++ b/examples/counter-next/Cargo.lock
@@ -466,13 +466,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-util-schemas"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 1.0.69",
+ "toml 0.8.22",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7835cfc6135093070e95eb2b53e5d9b5c403dc3a6be6040ee026270aa82502"
+dependencies = [
+ "camino",
+ "cargo-platform 0.2.0",
+ "cargo-util-schemas",
  "semver",
  "serde",
  "serde_json",
@@ -742,7 +782,7 @@ dependencies = [
  "anyhow",
  "ascent",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "clap",
  "convert_case 0.8.0",
  "env_logger",
@@ -1353,13 +1393,14 @@ checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "guppy"
-version = "0.17.18"
+version = "0.17.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b59852737bb6ccfe90e37408dfefd968b23bfd14daf30406d49ee46b4763e64a"
+checksum = "81dfbb4e91461d20334e04ea276ec826d62f4509ccd641db47d4ae15277dbb03"
 dependencies = [
  "ahash",
  "camino",
- "cargo_metadata",
+ "cargo-util-schemas",
+ "cargo_metadata 0.20.0",
  "cfg-if",
  "debug-ignore",
  "fixedbitset 0.5.7",
@@ -2104,6 +2145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c04f5d74368e4d0dfe06c45c8627c81bd7c317d52762d118fb9b3076f6420fd"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,6 +2833,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3233,8 +3304,15 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tracing"
@@ -3309,7 +3387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd1d240101ba3b9d7532ae86d9cb64d9a7ff63e13a2b7b9e94a32a601d8233"
 dependencies = [
  "anyhow",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "uniffi_bindgen",
  "uniffi_core",
  "uniffi_macros",
@@ -3325,7 +3403,7 @@ dependencies = [
  "anyhow",
  "askama",
  "camino",
- "cargo_metadata",
+ "cargo_metadata 0.19.2",
  "fs-err",
  "glob",
  "goblin",


### PR DESCRIPTION
Adds `then_notify()` to `RequestBuilder` so that you can follow up with a `notify_shell` after processing the response.
Also adds `build()` methods to all 3 builders that turns the builder into a `Command` (ignoring any responses that may come back). Typically you'd use `then_send` to get any responses back to the app via `Event`s, but sometimes you might not care, say, if it's a 3rd party capability or the last in a chain.