### PR TITLE
feat(counter_next): remove legacy boilerplate from sse capability

### DIFF
--- a/examples/counter-next/shared/src/app.rs
+++ b/examples/counter-next/shared/src/app.rs
@@ -8,7 +8,7 @@ use crux_http::{command::Http, protocol::HttpRequest};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-use crate::sse::{ServerSentEvents, SseRequest};
+use crate::sse::{self, SseRequest};
 
 const API_URL: &str = "https://crux-counter.fly.dev";
 
@@ -119,7 +119,7 @@ impl crux_core::App for App {
             Event::StartWatch => {
                 let base = Url::parse(API_URL).unwrap();
                 let url = base.join("/sse").unwrap();
-                ServerSentEvents::get(url).then_send(Event::Update)
+                sse::get(url).then_send(Event::Update)
             }
         }
     }

--- a/examples/counter-next/shared/src/capabilities/sse.rs
+++ b/examples/counter-next/shared/src/capabilities/sse.rs
@@ -2,14 +2,9 @@ use std::{convert::From, future};
 
 use async_sse::{decode, Event as SseEvent};
 use async_std::io::Cursor;
+use crux_core::{capability::Operation, command::StreamBuilder, Request};
 use futures::{Stream, StreamExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-
-use crux_core::{
-    capability::{CapabilityContext, Operation},
-    command::StreamBuilder,
-    Request,
-};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct SseRequest {
@@ -33,45 +28,31 @@ impl Operation for SseRequest {
     type Output = SseResponse;
 }
 
-#[derive(crux_core::macros::Capability)]
-pub struct ServerSentEvents<Event> {
-    context: CapabilityContext<SseRequest, Event>,
-}
-
-impl<Event> ServerSentEvents<Event>
+pub fn get<Effect, Event, T>(
+    url: impl Into<String>,
+) -> StreamBuilder<Effect, Event, impl Stream<Item = T>>
 where
+    Effect: From<Request<SseRequest>> + Send + 'static,
     Event: Send + 'static,
+    T: Send + DeserializeOwned,
 {
-    #[must_use]
-    pub fn new(context: CapabilityContext<SseRequest, Event>) -> Self {
-        Self { context }
-    }
+    let url = url.into();
 
-    pub fn get<Effect, T>(
-        url: impl Into<String>,
-    ) -> StreamBuilder<Effect, Event, impl Stream<Item = T>>
-    where
-        Effect: From<Request<SseRequest>> + Send + 'static,
-        T: Send + DeserializeOwned,
-    {
-        let url = url.into();
+    StreamBuilder::new(|ctx| {
+        ctx.stream_from_shell(SseRequest { url })
+            .take_while(|response| future::ready(!response.is_done()))
+            .flat_map(|response| {
+                let SseResponse::Chunk(data) = response else {
+                    unreachable!()
+                };
 
-        StreamBuilder::new(|ctx| {
-            ctx.stream_from_shell(SseRequest { url })
-                .take_while(|response| future::ready(!response.is_done()))
-                .flat_map(|response| {
-                    let SseResponse::Chunk(data) = response else {
-                        unreachable!()
-                    };
-
-                    decode(Cursor::new(data))
+                decode(Cursor::new(data))
+            })
+            .filter_map(|sse_event| async {
+                sse_event.ok().and_then(|event| match event {
+                    SseEvent::Message(msg) => serde_json::from_slice(msg.data()).ok(),
+                    SseEvent::Retry(_) => None, // do we need to worry about this?
                 })
-                .filter_map(|sse_event| async {
-                    sse_event.ok().and_then(|event| match event {
-                        SseEvent::Message(msg) => serde_json::from_slice(msg.data()).ok(),
-                        SseEvent::Retry(_) => None, // do we need to worry about this?
-                    })
-                })
-        })
-    }
+            })
+    })
 }


### PR DESCRIPTION
Modifies the `sse` capability in `counter-next` example to remove support for deprecated capabilities.