### PR TITLE
feat(crux_core): facet_typegen support for external dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,15 +342,15 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.2.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
+checksum = "7dc1a6f7b5651af85774ae5a34b4e8be397d9cf4bc063b7e6dbd99a841837830"
 dependencies = [
  "semver",
  "serde",
  "serde-untagged",
  "serde-value",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "toml 0.8.23",
  "unicode-xid",
  "url",
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7835cfc6135093070e95eb2b53e5d9b5c403dc3a6be6040ee026270aa82502"
+checksum = "5cfca2aaa699835ba88faf58a06342a314a950d2b9686165e038286c30316868"
 dependencies = [
  "camino",
  "cargo-platform 0.2.0",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2b34126159980f92da2a08bdec0694fd80fb5eb9e48aff25d20a0d8dfa710d"
+checksum = "0d0390889d58f934f01cd49736275b4c2da15bcfc328c78ff2349907e6cabf22"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -649,7 +649,7 @@ version = "0.7.0-rc2"
 dependencies = [
  "crux_core",
  "crux_http",
- "darling",
+ "darling 0.21.0",
  "facet",
  "heck 0.5.0",
  "insta",
@@ -688,8 +688,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
+dependencies = [
+ "darling_core 0.21.0",
+ "darling_macro 0.21.0",
 ]
 
 [[package]]
@@ -707,12 +717,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
+dependencies = [
+ "darling_core 0.21.0",
  "quote",
  "syn 2.0.104",
 ]
@@ -763,7 +798,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -985,15 +1020,17 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b557774414687e06ec5547be3f7c56dd2bf291e713c351a97cef1510ff49b96"
+checksum = "597b8225d4afe8e69add28d721fb02c142aa67230b56d85064ee612779cde545"
 dependencies = [
  "anyhow",
  "erased-discriminant",
  "facet",
  "heck 0.5.0",
  "include_dir 0.7.4",
+ "indent",
+ "indoc",
  "once_cell",
  "serde",
  "textwrap 0.16.2",
@@ -1033,6 +1070,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1264,14 +1307,13 @@ dependencies = [
 
 [[package]]
 name = "guppy"
-version = "0.17.19"
+version = "0.17.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfbb4e91461d20334e04ea276ec826d62f4509ccd641db47d4ae15277dbb03"
+checksum = "7eadc0c380d2c5f421758a5838ce593687da4a47d1dcf1169bf3bad629b764e7"
 dependencies = [
  "ahash",
  "camino",
- "cargo-util-schemas",
- "cargo_metadata 0.20.0",
+ "cargo_metadata 0.21.0",
  "cfg-if",
  "debug-ignore",
  "fixedbitset 0.5.7",
@@ -1281,7 +1323,7 @@ dependencies = [
  "nested",
  "once_cell",
  "pathdiff",
- "petgraph 0.7.1",
+ "petgraph 0.8.2",
  "semver",
  "serde",
  "serde_json",
@@ -1312,6 +1354,11 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1569,6 +1616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indent"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f1a0777d972970f204fdf8ef319f1f4f8459131636d7e3c96c5d59570d0fa6"
+
+[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1630,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "infer"
@@ -1866,11 +1925,12 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
 dependencies = [
  "fixedbitset 0.5.7",
+ "hashbrown 0.15.4",
  "indexmap",
 ]
 
@@ -2645,9 +2705,9 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "target-spec"
-version = "3.4.2"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49424d0fdcba4406e46d1cea3014c4d1987263790b8e5d1be45c4509c9d52553"
+checksum = "53928b291de23967df6740f2e584bb68101890f63d730292c0a5205092c8e0fa"
 dependencies = [
  "cfg-expr",
  "guppy-workspace-hack",
@@ -3296,9 +3356,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -3338,7 +3398,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "cargo_metadata 0.20.0",
+ "cargo_metadata 0.21.0",
  "clap",
  "human-repr",
  "ignore",

--- a/crux_cli/Cargo.toml
+++ b/crux_cli/Cargo.toml
@@ -18,7 +18,7 @@ anyhow.workspace = true
 ascent = "0.8.0"
 camino = "1.1.10"
 cargo_metadata = "=0.19"
-clap = { version = "4.5.40", features = ["derive", "env"] }
+clap = { version = "4.5.41", features = ["derive", "env"] }
 convert_case = "0.8.0"
 env_logger = "0.11.8"
 guppy = "0.17.19"

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -21,7 +21,7 @@ crux_cli = { version = "0.1.0", optional = true, path = "../crux_cli" }
 crux_macros = { version = "0.7.0-rc2", path = "../crux_macros", optional = true }
 erased-serde = "0.4"
 facet.workspace = true
-facet_generate = { version = "0.6.0", optional = true }
+facet_generate = { version = "0.7.0", optional = true }
 futures = "0.3.31"
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0.140"

--- a/crux_macros/Cargo.toml
+++ b/crux_macros/Cargo.toml
@@ -13,7 +13,7 @@ keywords.workspace = true
 proc-macro = true
 
 [dependencies]
-darling = "0.20.11"
+darling = "0.21.0"
 heck = "0.5.0"
 proc-macro2 = "1.0.95"
 proc-macro-error = "1.0.4"

--- a/examples/counter-next/.gitignore
+++ b/examples/counter-next/.gitignore
@@ -1,3 +1,4 @@
 /target
 generated
 .idea
+.build

--- a/examples/counter-next/Cargo.lock
+++ b/examples/counter-next/Cargo.lock
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -466,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -736,7 +736,7 @@ dependencies = [
 name = "crux_macros"
 version = "0.7.0-rc2"
 dependencies = [
- "darling",
+ "darling 0.21.0",
  "heck 0.5.0",
  "proc-macro-error",
  "proc-macro2",
@@ -750,8 +750,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
+dependencies = [
+ "darling_core 0.21.0",
+ "darling_macro 0.21.0",
 ]
 
 [[package]]
@@ -769,12 +779,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
+dependencies = [
+ "darling_core 0.21.0",
  "quote",
  "syn 2.0.104",
 ]
@@ -850,7 +885,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -1067,15 +1102,17 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b557774414687e06ec5547be3f7c56dd2bf291e713c351a97cef1510ff49b96"
+checksum = "597b8225d4afe8e69add28d721fb02c142aa67230b56d85064ee612779cde545"
 dependencies = [
  "anyhow",
  "erased-discriminant",
  "facet",
  "heck 0.5.0",
  "include_dir 0.7.4",
+ "indent",
+ "indoc",
  "once_cell",
  "serde",
  "textwrap 0.16.2",
@@ -1266,10 +1303,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1279,9 +1314,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1675,6 +1712,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indent"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f1a0777d972970f204fdf8ef319f1f4f8459131636d7e3c96c5d59570d0fa6"
+
+[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1726,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "infer"
@@ -1831,15 +1880,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leptos"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ceaf7d86820125c57dcd380edac4b972debf480ee4c7eea6dd7cea212615978"
+checksum = "6c202a7897aa73c90ac4ce73713512d871f75e79847558d9e88f778659b164dc"
 dependencies = [
  "any_spawner",
  "cfg-if",
  "either_of",
  "futures",
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "hydration_context",
  "leptos_config",
  "leptos_dom",
@@ -1854,7 +1903,7 @@ dependencies = [
  "rustc_version",
  "send_wrapper",
  "serde",
- "serde_qs 0.14.0",
+ "serde_qs 0.15.0",
  "server_fn",
  "slotmap",
  "tachys",
@@ -1868,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_config"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4100ad54455f82b686c9d0500a45c909eb50ce68ccb2ed51439ff2596f54fd"
+checksum = "74eec2103dfa808f4b13c149dfbd3842f13a5948489fda3de31cc565fb28dbec"
 dependencies = [
  "config",
  "regex",
@@ -1881,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_dom"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adaca2ec1d6215a7c43dc6353d487e4e34faf325b8e4df2ca3df488964d403be"
+checksum = "25b845379c33884f0dead9abb5aa3d258d7bd507789fc2527a5972f82c0757c7"
 dependencies = [
  "js-sys",
  "or_poisoned",
@@ -1896,9 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_hot_reload"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597f84532609518092960ac241741963c90c216ee11f752e1b238b846f043640"
+checksum = "fae732329192df886803f076515d73c883166a4c8cbc5532584d0d1e43539300"
 dependencies = [
  "anyhow",
  "camino",
@@ -1914,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_macro"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2ec91579e9a1344adc1eee637cb774a01354a3d25857cbd028b0289efe131d"
+checksum = "8e32ae8783d4b64838167e026ef773dbc53399e9e6658e9c2f65e0ce67a5ccec"
 dependencies = [
  "attribute-derive",
  "cfg-if",
@@ -1937,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "leptos_server"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5af59932aa8a640da4d3d20650cf07084433e25db0ee690203d893b81773db29"
+checksum = "26851048e161998b8f9fb3261a833ec64df2a2669ea95f360c54b7f47a1e07cb"
 dependencies = [
  "any_spawner",
  "base64 0.22.1",
@@ -2861,17 +2910,6 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b417bedc008acbdf6d6b4bc482d29859924114bbe2650b7921fb68a261d0aa6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "serde_qs"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3faaf9e727533a19351a43cc5a8de957372163c7d35cc48c90b75cdda13c352"
@@ -2904,9 +2942,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b0f92b9d3a62c73f238ac21f7a09f15bad335a9d1651514d9da80d2eaf8d4c"
+checksum = "9c27fbd25ecc066481e383e2ed62ab2480e708aa3fe46cba36e95f58e61dfd04"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2917,14 +2955,13 @@ dependencies = [
  "gloo-net",
  "http",
  "js-sys",
- "once_cell",
  "pin-project-lite",
  "rustc_version",
  "rustversion",
  "send_wrapper",
  "serde",
  "serde_json",
- "serde_qs 0.14.0",
+ "serde_qs 0.15.0",
  "server_fn_macro_default",
  "thiserror 2.0.12",
  "throw_error",
@@ -2938,9 +2975,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341dd1087afe9f3e546c5979a4f0b6d55ac072e1201313f86e7fe364223835ac"
+checksum = "b9d530c872590473016016679c94e3bddf47372941fc924f687ffd11a1778a71"
 dependencies = [
  "const_format",
  "convert_case 0.8.0",
@@ -2953,9 +2990,9 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro_default"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ab934f581482a66da82f2b57b15390ad67c9ab85bd9a6c54bb65060fb1380"
+checksum = "ca7abc92ed696648275ed9ff171131a83d571af11748593dc2e6eb6a4e22a5b9"
 dependencies = [
  "server_fn_macro",
  "syn 2.0.104",

--- a/examples/counter-next/iOS/CounterApp.xcodeproj/project.pbxproj
+++ b/examples/counter-next/iOS/CounterApp.xcodeproj/project.pbxproj
@@ -10,9 +10,11 @@
 		08A5891079278B0627EECC52 /* Shared in Frameworks */ = {isa = PBXBuildFile; productRef = D05E19303943AC146E9AB212 /* Shared */; };
 		0D4D3C5B2AA243A48B9CEE38 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6A6C59672AA736317738B5C /* ContentView.swift */; };
 		0EDCC21106F85DBD04C91356 /* sse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72B940D339BFB9B4DC05041C /* sse.swift */; };
+		4673110F6AD3F8E2A37B0111 /* Serde in Frameworks */ = {isa = PBXBuildFile; productRef = B5D6D2B0E5CFCCBA18D3CE3E /* Serde */; };
 		B6930825270C051C48F86524 /* core.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408B50841C0469CE0D78A7C2 /* core.swift */; };
 		B80467C7DA8DB82760663B44 /* CounterAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D533D9BD281C15290E4016E5 /* CounterAppApp.swift */; };
 		C9DE83DFE3BDDF3357E9DFC6 /* SharedTypes in Frameworks */ = {isa = PBXBuildFile; productRef = 32258924E0AD419BAA621949 /* SharedTypes */; };
+		DAEFD22602D3904B391A4585 /* ViewModel in Frameworks */ = {isa = PBXBuildFile; productRef = 683E4479AA75D6CE41BF49BD /* ViewModel */; };
 		E49A93362F08CF053C69A7F5 /* http.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCEAEA08AFCD101ED86B664C /* http.swift */; };
 /* End PBXBuildFile section */
 
@@ -23,9 +25,11 @@
 		6D984934DC207C1C28EDF6F1 /* SharedTypes */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SharedTypes; path = ../shared_types/generated/swift/SharedTypes; sourceTree = SOURCE_ROOT; };
 		72B940D339BFB9B4DC05041C /* sse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sse.swift; sourceTree = "<group>"; };
 		9D06BFB95E0269CB9E1CD716 /* CounterApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CounterApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B28E9A30C34D6FA90F1FB6DF /* ViewModel */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ViewModel; path = ../shared_types/generated/swift/ViewModel; sourceTree = SOURCE_ROOT; };
 		BCEAEA08AFCD101ED86B664C /* http.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = http.swift; sourceTree = "<group>"; };
 		D533D9BD281C15290E4016E5 /* CounterAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterAppApp.swift; sourceTree = "<group>"; };
 		D6A6C59672AA736317738B5C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		EF9261C9BEE050FA5484A8C7 /* Serde */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Serde; path = ../shared_types/generated/swift/Serde; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -35,6 +39,8 @@
 			files = (
 				08A5891079278B0627EECC52 /* Shared in Frameworks */,
 				C9DE83DFE3BDDF3357E9DFC6 /* SharedTypes in Frameworks */,
+				DAEFD22602D3904B391A4585 /* ViewModel in Frameworks */,
+				4673110F6AD3F8E2A37B0111 /* Serde in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -57,8 +63,10 @@
 		79077CB87B15CD5B056551FE /* Packages */ = {
 			isa = PBXGroup;
 			children = (
+				EF9261C9BEE050FA5484A8C7 /* Serde */,
 				0BC930BE6C51EBF4D7F07A9C /* Shared */,
 				6D984934DC207C1C28EDF6F1 /* SharedTypes */,
+				B28E9A30C34D6FA90F1FB6DF /* ViewModel */,
 			);
 			name = Packages;
 			sourceTree = "<group>";
@@ -98,6 +106,8 @@
 			packageProductDependencies = (
 				D05E19303943AC146E9AB212 /* Shared */,
 				32258924E0AD419BAA621949 /* SharedTypes */,
+				683E4479AA75D6CE41BF49BD /* ViewModel */,
+				B5D6D2B0E5CFCCBA18D3CE3E /* Serde */,
 			);
 			productName = CounterApp;
 			productReference = 9D06BFB95E0269CB9E1CD716 /* CounterApp.app */;
@@ -125,8 +135,10 @@
 			mainGroup = B86E33DC287DA7AC92DD5972;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				1D0047598ACCFDEFDD26D3BE /* XCLocalSwiftPackageReference "../shared_types/generated/swift/Serde" */,
 				D3BF0BCB5F0BABF3D7D00966 /* XCLocalSwiftPackageReference "../shared/Shared" */,
 				C259B15E6BEC83EABD3451C7 /* XCLocalSwiftPackageReference "../shared_types/generated/swift/SharedTypes" */,
+				767221B0DF16AFB369C1F52F /* XCLocalSwiftPackageReference "../shared_types/generated/swift/ViewModel" */,
 			);
 			preferredProjectObjectVersion = 54;
 			projectDirPath = "";
@@ -328,6 +340,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
+		1D0047598ACCFDEFDD26D3BE /* XCLocalSwiftPackageReference "../shared_types/generated/swift/Serde" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../shared_types/generated/swift/Serde;
+		};
+		767221B0DF16AFB369C1F52F /* XCLocalSwiftPackageReference "../shared_types/generated/swift/ViewModel" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../shared_types/generated/swift/ViewModel;
+		};
 		C259B15E6BEC83EABD3451C7 /* XCLocalSwiftPackageReference "../shared_types/generated/swift/SharedTypes" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../shared_types/generated/swift/SharedTypes;
@@ -342,6 +362,14 @@
 		32258924E0AD419BAA621949 /* SharedTypes */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = SharedTypes;
+		};
+		683E4479AA75D6CE41BF49BD /* ViewModel */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ViewModel;
+		};
+		B5D6D2B0E5CFCCBA18D3CE3E /* Serde */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Serde;
 		};
 		D05E19303943AC146E9AB212 /* Shared */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/examples/counter-next/iOS/CounterApp/core.swift
+++ b/examples/counter-next/iOS/CounterApp/core.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Shared
 import SharedTypes
+import ViewModel
 
 fileprivate class EffectHandler: CruxShell, @unchecked Sendable {
     public var handler: ((Data) -> Void)?

--- a/examples/counter-next/iOS/project.yml
+++ b/examples/counter-next/iOS/project.yml
@@ -4,6 +4,10 @@ packages:
     path: ../shared/Shared
   SharedTypes:
     path: ../shared_types/generated/swift/SharedTypes
+  ViewModel:
+    path: ../shared_types/generated/swift/ViewModel
+  Serde:
+    path: ../shared_types/generated/swift/Serde
 options:
   bundleIdPrefix: com.crux.example.counter
 targets:
@@ -15,6 +19,8 @@ targets:
     dependencies:
       - package: Shared
       - package: SharedTypes
+      - package: ViewModel
+      - package: Serde
     info:
       path: CounterApp/Info.plist
       properties:

--- a/examples/counter-next/shared/src/app.rs
+++ b/examples/counter-next/shared/src/app.rs
@@ -35,7 +35,6 @@ impl<T> From<crux_http::Result<crux_http::Response<T>>>
     }
 }
 
-// ANCHOR: model
 #[derive(Default, Serialize)]
 pub struct Model {
     count: Count,
@@ -47,9 +46,9 @@ pub struct Count {
     #[serde(deserialize_with = "ts_milliseconds_option")]
     updated_at: Option<DateTime<Utc>>,
 }
-// ANCHOR_END: model
 
 #[derive(Facet, Serialize, Deserialize, Debug, Clone, Default)]
+#[facet(namespace = "view_model")]
 pub struct ViewModel {
     pub text: String,
     pub confirmed: bool,

--- a/examples/counter-next/shared_types/build.rs
+++ b/examples/counter-next/shared_types/build.rs
@@ -1,21 +1,55 @@
-use crux_core::type_generation::facet::TypeGen;
-use shared::App;
+use crux_core::type_generation::facet::{ExternalPackage, PackageLocation, TypeGen};
+use shared::{App, ViewModel};
 use std::path::PathBuf;
 
 fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed=../shared");
 
-    let mut typegen = TypeGen::new();
+    let mut typegen_app = TypeGen::new();
 
-    typegen.register_app::<App>()?;
+    typegen_app.register_app::<App>()?;
 
     let output_root = PathBuf::from("./generated");
 
-    typegen.swift("SharedTypes", output_root.join("swift"))?;
+    typegen_app.java("com.crux.example.counter.shared", output_root.join("java"))?;
 
-    typegen.java("com.crux.example.counter.shared", output_root.join("java"))?;
+    typegen_app.typescript("shared_types", output_root.join("typescript"))?;
 
-    typegen.typescript("shared_types", output_root.join("typescript"))?;
+    typegen_app.swift(
+        "SharedTypes",
+        output_root.join("swift"),
+        vec![
+            ExternalPackage {
+                for_namespace: "view_model".to_string(),
+                location: PackageLocation::Path("../ViewModel".to_string()),
+                version: None,
+            },
+            ExternalPackage {
+                for_namespace: "Serde".to_string(),
+                location: PackageLocation::Path("../Serde".to_string()),
+                version: None,
+            },
+        ],
+        false,
+        true,
+    )?;
+
+    let mut typegen_viewmodel = TypeGen::new();
+    typegen_viewmodel.register_type::<ViewModel>()?;
+    typegen_viewmodel.swift(
+        "ViewModel",
+        output_root.join("swift"),
+        vec![ExternalPackage {
+            for_namespace: "Serde".to_string(),
+            location: PackageLocation::Path("../Serde".to_string()),
+            version: None,
+        }],
+        false,
+        false,
+    )?;
+
+    let mut typegen_serde = TypeGen::new();
+    typegen_serde.swift("Serde", output_root.join("swift"), vec![], true, false)?;
 
     Ok(())
 }

--- a/examples/counter-next/web-leptos/Cargo.toml
+++ b/examples/counter-next/web-leptos/Cargo.toml
@@ -15,7 +15,7 @@ console_log = "1.0.0"
 futures-util = "0.3.31"
 gloo-net = { version = "0.6.0", features = ["http"] }
 js-sys = "0.3.77"
-leptos = { version = "0.8.2", features = ["csr"] }
+leptos = { version = "0.8.3", features = ["csr"] }
 log = "0.4.27"
 shared = { path = "../shared" }
 wasm-bindgen = "0.2.100"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,8 +11,8 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-cargo_metadata = "0.20.0"
-clap = { version = "4.5.40", features = ["derive"] }
+cargo_metadata = "0.21.0"
+clap = { version = "4.5.41", features = ["derive"] }
 human-repr = "1.1.0"
 ignore = "0.4.23"
 xshell = "0.2.7"

--- a/xtask/src/publish.rs
+++ b/xtask/src/publish.rs
@@ -11,7 +11,7 @@ const CARGO: &str = crate::CARGO;
 
 // in order for publishing
 const PACKAGES: &[&str] = &[
-    "crux_cli",
+    // "crux_cli",
     "crux_macros",
     "crux_core",
     "crux_http",


### PR DESCRIPTION
Minor changes to work with `facet_generate` v0.7.0, which supports emitting namespaces as external SPM packages.
The `counter_next` example emits 4 packages now:
1. `Shared` — the binary for the shared lib
2. `SharedTypes` — most of the generated foreign types
3. `ViewModel` — generated foreign types for the `ViewModel` struct
4. `Serde` — the generated serialization code as a separate package that `SharedTypes` and `ViewModel` both depend on.

Note: it's a bit hack at the moment, but will evolve as we find the rough edges