### PR TITLE
feat(crux_core): facet typegen with module support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "16c74e56284d2188cabb6ad99603d1ace887a5d7e7b695d01b728155ed9ed427"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -582,7 +582,7 @@ dependencies = [
  "anyhow",
  "assert_fs",
  "assert_matches",
- "async-channel 2.3.1",
+ "async-channel 2.4.0",
  "bincode",
  "crossbeam-channel",
  "crux_cli",
@@ -936,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a219b97d2f75648ed5470f9efaed7fac98b0f5218d701e305444578cfbb33d3b"
+checksum = "0be4cf803e7c34ab73217e3c05b6c382b8a70a5948a9282ed9d64f62c2a03a90"
 dependencies = [
  "facet-core",
  "facet-macros",
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8f4f44d3904eb16187e3c0d93c1f6eed2d5f5e5532fb3cbf60a0849fdae726"
+checksum = "bc0dfc311334e2fad887baaebdc3773c05bbbddc286bef7c9c87cfb3fb4235fb"
 dependencies = [
  "bitflags",
  "impls",
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41934d083cf0dab2dc480d9c69240448478f06455c69a738833dbe8ef244efbe"
+checksum = "c10707410fd2c4f6b779fa04eac1a25d2907322dfb31039f16829c7996236768"
 dependencies = [
  "facet-core",
  "facet-macros-emit",
@@ -967,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros-emit"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e390d85bbdd57eb8ef7f7b10254feaf9727f77cf4312722cd8f030a8c182491e"
+checksum = "c496a4d3bd731444d278cf1178302d854c46dd04661e79a67d926b63d60a4cbb"
 dependencies = [
  "facet-macros-parse",
  "quote",
@@ -977,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros-parse"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76290ce9f9701d81b4c2d4b819a64caea9334056d2fb5c5f8c88b24afd9b6dc1"
+checksum = "e5e81c2f638023b13c3ab6e73b29be6fec44bdced5e418839c215a4b81afc6e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -988,7 +988,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.3.0"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de4ac1cbf6c2a93fd148365c18e2dc9efafa7d373fb20a590822b7abc691708"
 dependencies = [
  "anyhow",
  "erased-discriminant",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.27.14"
+version = "0.27.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa337c2c038af4187e9de8114cb0e5cfb91acb3f80a11cd7f1cd8e41df1e79f"
+checksum = "a219b97d2f75648ed5470f9efaed7fac98b0f5218d701e305444578cfbb33d3b"
 dependencies = [
  "facet-core",
  "facet-macros",
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.27.14"
+version = "0.27.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5546e2ef2b0b8bb08e37ed75e1ba7f1f011866deb644b468dc57ab6087b286f1"
+checksum = "ea8f4f44d3904eb16187e3c0d93c1f6eed2d5f5e5532fb3cbf60a0849fdae726"
 dependencies = [
  "bitflags",
  "impls",
@@ -957,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.27.14"
+version = "0.27.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce3261034d213cc6341f60646f93f08037a615e62f6f89bbde3e1a07a9e3619"
+checksum = "41934d083cf0dab2dc480d9c69240448478f06455c69a738833dbe8ef244efbe"
 dependencies = [
  "facet-core",
  "facet-macros-emit",
@@ -989,13 +989,11 @@ dependencies = [
 [[package]]
 name = "facet_generate"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81d14ed7cac3ec43d6ca813a1fa06a1140da392c075208be1c7c5c1ae62a21f"
 dependencies = [
  "anyhow",
  "erased-discriminant",
  "facet",
- "heck 0.3.3",
+ "heck 0.5.0",
  "include_dir 0.7.4",
  "once_cell",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ keywords = ["cross-platform-ui", "crux", "crux_core", "ffi", "wasm"]
 
 [workspace.dependencies]
 anyhow = "1.0.98"
-facet = "=0.27.14"
+facet = "0.27.15"
 serde = "1.0.219"
 uniffi = "0.29.3"
 uniffi_bindgen = "0.29.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ keywords = ["cross-platform-ui", "crux", "crux_core", "ffi", "wasm"]
 
 [workspace.dependencies]
 anyhow = "1.0.98"
-facet = "0.27.15"
+facet = "0.27.16"
 serde = "1.0.219"
 uniffi = "0.29.3"
 uniffi_bindgen = "0.29.3"

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -21,7 +21,7 @@ crux_cli = { version = "0.1.0", optional = true, path = "../crux_cli" }
 crux_macros = { version = "0.6.1", path = "../crux_macros", optional = true }
 erased-serde = "0.4"
 facet.workspace = true
-facet_generate = { version = "0.3.0", optional = true, path = "../../facet_generate" }
+facet_generate = { version = "0.4.2", optional = true }
 futures = "0.3.31"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0.140"
@@ -34,7 +34,7 @@ uniffi = { workspace = true, optional = true }
 [dev-dependencies]
 assert_fs = "1.1.3"
 assert_matches = "1.5"
-async-channel = "2.3"
+async-channel = "2.4.0"
 crux_http = { path = "../crux_http" }
 crux_time = { path = "../crux_time" }
 doctest_support = { path = "../doctest_support" }

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -21,7 +21,7 @@ crux_cli = { version = "0.1.0", optional = true, path = "../crux_cli" }
 crux_macros = { version = "0.6.1", path = "../crux_macros", optional = true }
 erased-serde = "0.4"
 facet.workspace = true
-facet_generate = { version = "0.3.0", optional = true }
+facet_generate = { version = "0.3.0", optional = true, path = "../../facet_generate" }
 futures = "0.3.31"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0.140"

--- a/crux_core/src/type_generation/serde.rs
+++ b/crux_core/src/type_generation/serde.rs
@@ -1,8 +1,8 @@
 //! Generation of foreign language types (currently Swift, Java, TypeScript) for Crux
 //!
-//! In order to use this module, you'll need a separate crate from your shared library, possibly
-//! called `shared_types`. This is necessary because we need to reference types from your shared library
-//! during the build process (`build.rs`).
+//! To use this module, you can add a separate crate from your shared library, possibly
+//! called `shared_types`, which will allow you to reference types from your shared library
+//! during the build process (e.g. in `shared_types/build.rs`).
 //!
 //! This module is behind the feature called `typegen`, and is not compiled into the default crate.
 //!
@@ -10,7 +10,7 @@
 //!
 //! ```rust,ignore
 //! [build-dependencies]
-//! crux_core = { version = "0.7", features = ["typegen"] }
+//! crux_core = { version = "0.15", features = ["typegen"] }
 //! ```
 //!
 //! * Your `shared_types` library, will have an empty `lib.rs`, since we only use it for generating foreign language type declarations.

--- a/crux_core/typegen_extensions/swift/requests.swift
+++ b/crux_core/typegen_extensions/swift/requests.swift
@@ -1,21 +1,20 @@
 import Serde
 
+extension [Request] {
+    public static func bincodeDeserialize(input: [UInt8]) throws -> [Request] {
+        let deserializer = BincodeDeserializer(input: input)
+        try deserializer.increase_container_depth()
+        let length = try deserializer.deserialize_len()
 
-public extension [Request] {
-  static func bincodeDeserialize(input: [UInt8]) throws -> [Request] {
-    let deserializer = BincodeDeserializer(input: input)
-    try deserializer.increase_container_depth()
-    let length = try deserializer.deserialize_len()
+        var requests: [Request] = []
+        for _ in 0..<length {
+            while deserializer.get_buffer_offset() < input.count {
+                let req = try Request.deserialize(deserializer: deserializer)
+                requests.append(req)
+            }
+        }
+        deserializer.decrease_container_depth()
 
-    var requests: [Request] = []
-    for _ in 0 ..< length {
-      while deserializer.get_buffer_offset() < input.count {
-        let req = try Request.deserialize(deserializer: deserializer)
-        requests.append(req)
-      }
+        return requests
     }
-    deserializer.decrease_container_depth()
-
-    return requests
-  }
 }

--- a/crux_core/typegen_extensions/typescript/serde/binaryDeserializer.ts
+++ b/crux_core/typegen_extensions/typescript/serde/binaryDeserializer.ts
@@ -107,8 +107,10 @@ export abstract class BinaryDeserializer implements Deserializer {
     const high = this.deserializeI32();
 
     // combine the two 32-bit values and return (little endian)
-    return (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
-      BigInt(low.toString());
+    return (
+      (BigInt(high.toString()) << BinaryDeserializer.BIG_32) |
+      BigInt(low.toString())
+    );
   }
 
   public deserializeI128(): bigint {
@@ -116,8 +118,10 @@ export abstract class BinaryDeserializer implements Deserializer {
     const high = this.deserializeI64();
 
     // combine the two 64-bit values and return (little endian)
-    return (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
-      BigInt(low.toString());
+    return (
+      (BigInt(high.toString()) << BinaryDeserializer.BIG_64) |
+      BigInt(low.toString())
+    );
   }
 
   public deserializeOptionTag(): boolean {

--- a/crux_macros/Cargo.toml
+++ b/crux_macros/Cargo.toml
@@ -23,7 +23,7 @@ syn = "2.0.104"
 [dev-dependencies]
 crux_core = { path = "../crux_core" }
 crux_http = { path = "../crux_http" }
-facet = "0.27.15"
+facet = { workspace = true }
 insta = "1.43.1"
 prettyplease = "0.2"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/crux_macros/Cargo.toml
+++ b/crux_macros/Cargo.toml
@@ -23,7 +23,7 @@ syn = "2.0.104"
 [dev-dependencies]
 crux_core = { path = "../crux_core" }
 crux_http = { path = "../crux_http" }
-facet = "=0.27.14"
+facet = "0.27.15"
 insta = "1.43.1"
 prettyplease = "0.2"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,1 +1,3 @@
 generated/
+.settings
+.project

--- a/examples/counter-next/Android/app/src/main/java/com/crux/example/counter/sse.kt
+++ b/examples/counter-next/Android/app/src/main/java/com/crux/example/counter/sse.kt
@@ -1,7 +1,7 @@
 package com.crux.example.counter
 
-import com.crux.example.counter.shared.SseRequest
-import com.crux.example.counter.shared.SseResponse
+import com.crux.example.counter.shared.server_sent_events.SseRequest
+import com.crux.example.counter.shared.server_sent_events.SseResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.request.prepareGet
 import io.ktor.client.statement.bodyAsChannel

--- a/examples/counter-next/Android/gradle/libs.versions.toml
+++ b/examples/counter-next/Android/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.1"
+agp = "8.11.0"
 kotlin = "2.1.20"
 coreKtx = "1.16.0"
 junit = "4.13.2"

--- a/examples/counter-next/Android/gradle/libs.versions.toml
+++ b/examples/counter-next/Android/gradle/libs.versions.toml
@@ -1,21 +1,21 @@
 [versions]
 agp = "8.11.0"
-kotlin = "2.1.20"
+kotlin = "2.2.0"
 coreKtx = "1.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.9.1"
 activityCompose = "1.10.1"
-composeBom = "2025.06.00"
+composeBom = "2025.06.01"
 
 # added
-jna = "5.15.0"
+jna = "5.17.0"
 lifecycle = "2.9.1"
 rustAndroid = "0.9.6"
 appcompat = "1.7.1"
 material = "1.12.0"
-ktorClient = "2.2.2"
+ktorClient = "3.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/examples/counter-next/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/counter-next/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Oct 10 11:31:20 BST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/examples/counter-next/Cargo.lock
+++ b/examples/counter-next/Cargo.lock
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "16c74e56284d2188cabb6ad99603d1ace887a5d7e7b695d01b728155ed9ed427"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -242,7 +242,7 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.4.0",
  "async-executor",
  "async-io",
  "async-lock",
@@ -422,7 +422,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel 2.4.0",
  "async-task",
  "futures-io",
  "futures-lite 2.6.0",
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "collection_literals"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186dce98367766de751c42c4f03970fc60fc012296e706ccbb9d5df9b6c1e271"
+checksum = "26b3f65b8fb8e88ba339f7d23a390fe1b0896217da05e2a66c584c9b29a91df8"
 
 [[package]]
 name = "colorchoice"
@@ -1127,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "facet"
-version = "0.27.14"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa337c2c038af4187e9de8114cb0e5cfb91acb3f80a11cd7f1cd8e41df1e79f"
+checksum = "0be4cf803e7c34ab73217e3c05b6c382b8a70a5948a9282ed9d64f62c2a03a90"
 dependencies = [
  "facet-core",
  "facet-macros",
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "facet-core"
-version = "0.27.14"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5546e2ef2b0b8bb08e37ed75e1ba7f1f011866deb644b468dc57ab6087b286f1"
+checksum = "bc0dfc311334e2fad887baaebdc3773c05bbbddc286bef7c9c87cfb3fb4235fb"
 dependencies = [
  "bitflags",
  "bytes",
@@ -1150,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros"
-version = "0.27.14"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce3261034d213cc6341f60646f93f08037a615e62f6f89bbde3e1a07a9e3619"
+checksum = "c10707410fd2c4f6b779fa04eac1a25d2907322dfb31039f16829c7996236768"
 dependencies = [
  "facet-core",
  "facet-macros-emit",
@@ -1160,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros-emit"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e390d85bbdd57eb8ef7f7b10254feaf9727f77cf4312722cd8f030a8c182491e"
+checksum = "c496a4d3bd731444d278cf1178302d854c46dd04661e79a67d926b63d60a4cbb"
 dependencies = [
  "facet-macros-parse",
  "quote",
@@ -1170,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "facet-macros-parse"
-version = "0.27.15"
+version = "0.27.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76290ce9f9701d81b4c2d4b819a64caea9334056d2fb5c5f8c88b24afd9b6dc1"
+checksum = "e5e81c2f638023b13c3ab6e73b29be6fec44bdced5e418839c215a4b81afc6e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.3.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "erased-discriminant",

--- a/examples/counter-next/Cargo.lock
+++ b/examples/counter-next/Cargo.lock
@@ -1182,13 +1182,11 @@ dependencies = [
 [[package]]
 name = "facet_generate"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81d14ed7cac3ec43d6ca813a1fa06a1140da392c075208be1c7c5c1ae62a21f"
 dependencies = [
  "anyhow",
  "erased-discriminant",
  "facet",
- "heck 0.3.3",
+ "heck 0.5.0",
  "include_dir 0.7.4",
  "once_cell",
  "serde",

--- a/examples/counter-next/iOS/CounterApp/sse.swift
+++ b/examples/counter-next/iOS/CounterApp/sse.swift
@@ -1,4 +1,4 @@
-import SharedTypes
+import ServerSentEvents
 import SwiftUI
 
 enum SseError: Error {

--- a/examples/counter-next/shared/Cargo.toml
+++ b/examples/counter-next/shared/Cargo.toml
@@ -21,7 +21,7 @@ async-std = "1.13.1"
 chrono = { version = "0.4.41", features = ["serde"] }
 crux_core.workspace = true
 crux_http.workspace = true
-facet = { version = "=0.27.14", features = ["bytes", "chrono"] }
+facet = { version = "0.27.15", features = ["bytes", "chrono"] }
 futures = "0.3.31"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0.140"

--- a/examples/counter-next/shared/src/capabilities/sse.rs
+++ b/examples/counter-next/shared/src/capabilities/sse.rs
@@ -8,11 +8,13 @@ use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 #[derive(Facet, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[facet(namespace = "server_sent_events")]
 pub struct SseRequest {
     pub url: String,
 }
 
 #[derive(Facet, Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[facet(namespace = "server_sent_events")]
 #[repr(C)]
 pub enum SseResponse {
     Chunk(Vec<u8>),

--- a/examples/counter-next/shared_types/build.rs
+++ b/examples/counter-next/shared_types/build.rs
@@ -11,11 +11,11 @@ fn main() -> anyhow::Result<()> {
 
     let output_root = PathBuf::from("./generated");
 
-    typegen.swift("SharedTypes", output_root.join("swift"))?;
+    // typegen.swift("SharedTypes", output_root.join("swift"))?;
 
-    typegen.java("com.crux.example.counter.shared", output_root.join("java"))?;
+    // typegen.java("com.crux.example.counter.shared", output_root.join("java"))?;
 
     typegen.typescript("shared_types", output_root.join("typescript"))?;
-
+    panic!();
     Ok(())
 }

--- a/examples/counter-next/shared_types/build.rs
+++ b/examples/counter-next/shared_types/build.rs
@@ -11,11 +11,11 @@ fn main() -> anyhow::Result<()> {
 
     let output_root = PathBuf::from("./generated");
 
-    // typegen.swift("SharedTypes", output_root.join("swift"))?;
+    typegen.swift("SharedTypes", output_root.join("swift"))?;
 
-    // typegen.java("com.crux.example.counter.shared", output_root.join("java"))?;
+    typegen.java("com.crux.example.counter.shared", output_root.join("java"))?;
 
     typegen.typescript("shared_types", output_root.join("typescript"))?;
-    panic!();
+
     Ok(())
 }

--- a/examples/counter-next/web-remix/app/sse.ts
+++ b/examples/counter-next/web-remix/app/sse.ts
@@ -1,8 +1,8 @@
-import type { SseRequest } from "shared_types/types/shared_types";
+import type { SseRequest } from "shared_types/types/server_sent_events";
 import {
   SseResponseVariantDone,
   SseResponseVariantChunk,
-} from "shared_types/types/shared_types";
+} from "shared_types/types/server_sent_events";
 
 export async function* request({ url }: SseRequest) {
   const request = new Request(url);

--- a/examples/weather/Cargo.toml
+++ b/examples/weather/Cargo.toml
@@ -15,6 +15,9 @@ anyhow = "1.0.98"
 crux_core = { path = "../../crux_core" }
 crux_http = { path = "../../crux_http" }
 crux_kv = { path = "../../crux_kv" }
+# crux_core = "0.15.0"
+# crux_http = "0.14.0"
+# crux_kv = "0.9.0"
 serde = "1.0.219"
 
 [workspace.metadata.bin]


### PR DESCRIPTION
Use `facet_generate` v0.4, which has namespace support for creation of specified modules in Swift, Kotlin and TypeScript. Updated `counter-next` example to put the types from the `ServerSentEvents` capability into their own namespace and tested for iOS, Android and NextJS.