### PR TITLE
turn uniffi optional

### DIFF
--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -11,8 +11,10 @@ keywords.workspace = true
 rust-version.workspace = true
 
 [features]
+default = ["bindgen"]
 cli = ["dep:crux_cli"]
 typegen = ["dep:serde-generate", "dep:serde-reflection"]
+bindgen = ["dep:uniffi"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -40,7 +42,7 @@ serde-reflection = { version = "=0.4.0", optional = true }
 wasm-bindgen = "0.2.100"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-uniffi.workspace = true
+uniffi = { workspace = true, optional = true }
 
 [dev-dependencies]
 assert_fs = "1.1.3"


### PR DESCRIPTION
Hi,
by default crux_core was pulling uniffi which is only required at build step, not at compile step... and is very slow to compile on cold builds (sometimes hot ones as well).
This allows the consumer of the lib to feature gate uniffi and turn it off when just compiling the core