### PR TITLE
Deprecate capabilities api

### DIFF
--- a/crux_core/src/capabilities/compose.rs
+++ b/crux_core/src/capabilities/compose.rs
@@ -37,7 +37,10 @@ use futures::Future;
 /// Note that testing composed effects is more difficult, because it is not possible to enter the effect
 /// transaction "in the middle" - only from the beginning - or to ignore some of the effects with out
 /// stalling the entire downstream dependency chain.
-#[deprecated]
+#[deprecated(
+    since = "0.16.0",
+    note = "The capabilities API has been deprecated. Use Command API instead"
+)]
 pub struct Compose<Ev> {
     #[expect(deprecated)]
     context: CapabilityContext<Never, Ev>,
@@ -45,7 +48,10 @@ pub struct Compose<Ev> {
 
 /// A restricted context given to the closure passed to [`Compose::spawn`]. This context can only
 /// update the app, not request from the shell or spawn further tasks.
-#[deprecated]
+#[deprecated(
+    since = "0.16.0",
+    note = "The capabilities API has been deprecated. Use Command API instead"
+)]
 pub struct ComposeContext<Ev> {
     #[expect(deprecated)]
     context: CapabilityContext<Never, Ev>,

--- a/crux_core/src/capabilities/compose.rs
+++ b/crux_core/src/capabilities/compose.rs
@@ -1,8 +1,11 @@
 //! A capability which can spawn tasks which orchestrate across other capabilities. This
 //! is useful for orchestrating a number of different effects into a single transaction.
 
-use crate::capability::{CapabilityContext, Never};
-use crate::Capability;
+#[expect(deprecated)]
+use crate::{
+    capability::{CapabilityContext, Never},
+    Capability,
+};
 use futures::Future;
 
 /// Compose capability can be used to orchestrate effects into a single transaction.
@@ -34,16 +37,21 @@ use futures::Future;
 /// Note that testing composed effects is more difficult, because it is not possible to enter the effect
 /// transaction "in the middle" - only from the beginning - or to ignore some of the effects with out
 /// stalling the entire downstream dependency chain.
+#[deprecated]
 pub struct Compose<Ev> {
+    #[expect(deprecated)]
     context: CapabilityContext<Never, Ev>,
 }
 
 /// A restricted context given to the closure passed to [`Compose::spawn`]. This context can only
 /// update the app, not request from the shell or spawn further tasks.
+#[deprecated]
 pub struct ComposeContext<Ev> {
+    #[expect(deprecated)]
     context: CapabilityContext<Never, Ev>,
 }
 
+#[expect(deprecated)]
 impl<Ev> Clone for ComposeContext<Ev> {
     fn clone(&self) -> Self {
         Self {
@@ -52,6 +60,7 @@ impl<Ev> Clone for ComposeContext<Ev> {
     }
 }
 
+#[expect(deprecated)]
 impl<Ev> ComposeContext<Ev> {
     /// Update the app with an event. This forwards to [`CapabilityContext::update_app`].
     pub fn update_app(&self, event: Ev)
@@ -62,6 +71,7 @@ impl<Ev> ComposeContext<Ev> {
     }
 }
 
+#[expect(deprecated)]
 impl<Ev> Compose<Ev> {
     #[must_use]
     pub fn new(context: CapabilityContext<Never, Ev>) -> Self {
@@ -141,6 +151,7 @@ impl<Ev> Compose<Ev> {
     }
 }
 
+#[expect(deprecated)]
 impl<E> Clone for Compose<E> {
     fn clone(&self) -> Self {
         Self {
@@ -149,6 +160,7 @@ impl<E> Clone for Compose<E> {
     }
 }
 
+#[expect(deprecated)]
 impl<Ev> Capability<Ev> for Compose<Ev> {
     type Operation = Never;
     type MappedSelf<MappedEv> = Compose<MappedEv>;

--- a/crux_core/src/capabilities/render.rs
+++ b/crux_core/src/capabilities/render.rs
@@ -4,11 +4,9 @@ use std::future::Future;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    capability::{CapabilityContext, Operation},
-    command::NotificationBuilder,
-    Capability, Command, Request,
-};
+#[expect(deprecated)]
+use crate::{capability::CapabilityContext, Capability};
+use crate::{capability::Operation, command::NotificationBuilder, Command, Request};
 
 /// Use an instance of `Render` to notify the Shell that it should update the user
 /// interface. This assumes a declarative UI framework is used in the Shell, which will
@@ -17,10 +15,13 @@ use crate::{
 ///
 /// For imperative UIs, the Shell will need to understand the difference between the two
 /// view models and update the user interface accordingly.
+#[deprecated]
 pub struct Render<Ev> {
+    #[expect(deprecated)]
     context: CapabilityContext<RenderOperation, Ev>,
 }
 
+#[expect(deprecated)]
 impl<Ev> Clone for Render<Ev> {
     fn clone(&self) -> Self {
         Self {
@@ -38,6 +39,7 @@ impl Operation for RenderOperation {
 }
 
 /// Public API of the capability, called by `App::update`.
+#[expect(deprecated)]
 impl<Ev> Render<Ev>
 where
     Ev: 'static,
@@ -57,6 +59,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<Ev> Capability<Ev> for Render<Ev> {
     type Operation = RenderOperation;
     type MappedSelf<MappedEv> = Render<MappedEv>;

--- a/crux_core/src/capabilities/render.rs
+++ b/crux_core/src/capabilities/render.rs
@@ -15,7 +15,10 @@ use crate::{capability::Operation, command::NotificationBuilder, Command, Reques
 ///
 /// For imperative UIs, the Shell will need to understand the difference between the two
 /// view models and update the user interface accordingly.
-#[deprecated]
+#[deprecated(
+    since = "0.16.0",
+    note = "The Render capability has been deprecated. Use render::render() with the Command API instead."
+)]
 pub struct Render<Ev> {
     #[expect(deprecated)]
     context: CapabilityContext<RenderOperation, Ev>,

--- a/crux_core/src/capability/mod.rs
+++ b/crux_core/src/capability/mod.rs
@@ -300,7 +300,10 @@ impl Operation for Never {
 ///     }
 /// }
 /// ```
-#[deprecated]
+#[deprecated(
+    since = "0.16.0",
+    note = "The capabilities API has been deprecated. Use Command API instead"
+)]
 pub trait Capability<Ev> {
     type Operation: Operation + DeserializeOwned;
 
@@ -374,7 +377,10 @@ pub trait Capability<Ev> {
 ///     }
 /// }
 /// ```
-#[deprecated]
+#[deprecated(
+    since = "0.16.0",
+    note = "The capabilities API has been deprecated. Use Command API instead. If you're using #[derive(Effect)] on a Capabilities type, you should use the #[effect] macro with an enum Effect instead."
+)]
 pub trait WithContext<Ev, Ef> {
     fn new_with_context(context: ProtoContext<Ef, Ev>) -> Self;
 }
@@ -421,7 +427,10 @@ impl<Event, Effect> WithContext<Event, Effect> for () {
 ///
 // used in docs/internals/runtime.md
 // ANCHOR: capability_context
-#[deprecated]
+#[deprecated(
+    since = "0.16.0",
+    note = "The capabilities API has been deprecated. Use Command API instead"
+)]
 pub struct CapabilityContext<Op, Event>
 where
     Op: Operation,

--- a/crux_core/src/capability/mod.rs
+++ b/crux_core/src/capability/mod.rs
@@ -1,5 +1,10 @@
 //! Capabilities provide a user-friendly API to request side-effects from the shell.
 //!
+//! NOTE: Capabilities are the legacy interface to side-effect and this module will be removed in a future version
+//! of crux. If you're starting a new app, you should use the [`command`](crate::command) API.
+//!
+//! For more help migrating from Capabilities to Commands, see [the documentation book](https://redbadger.github.io/crux/guide/effects.html#migrating-from-previous-versions-of-crux)
+//!
 //! Typically, capabilities provide I/O and host API access. Capabilities are external to the
 //! core Crux library. Some are part of the Crux core distribution, others are expected to be built by the
 //! community. Apps can also build single-use capabilities where necessary.
@@ -295,6 +300,7 @@ impl Operation for Never {
 ///     }
 /// }
 /// ```
+#[deprecated]
 pub trait Capability<Ev> {
     type Operation: Operation + DeserializeOwned;
 
@@ -368,10 +374,12 @@ pub trait Capability<Ev> {
 ///     }
 /// }
 /// ```
+#[deprecated]
 pub trait WithContext<Ev, Ef> {
     fn new_with_context(context: ProtoContext<Ef, Ev>) -> Self;
 }
 
+#[expect(deprecated)]
 impl<Event, Effect> WithContext<Event, Effect> for () {
     fn new_with_context(_context: ProtoContext<Effect, Event>) -> Self {}
 }
@@ -413,6 +421,7 @@ impl<Event, Effect> WithContext<Event, Effect> for () {
 ///
 // used in docs/internals/runtime.md
 // ANCHOR: capability_context
+#[deprecated]
 pub struct CapabilityContext<Op, Event>
 where
     Op: Operation,
@@ -480,6 +489,7 @@ impl<Effect, Event> CommandSpawner<Effect, Event> {
     }
 }
 
+#[expect(deprecated)]
 impl<Op, Ev> Clone for CapabilityContext<Op, Ev>
 where
     Op: Operation,
@@ -491,6 +501,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<Eff, Ev> ProtoContext<Eff, Ev>
 where
     Ev: 'static,
@@ -528,6 +539,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<Op, Ev> CapabilityContext<Op, Ev>
 where
     Op: Operation,
@@ -671,6 +683,7 @@ where
 }
 
 #[cfg(test)]
+#[expect(deprecated)]
 mod tests {
     use serde::{Deserialize, Serialize};
     use static_assertions::assert_impl_all;

--- a/crux_core/src/capability/shell_request.rs
+++ b/crux_core/src/capability/shell_request.rs
@@ -67,6 +67,7 @@ impl<T> Future for ShellRequest<T> {
     }
 }
 
+#[expect(deprecated)]
 impl<Op, Ev> crate::capability::CapabilityContext<Op, Ev>
 where
     Op: crate::capability::Operation,
@@ -126,6 +127,7 @@ where
 }
 
 #[cfg(test)]
+#[expect(deprecated)]
 mod tests {
     use assert_matches::assert_matches;
 

--- a/crux_core/src/capability/shell_stream.rs
+++ b/crux_core/src/capability/shell_stream.rs
@@ -42,6 +42,7 @@ impl<T> Stream for ShellStream<T> {
     }
 }
 
+#[expect(deprecated)]
 impl<Op, Ev> crate::capability::CapabilityContext<Op, Ev>
 where
     Op: crate::capability::Operation,
@@ -91,6 +92,7 @@ where
 }
 
 #[cfg(test)]
+#[expect(deprecated)]
 mod tests {
     use assert_matches::assert_matches;
 

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -10,7 +10,9 @@ pub use resolve::{RequestHandle, Resolvable, ResolveError};
 
 use crate::capability::CommandSpawner;
 use crate::capability::{self, channel::Receiver, ProtoContext, QueuingExecutor};
-use crate::{App, WithContext};
+use crate::App;
+#[expect(deprecated)]
+use crate::WithContext;
 
 /// The Crux core. Create an instance of this type with your App type as the type parameter
 ///
@@ -57,6 +59,7 @@ where
     /// ```
     ///
     #[must_use]
+    #[expect(deprecated)]
     pub fn new() -> Self
     where
         A::Capabilities: WithContext<A::Event, A::Effect>,
@@ -160,6 +163,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<A> Default for Core<A>
 where
     A: App,

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -34,18 +34,18 @@
 //! * Effect - A side-effect the core can request from the shell. This is typically a form of I/O or similar
 //!   interaction with the host platform. Updating the UI is considered an effect.
 //!
-//! * Capability - A user-friendly API used to request effects and provide events that should be dispatched
-//!   when an effect is completed. For example, a HTTP client is a capability.
-//!
-//! * Command - A description of a side-effect to be executed by the shell. Commands can be combined
-//!   (synchronously with combinators, or asynchronously with Rust async) to run
+//! * Command - A description of a side-effect or a sequence of side-effects to be executed by the shell.
+//!   Commands can be combined (synchronously with combinators, or asynchronously with Rust async) to run
 //!   sequentially or concurrently, or any combination thereof.
+//!
+//! * Capability - A user-friendly API used to create Commands for a specific effect type (e.g. HTTP)
+//!
 //!
 //! Below is a minimal example of a Crux-based application Core:
 //!
 //! ```rust
 //!// src/app.rs
-//!use crux_core::{render::{self, Render}, App, macros::Effect, Command};
+//!use crux_core::{render::{self, RenderOperation}, App, macros::effect, Command};
 //!use serde::{Deserialize, Serialize};
 //!
 //!// Model describing the application state
@@ -62,12 +62,10 @@
 //!    Reset,
 //!}
 //!
-//!// Capabilities listing the side effects the Core
-//!// will use to request side effects from the Shell
-//!#[cfg_attr(feature = "typegen", derive(crux_core::macros::Export))]
-//!#[derive(Effect)]
-//!pub struct Capabilities {
-//!    pub render: Render<Event>,
+//!// Effects the Core will request from the Shell
+//!#[effect(typegen)]
+//!pub enum Effect {
+//!    Render(RenderOperation),
 //!}
 //!
 //!#[derive(Default)]
@@ -79,12 +77,11 @@
 //!    // Use the above Model
 //!    type Model = Model;
 //!    type ViewModel = String;
-//!    // Use the above Capabilities
-//!    type Capabilities = Capabilities;
+//!    type Capabilities = (); // unused, see https://redbadger.github.io/crux/guide/effects.html
 //!    // Use the above generated Effect
 //!    type Effect = Effect;
 //!
-//!    fn update(&self, event: Event, model: &mut Model, caps: &Capabilities) -> Command<Effect, Event> {
+//!    fn update(&self, event: Event, model: &mut Model, _caps: &()) -> Command<Effect, Event> {
 //!        match event {
 //!            Event::Increment => model.count += 1,
 //!            Event::Decrement => model.count -= 1,
@@ -170,6 +167,7 @@ mod core;
 use serde::Serialize;
 
 pub use capabilities::*;
+#[expect(deprecated)]
 pub use capability::{Capability, WithContext};
 pub use command::Command;
 pub use core::{Core, Effect, Request, Resolvable, ResolveError};

--- a/crux_core/src/middleware/mod.rs
+++ b/crux_core/src/middleware/mod.rs
@@ -1,5 +1,7 @@
 //! Middleware which can be wrapped around the Core to modify its behaviour.
 //!
+//! Note that this is still somewhat experimental.
+//!
 //! This is useful for changing the mechanics of the Core without modifying the actual
 //! behaviour of the app.
 //!

--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -2,12 +2,14 @@
 use anyhow::Result;
 use std::{collections::VecDeque, sync::Arc};
 
+#[expect(deprecated)]
+use crate::WithContext;
 use crate::{
     capability::{
         channel::Receiver, executor_and_spawner, CommandSpawner, Operation, ProtoContext,
         QueuingExecutor,
     },
-    Command, Request, Resolvable, WithContext,
+    Command, Request, Resolvable,
 };
 
 /// `AppTester` is a simplified execution environment for Crux apps for use in
@@ -46,6 +48,7 @@ struct AppContext<Ef, Ev> {
     executor: QueuingExecutor,
 }
 
+#[expect(deprecated)]
 impl<App> AppTester<App>
 where
     App: crate::App,
@@ -122,6 +125,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 impl<App> Default for AppTester<App>
 where
     App: crate::App,

--- a/crux_core/tests/capability_orchestration.rs
+++ b/crux_core/tests/capability_orchestration.rs
@@ -18,6 +18,7 @@ mod app {
     }
 
     #[derive(Effect)]
+    #[expect(deprecated)]
     pub struct Capabilities {
         one: super::capabilities::one::CapabilityOne<Event>,
         two: super::capabilities::two::CapabilityTwo<Event>,
@@ -66,7 +67,9 @@ mod app {
 
 pub mod capabilities {
     pub mod one {
-        use crux_core::capability::{CapabilityContext, Operation};
+        #[expect(deprecated)]
+        use crux_core::capability::CapabilityContext;
+        use crux_core::capability::Operation;
         use crux_core::macros::Capability;
         use serde::{Deserialize, Serialize};
 
@@ -80,6 +83,7 @@ pub mod capabilities {
         }
 
         #[derive(Capability)]
+        #[expect(deprecated)]
         pub struct CapabilityOne<E> {
             context: CapabilityContext<OpOne, E>,
         }
@@ -94,6 +98,7 @@ pub mod capabilities {
             }
         }
 
+        #[expect(deprecated)]
         impl<E> CapabilityOne<E> {
             #[must_use]
             pub fn new(context: CapabilityContext<OpOne, E>) -> Self {
@@ -128,7 +133,9 @@ pub mod capabilities {
     }
 
     pub mod two {
-        use crux_core::capability::{CapabilityContext, Operation};
+        #[expect(deprecated)]
+        use crux_core::capability::CapabilityContext;
+        use crux_core::capability::Operation;
         use crux_core::macros::Capability;
         use serde::{Deserialize, Serialize};
 
@@ -142,6 +149,7 @@ pub mod capabilities {
         }
 
         #[derive(Capability)]
+        #[expect(deprecated)]
         pub struct CapabilityTwo<E> {
             context: CapabilityContext<OpTwo, E>,
         }
@@ -156,6 +164,7 @@ pub mod capabilities {
             }
         }
 
+        #[expect(deprecated)]
         impl<E> CapabilityTwo<E> {
             #[must_use]
             pub fn new(context: CapabilityContext<OpTwo, E>) -> Self {

--- a/crux_core/tests/capability_runtime.rs
+++ b/crux_core/tests/capability_runtime.rs
@@ -1,6 +1,8 @@
 mod capability {
     use async_channel::Sender;
-    use crux_core::capability::{CapabilityContext, Operation};
+    #[expect(deprecated)]
+    use crux_core::capability::CapabilityContext;
+    use crux_core::capability::Operation;
     use crux_core::macros::Capability;
     use futures::{FutureExt, StreamExt};
     use serde::{Deserialize, Serialize};
@@ -15,6 +17,7 @@ mod capability {
     }
 
     #[derive(Capability)]
+    #[expect(deprecated)]
     pub struct Crawler<Ev> {
         context: CapabilityContext<Fetch, Ev>,
         tasks_tx: Sender<(usize, Sender<usize>)>,
@@ -40,6 +43,7 @@ mod capability {
     //
     // We use this in the test to make sure the capability runtime supports
     // this type of use-case correctly.
+    #[expect(deprecated)]
     impl<Ev> Crawler<Ev>
     where
         Ev: 'static,
@@ -165,6 +169,7 @@ mod app {
     }
 
     #[derive(Effect)]
+    #[expect(deprecated)]
     pub struct Capabilities {
         crawler: super::capability::Crawler<Event>,
         render: crux_core::render::Render<Event>,

--- a/crux_core/tests/json_bridge.rs
+++ b/crux_core/tests/json_bridge.rs
@@ -1,7 +1,8 @@
 mod app {
-    use crux_core::render::{render, Render};
-    use crux_core::{macros::Effect, Command};
-    use crux_http::command::Http;
+    use crux_core::render::{render, RenderOperation};
+    use crux_core::Command;
+    use crux_http::{command::Http, protocol::HttpRequest};
+    use crux_macros::effect;
     use serde::{Deserialize, Serialize};
 
     #[derive(Default)]
@@ -13,20 +14,26 @@ mod app {
         Get,
     }
 
+    #[effect]
+    pub enum Effect {
+        Http(HttpRequest),
+        Render(RenderOperation),
+    }
+
     #[derive(Serialize, Deserialize)]
     pub struct ViewModel;
     impl crux_core::App for App {
         type Event = Event;
         type Model = ();
         type ViewModel = ViewModel;
-        type Capabilities = Capabilities;
+        type Capabilities = ();
         type Effect = Effect;
 
         fn update(
             &self,
             event: Event,
             _model: &mut Self::Model,
-            _caps: &Capabilities,
+            _caps: &(),
         ) -> Command<Effect, Event> {
             match event {
                 Event::Trigger => render(),
@@ -39,13 +46,6 @@ mod app {
         fn view(&self, _model: &Self::Model) -> Self::ViewModel {
             unimplemented!();
         }
-    }
-
-    #[derive(Effect)]
-    #[allow(dead_code)]
-    pub struct Capabilities {
-        pub http: crux_http::Http<Event>,
-        pub render: Render<Event>,
     }
 }
 

--- a/crux_core/tests/testing.rs
+++ b/crux_core/tests/testing.rs
@@ -1,4 +1,5 @@
 //! Test for the testing APIs
+#![expect(deprecated)]
 
 use crux_core::testing::AppTester;
 

--- a/crux_core/tests/typegen.rs
+++ b/crux_core/tests/typegen.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "typegen")]
 mod shared {
-    use crux_core::macros::{Effect, Export};
-    use crux_core::render::Render;
+    use crux_core::render::RenderOperation;
     use crux_core::Command;
+    use crux_macros::effect;
     use serde::{Deserialize, Serialize};
 
     #[derive(Default)]
@@ -20,14 +20,14 @@ mod shared {
         type Event = Event;
         type Model = ();
         type ViewModel = ViewModel;
-        type Capabilities = Capabilities;
+        type Capabilities = ();
         type Effect = Effect;
 
         fn update(
             &self,
             _event: Event,
             _model: &mut Self::Model,
-            _caps: &Capabilities,
+            _caps: &(),
         ) -> Command<Effect, Event> {
             Command::done()
         }
@@ -37,10 +37,9 @@ mod shared {
         }
     }
 
-    #[derive(Effect, Export)]
-    pub struct Capabilities {
-        #[allow(dead_code)]
-        pub render: Render<Event>,
+    #[effect(typegen)]
+    pub enum Effect {
+        Render(RenderOperation),
     }
 }
 

--- a/crux_http/src/lib.rs
+++ b/crux_http/src/lib.rs
@@ -6,6 +6,7 @@
 //! This is still work in progress and large parts of HTTP are not yet supported.
 // #![warn(missing_docs)]
 
+#[expect(deprecated)]
 use crux_core::capability::CapabilityContext;
 use http_types::Method;
 use url::Url;
@@ -38,11 +39,14 @@ use client::Client;
 pub type Result<T> = std::result::Result<T, HttpError>;
 
 /// The Http capability API.
+#[deprecated]
 pub struct Http<Ev> {
+    #[expect(deprecated)]
     context: CapabilityContext<protocol::HttpRequest, Ev>,
     client: Client,
 }
 
+#[expect(deprecated)]
 impl<Ev> crux_core::Capability<Ev> for Http<Ev> {
     type Operation = protocol::HttpRequest;
 
@@ -58,6 +62,7 @@ impl<Ev> crux_core::Capability<Ev> for Http<Ev> {
     }
 }
 
+#[expect(deprecated)]
 impl<Ev> Clone for Http<Ev> {
     fn clone(&self) -> Self {
         Self {
@@ -67,6 +72,7 @@ impl<Ev> Clone for Http<Ev> {
     }
 }
 
+#[expect(deprecated)]
 impl<Ev> Http<Ev>
 where
     Ev: 'static,

--- a/crux_http/src/lib.rs
+++ b/crux_http/src/lib.rs
@@ -39,7 +39,10 @@ use client::Client;
 pub type Result<T> = std::result::Result<T, HttpError>;
 
 /// The Http capability API.
-#[deprecated]
+#[deprecated(
+    since = "0.15.0",
+    note = "The capabilities API has been deprecated. Use command::Http instead."
+)]
 pub struct Http<Ev> {
     #[expect(deprecated)]
     context: CapabilityContext<protocol::HttpRequest, Ev>,

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -213,6 +213,7 @@ pub(crate) trait EffectSender {
 }
 
 #[async_trait]
+#[expect(deprecated)]
 impl<Ev> EffectSender for crux_core::capability::CapabilityContext<HttpRequest, Ev>
 where
     Ev: 'static,

--- a/crux_http/src/request_builder.rs
+++ b/crux_http/src/request_builder.rs
@@ -48,11 +48,13 @@ pub struct RequestBuilder<Event, ExpectBody = Vec<u8>> {
 // Middleware request builders won't have access to the capability, so they get a client
 // and therefore can't send events themselves.  Normal request builders get direct access
 // to the capability itself.
+#[expect(deprecated)]
 enum CapOrClient<Event> {
     Client(Client),
     Capability(crate::Http<Event>),
 }
 
+#[expect(deprecated)]
 impl<Event> RequestBuilder<Event, Vec<u8>> {
     pub(crate) fn new(method: Method, url: Url, capability: crate::Http<Event>) -> Self {
         Self {
@@ -414,6 +416,7 @@ where
     /// dispatched to the app's `update` function.
     /// # Panics
     /// Panics if the `RequestBuilder` has not been initialized.
+    #[expect(deprecated)]
     pub fn send<F>(self, make_event: F)
     where
         F: FnOnce(crate::Result<Response<ExpectBody>>) -> Event + Send + 'static,
@@ -468,6 +471,7 @@ impl<T, Eb> std::future::IntoFuture for RequestBuilder<T, Eb> {
         Box::pin({
             let client = match self.cap_or_client {
                 CapOrClient::Client(c) => c,
+                #[expect(deprecated)]
                 CapOrClient::Capability(c) => c.client,
             };
 

--- a/crux_http/tests/capability_with_shell.rs
+++ b/crux_http/tests/capability_with_shell.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated)]
+
 mod shared {
     use crux_core::render::{render, Render};
     use crux_core::{macros::Effect, Command};

--- a/crux_http/tests/capability_with_tester.rs
+++ b/crux_http/tests/capability_with_tester.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated)]
+
 mod shared {
 
     use std::{cmp::max, collections::HashMap, future::IntoFuture};

--- a/crux_http/tests/command_with_shell.rs
+++ b/crux_http/tests/command_with_shell.rs
@@ -1,10 +1,10 @@
 mod shared {
     use crux_core::{
-        macros::Effect,
-        render::{render, Render},
+        macros::effect,
+        render::{render, RenderOperation},
         Command,
     };
-    use crux_http::command::Http;
+    use crux_http::{command::Http, protocol::HttpRequest};
     use serde::{Deserialize, Serialize};
 
     #[derive(Default)]
@@ -39,15 +39,10 @@ mod shared {
         type Model = Model;
         type ViewModel = ViewModel;
 
-        type Capabilities = Capabilities;
+        type Capabilities = ();
         type Effect = Effect;
 
-        fn update(
-            &self,
-            event: Event,
-            model: &mut Model,
-            _caps: &Capabilities,
-        ) -> Command<Effect, Event> {
+        fn update(&self, event: Event, model: &mut Model, _caps: &()) -> Command<Effect, Event> {
             match event {
                 Event::Get => Http::get("http://example.com")
                     .build()
@@ -83,11 +78,10 @@ mod shared {
         }
     }
 
-    #[derive(Effect)]
-    #[allow(dead_code)]
-    pub(crate) struct Capabilities {
-        pub http: crux_http::Http<Event>,
-        pub render: Render<Event>,
+    #[effect]
+    pub enum Effect {
+        Http(HttpRequest),
+        Render(RenderOperation),
     }
 }
 

--- a/crux_http/tests/command_with_tester.rs
+++ b/crux_http/tests/command_with_tester.rs
@@ -2,8 +2,8 @@ mod shared {
 
     use std::{cmp::max, collections::HashMap};
 
-    use crux_core::{macros::Effect, Command};
-    use crux_http::command::Http;
+    use crux_core::{macros::effect, Command};
+    use crux_http::{command::Http, protocol::HttpRequest};
     use futures_util::join;
     use http_types::StatusCode;
     use serde::{Deserialize, Serialize};
@@ -40,15 +40,10 @@ mod shared {
         type Model = Model;
         type ViewModel = ViewModel;
 
-        type Capabilities = Capabilities;
+        type Capabilities = ();
         type Effect = Effect;
 
-        fn update(
-            &self,
-            event: Event,
-            model: &mut Model,
-            _caps: &Capabilities,
-        ) -> Command<Effect, Event> {
+        fn update(&self, event: Event, model: &mut Model, _caps: &()) -> Command<Effect, Event> {
             match event {
                 Event::Get => Http::get("http://example.com")
                     .header("Authorization", "secret-token")
@@ -129,10 +124,9 @@ mod shared {
         }
     }
 
-    #[derive(Effect)]
-    #[allow(unused)]
-    pub(crate) struct Capabilities {
-        pub http: crux_http::Http<Event>,
+    #[effect]
+    pub enum Effect {
+        Http(HttpRequest),
     }
 }
 

--- a/crux_kv/src/lib.rs
+++ b/crux_kv/src/lib.rs
@@ -10,7 +10,9 @@ pub mod value;
 
 use serde::{Deserialize, Serialize};
 
-use crux_core::capability::{CapabilityContext, Operation};
+#[expect(deprecated)]
+use crux_core::capability::CapabilityContext;
+use crux_core::capability::Operation;
 
 use error::KeyValueError;
 use value::Value;
@@ -131,10 +133,13 @@ impl Operation for KeyValueOperation {
     }
 }
 
+#[deprecated]
 pub struct KeyValue<Ev> {
+    #[expect(deprecated)]
     context: CapabilityContext<KeyValueOperation, Ev>,
 }
 
+#[expect(deprecated)]
 impl<Ev> crux_core::Capability<Ev> for KeyValue<Ev> {
     type Operation = KeyValueOperation;
 
@@ -150,6 +155,7 @@ impl<Ev> crux_core::Capability<Ev> for KeyValue<Ev> {
     }
 }
 
+#[expect(deprecated)]
 impl<Ev> Clone for KeyValue<Ev> {
     fn clone(&self) -> Self {
         Self {
@@ -158,6 +164,7 @@ impl<Ev> Clone for KeyValue<Ev> {
     }
 }
 
+#[expect(deprecated)]
 impl<Ev> KeyValue<Ev>
 where
     Ev: 'static,
@@ -320,6 +327,7 @@ where
     }
 }
 
+#[expect(deprecated)]
 async fn get<Ev: 'static>(
     context: &CapabilityContext<KeyValueOperation, Ev>,
     key: String,
@@ -330,6 +338,7 @@ async fn get<Ev: 'static>(
         .unwrap_get()
 }
 
+#[expect(deprecated)]
 async fn set<Ev: 'static>(
     context: &CapabilityContext<KeyValueOperation, Ev>,
     key: String,
@@ -341,6 +350,7 @@ async fn set<Ev: 'static>(
         .unwrap_set()
 }
 
+#[expect(deprecated)]
 async fn delete<Ev: 'static>(
     context: &CapabilityContext<KeyValueOperation, Ev>,
     key: String,
@@ -351,6 +361,7 @@ async fn delete<Ev: 'static>(
         .unwrap_delete()
 }
 
+#[expect(deprecated)]
 async fn exists<Ev: 'static>(
     context: &CapabilityContext<KeyValueOperation, Ev>,
     key: String,
@@ -361,6 +372,7 @@ async fn exists<Ev: 'static>(
         .unwrap_exists()
 }
 
+#[expect(deprecated)]
 async fn list_keys<Ev: 'static>(
     context: &CapabilityContext<KeyValueOperation, Ev>,
     prefix: String,

--- a/crux_kv/src/lib.rs
+++ b/crux_kv/src/lib.rs
@@ -133,7 +133,10 @@ impl Operation for KeyValueOperation {
     }
 }
 
-#[deprecated]
+#[deprecated(
+    since = "0.10.0",
+    note = "The capabilities API has been deprecated. Use command::KeyValue instead."
+)]
 pub struct KeyValue<Ev> {
     #[expect(deprecated)]
     context: CapabilityContext<KeyValueOperation, Ev>,

--- a/crux_macros/src/effect.rs
+++ b/crux_macros/src/effect.rs
@@ -121,7 +121,7 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
             #[cfg(feature = "typegen")]
             impl crux_core::typegen::Export for #enum_ident {
                 fn register_types(generator: &mut ::crux_core::typegen::TypeGen) -> ::crux_core::typegen::Result {
-                    use ::crux_core::capability::{Capability, Operation};
+                    use ::crux_core::capability::{Operation};
                     #(#effect_gen)*
                     generator.register_type::<#ffi_enum_ident>()?;
                     generator.register_type::<::crux_core::bridge::Request<#ffi_enum_ident>>()?;
@@ -194,7 +194,7 @@ mod test {
 
         let actual = effect_impl(args, input);
 
-        insta::assert_snapshot!(pretty_print(&actual), @r###"
+        insta::assert_snapshot!(pretty_print(&actual), @r##"
         #[derive(Debug)]
         pub enum Effect {
             Render(::crux_core::Request<RenderOperation>),
@@ -244,14 +244,14 @@ mod test {
             fn register_types(
                 generator: &mut ::crux_core::typegen::TypeGen,
             ) -> ::crux_core::typegen::Result {
-                use ::crux_core::capability::{Capability, Operation};
+                use ::crux_core::capability::Operation;
                 RenderOperation::register_types(generator)?;
                 generator.register_type::<EffectFfi>()?;
                 generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
                 Ok(())
             }
         }
-        "###);
+        "##);
     }
 
     #[test]
@@ -265,7 +265,7 @@ mod test {
 
         let actual = effect_impl(args, input);
 
-        insta::assert_snapshot!(pretty_print(&actual), @r#"
+        insta::assert_snapshot!(pretty_print(&actual), @r##"
         #[derive(Debug)]
         pub enum MyEffect {
             Render(::crux_core::Request<RenderOperation>),
@@ -315,14 +315,14 @@ mod test {
             fn register_types(
                 generator: &mut ::crux_core::typegen::TypeGen,
             ) -> ::crux_core::typegen::Result {
-                use ::crux_core::capability::{Capability, Operation};
+                use ::crux_core::capability::Operation;
                 RenderOperation::register_types(generator)?;
                 generator.register_type::<MyEffectFfi>()?;
                 generator.register_type::<::crux_core::bridge::Request<MyEffectFfi>>()?;
                 Ok(())
             }
         }
-        "#);
+        "##);
     }
 
     #[test]
@@ -395,7 +395,7 @@ mod test {
 
         let actual = effect_impl(args, input);
 
-        insta::assert_snapshot!(pretty_print(&actual), @r###"
+        insta::assert_snapshot!(pretty_print(&actual), @r##"
         #[derive(Debug)]
         pub enum Effect {
             Render(::crux_core::Request<RenderOperation>),
@@ -475,7 +475,7 @@ mod test {
             fn register_types(
                 generator: &mut ::crux_core::typegen::TypeGen,
             ) -> ::crux_core::typegen::Result {
-                use ::crux_core::capability::{Capability, Operation};
+                use ::crux_core::capability::Operation;
                 RenderOperation::register_types(generator)?;
                 HttpRequest::register_types(generator)?;
                 generator.register_type::<EffectFfi>()?;
@@ -483,7 +483,7 @@ mod test {
                 Ok(())
             }
         }
-        "###);
+        "##);
     }
 
     #[test]

--- a/crux_platform/src/lib.rs
+++ b/crux_platform/src/lib.rs
@@ -22,7 +22,7 @@ impl Operation for PlatformRequest {
 }
 
 #[derive(Capability)]
-#[deprecated]
+#[deprecated(since = "0.7.0", note = "The Platform capability has been deprecated.")]
 #[expect(deprecated)]
 pub struct Platform<Ev> {
     context: CapabilityContext<PlatformRequest, Ev>,

--- a/crux_platform/src/lib.rs
+++ b/crux_platform/src/lib.rs
@@ -3,7 +3,10 @@
 
 pub mod command;
 
-use crux_core::capability::{CapabilityContext, Operation};
+#[expect(deprecated)]
+use crux_core::capability::CapabilityContext;
+
+use crux_core::capability::Operation;
 use crux_core::macros::Capability;
 use serde::{Deserialize, Serialize};
 
@@ -19,10 +22,13 @@ impl Operation for PlatformRequest {
 }
 
 #[derive(Capability)]
+#[deprecated]
+#[expect(deprecated)]
 pub struct Platform<Ev> {
     context: CapabilityContext<PlatformRequest, Ev>,
 }
 
+#[expect(deprecated)]
 impl<Ev> Platform<Ev>
 where
     Ev: 'static,

--- a/crux_platform/tests/platform_test.rs
+++ b/crux_platform/tests/platform_test.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated)]
+
 mod shared {
     use crux_core::render::Render;
     use crux_core::{macros::Effect, Command};

--- a/crux_time/src/lib.rs
+++ b/crux_time/src/lib.rs
@@ -34,7 +34,10 @@ fn get_timer_id() -> TimerId {
 ///
 /// This capability provides access to the current time and allows the app to ask for
 /// notifications when a specific instant has arrived or a duration has elapsed.
-#[deprecated]
+#[deprecated(
+    since = "0.14.0",
+    note = "The Capability API has been deprecated. Use command::Time instead."
+)]
 #[expect(deprecated)]
 pub struct Time<Ev> {
     context: CapabilityContext<TimeRequest, Ev>,

--- a/crux_time/src/lib.rs
+++ b/crux_time/src/lib.rs
@@ -20,6 +20,7 @@ use std::{
     time::SystemTime,
 };
 
+#[expect(deprecated)]
 use crux_core::capability::CapabilityContext;
 
 pub use protocol::{duration::Duration, instant::Instant, TimeRequest, TimeResponse, TimerId};
@@ -33,10 +34,13 @@ fn get_timer_id() -> TimerId {
 ///
 /// This capability provides access to the current time and allows the app to ask for
 /// notifications when a specific instant has arrived or a duration has elapsed.
+#[deprecated]
+#[expect(deprecated)]
 pub struct Time<Ev> {
     context: CapabilityContext<TimeRequest, Ev>,
 }
 
+#[expect(deprecated)]
 impl<Ev> crux_core::Capability<Ev> for Time<Ev> {
     type Operation = TimeRequest;
     type MappedSelf<MappedEv> = Time<MappedEv>;
@@ -51,6 +55,7 @@ impl<Ev> crux_core::Capability<Ev> for Time<Ev> {
     }
 }
 
+#[expect(deprecated)]
 impl<Ev> Clone for Time<Ev> {
     fn clone(&self) -> Self {
         Self {
@@ -59,6 +64,7 @@ impl<Ev> Clone for Time<Ev> {
     }
 }
 
+#[expect(deprecated)]
 impl<Ev> Time<Ev>
 where
     Ev: 'static,

--- a/doctest_support/src/lib.rs
+++ b/doctest_support/src/lib.rs
@@ -121,6 +121,7 @@ pub mod command {
 }
 
 pub mod compose {
+    #[expect(deprecated)]
     pub mod capabilities {
         pub mod capability_one {
             use crux_core::capability::{CapabilityContext, Operation};

--- a/examples/notes/shared/src/capabilities/pub_sub.rs
+++ b/examples/notes/shared/src/capabilities/pub_sub.rs
@@ -1,3 +1,5 @@
+#![expect(deprecated)] // FIXME: Migrate PubSub to Command API
+
 use std::future::Future;
 
 use futures::Stream;


### PR DESCRIPTION
This marks the key types in the capabilities API deprecated to help users migrate and warn them about future removal of this API.

- [x] add deprecations and migrate remaining tests et. al
- [ ] review docs