### PR TITLE
turn web-sys crate conditional on wasm32 arch in crux_http

### DIFF
--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -32,8 +32,10 @@ serde_bytes = "0.11"
 serde_json = "1.0.140"
 thiserror = "2.0.12"
 url = "2.5.4"
-web-sys = { optional = true, version = "0.3.77", features = ["TextDecoder"] }
 serde_qs = "0.15.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-sys = { optional = true, version = "0.3.77", features = ["TextDecoder"] }
 
 [dev-dependencies]
 assert_fs = "1.1.3"


### PR DESCRIPTION
Hi, I stumbled upon this one while analyzing slow compilation on my hand and noticed web-sys was compiled for no reason. This can be circumvented on the consumer side by conditionally enabling the feature upon the target being wasm but it would be better to have it default.