### PR TITLE
Small polish of the middleware API

### DIFF
--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -172,7 +172,7 @@ use serde::Serialize;
 pub use capabilities::*;
 pub use capability::{Capability, WithContext};
 pub use command::Command;
-pub use core::{Core, Effect, Request, Resolvable, ResolveError};
+pub use core::{Core, Effect, Request, RequestHandle, Resolvable, ResolveError};
 #[cfg(feature = "cli")]
 pub use crux_cli as cli;
 pub use crux_macros as macros;

--- a/crux_core/src/middleware/effect_conversion.rs
+++ b/crux_core/src/middleware/effect_conversion.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::{capability::Operation, Request, ResolveError};
+use crate::{Resolvable, ResolveError};
 
 use super::Layer;
 
@@ -56,15 +56,14 @@ where
         }))
     }
 
-    fn resolve<Op, F>(
+    fn resolve<Output, F>(
         &self,
-        request: &mut Request<Op>,
-        output: Op::Output,
+        request: &mut impl Resolvable<Output>,
+        output: Output,
         effect_callback: F,
     ) -> Result<Vec<Self::Effect>, ResolveError>
     where
         F: Fn(Vec<Self::Effect>) + Sync + Send + 'static,
-        Op: Operation,
     {
         Ok(Self::map_effects(self.next.resolve(
             request,

--- a/examples/counter-next/shared/src/middleware.rs
+++ b/examples/counter-next/shared/src/middleware.rs
@@ -3,7 +3,7 @@ use std::{
     thread::spawn,
 };
 
-use crux_core::{Request, middleware::EffectMiddleware};
+use crux_core::{Request, RequestHandle, middleware::EffectMiddleware};
 use rand::{
     Rng as _, SeedableRng, TryRngCore as _,
     rngs::{OsRng, StdRng},
@@ -49,17 +49,15 @@ where
     fn try_process_effect_with(
         &self,
         effect: Effect,
-        resolve_callback: impl FnOnce(Request<RandomNumberRequest>, RandomNumber) + Send + 'static,
+        resolve_callback: impl FnOnce(RequestHandle<RandomNumber>, RandomNumber) + Send + 'static,
     ) -> Result<(), Effect> {
-        let rand_request @ Request {
-            operation: RandomNumberRequest(_, _),
-            ..
-        } = effect.try_into()?;
+        let rand_request = effect.try_into()?;
+        let (operation, handle): (RandomNumberRequest, _) = rand_request.split();
 
         self.jobs_tx
             .send((
-                rand_request.operation.clone(),
-                Box::new(move |number| resolve_callback(rand_request, number)),
+                operation,
+                Box::new(move |number| resolve_callback(handle, number)),
             ))
             .expect("Job failed to send to worker thread");
 


### PR DESCRIPTION
This allows the middleware to resolve any `impl Resolvable` (request, or request handle), and moves the effect handling middleware to use the request handle instead of request, so that `Request::split` can be used.

This should be a minor improvement to the readability of the effect middlware code.