### PR TITLE
Relax Serialize bound when not using Bridge.

### DIFF
--- a/crux_core/src/bridge/mod.rs
+++ b/crux_core/src/bridge/mod.rs
@@ -74,6 +74,7 @@ where
     pub fn process_event(&self, event: &[u8]) -> Result<Vec<u8>, BridgeError>
     where
         A::Event: for<'a> Deserialize<'a>,
+        A::Effect: crate::core::EffectFFI,
     {
         let options = Self::bincode_options();
 
@@ -104,6 +105,7 @@ where
     // ANCHOR_END: handle_response_sig
     where
         A::Event: for<'a> Deserialize<'a>,
+        A::Effect: crate::core::EffectFFI,
     {
         let options = Self::bincode_options();
 
@@ -122,7 +124,10 @@ where
     /// # Errors
     ///
     /// Returns an error if the view model could not be serialized.
-    pub fn view(&self) -> Result<Vec<u8>, BridgeError> {
+    pub fn view(&self) -> Result<Vec<u8>, BridgeError>
+    where
+        A::ViewModel: Serialize,
+    {
         let options = Self::bincode_options();
 
         let mut return_buffer = vec![];
@@ -182,6 +187,7 @@ where
     pub fn process_event<'de, D, S>(&self, event: D, requests_out: S) -> Result<(), BridgeError>
     where
         for<'a> A::Event: Deserialize<'a>,
+        A::Effect: crate::core::EffectFFI,
         D: ::serde::de::Deserializer<'de> + 'de,
         S: ::serde::ser::Serializer,
     {
@@ -212,6 +218,7 @@ where
     ) -> Result<(), BridgeError>
     where
         for<'a> A::Event: Deserialize<'a>,
+        A::Effect: crate::core::EffectFFI,
         D: ::serde::de::Deserializer<'de>,
         S: ::serde::ser::Serializer,
     {
@@ -231,6 +238,7 @@ where
     ) -> Result<(), BridgeError>
     where
         A::Event: for<'a> Deserialize<'a>,
+        A::Effect: crate::core::EffectFFI,
     {
         let effects = match id {
             None => {
@@ -266,6 +274,7 @@ where
     pub fn view<S>(&self, ser: S) -> Result<(), BridgeError>
     where
         S: ::serde::ser::Serializer,
+        A::ViewModel: Serialize,
     {
         self.core
             .view()

--- a/crux_core/src/bridge/registry.rs
+++ b/crux_core/src/bridge/registry.rs
@@ -6,7 +6,7 @@ use slab::Slab;
 
 use super::{BridgeError, Request};
 use crate::bridge::request_serde::ResolveSerialized;
-use crate::{Effect, ResolveError};
+use crate::{EffectFFI, ResolveError};
 
 #[derive(Facet, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -31,7 +31,7 @@ impl ResolveRegistry {
     // ANCHOR: register
     pub fn register<Eff>(&self, effect: Eff) -> Request<Eff::Ffi>
     where
-        Eff: Effect,
+        Eff: EffectFFI,
     {
         let (effect, resolve) = effect.serialize();
 

--- a/crux_core/src/capability/mod.rs
+++ b/crux_core/src/capability/mod.rs
@@ -373,7 +373,8 @@ pub trait Capability<Ev> {
 /// #         unimplemented!()
 /// #     }
 /// # }
-/// # impl crux_core::Effect for Effect {
+/// # impl crux_core::Effect for Effect {}
+/// # impl crux_core::EffectFFI for Effect {
 /// #     type Ffi = EffectFfi;
 /// #     fn serialize(self) -> (Self::Ffi, crux_core::bridge::ResolveSerialized) {
 /// #         match self {

--- a/crux_core/src/core/effect.rs
+++ b/crux_core/src/core/effect.rs
@@ -2,12 +2,23 @@ use serde::Serialize;
 
 use crate::bridge::ResolveSerialized;
 
-/// Implemented automatically with the Effect macro from `crux_macros`.
-/// This is used by the [`Bridge`](crate::bridge::Bridge) to serialize effects going across the
-/// FFI boundary.
+/// Implemented automatically with the effect macro from `crux_macros`.
+/// This is a marker trait to ensure the macro generated traits are present on the effect type.
+///
+/// You should annotate your type with `#[effect]` to implement this trait.
 // used in docs/internals/bridge.md
 // ANCHOR: effect
-pub trait Effect: Send + 'static {
+pub trait Effect: Send + 'static {}
+// ANCHOR_END: effect
+
+/// Implemented automatically with the effect macro from `crux_macros`.
+/// This is used by the [`Bridge`](crate::bridge::Bridge) to serialize effects going across the
+/// FFI boundary. If you don't need serialization and FFI, use [`Effect`].
+///
+/// You should annotate your type with `#[effect(typegen)]` to implement this trait.
+// used in docs/internals/bridge.md
+// ANCHOR: effect_typegen
+pub trait EffectFFI: Effect {
     /// Ffi is an enum with variants corresponding to the Effect variants
     /// but instead of carrying a `Request<Op>` they carry the `Op` directly
     type Ffi: Serialize;
@@ -20,4 +31,4 @@ pub trait Effect: Send + 'static {
     /// the [`Bridge`](crate::bridge::Bridge)
     fn serialize(self) -> (Self::Ffi, ResolveSerialized);
 }
-// ANCHOR_END: effect
+// ANCHOR_END: effect_typegen

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -4,7 +4,7 @@ mod resolve;
 
 use std::sync::RwLock;
 
-pub use effect::Effect;
+pub use effect::{Effect, EffectFFI};
 pub use request::Request;
 pub use resolve::{RequestHandle, Resolvable, ResolveError};
 

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -164,13 +164,11 @@ pub mod type_generation;
 mod capabilities;
 mod core;
 
-use serde::Serialize;
-
 pub use capabilities::*;
 #[expect(deprecated)]
 pub use capability::{Capability, WithContext};
 pub use command::Command;
-pub use core::{Core, Effect, Request, RequestHandle, Resolvable, ResolveError};
+pub use core::{Core, Effect, EffectFFI, Request, RequestHandle, Resolvable, ResolveError};
 #[cfg(feature = "cli")]
 pub use crux_cli as cli;
 pub use crux_macros as macros;
@@ -186,7 +184,7 @@ pub trait App: Default {
     type Model: Default;
     /// `ViewModel`, typically a `struct` describes the user interface that should be
     /// displayed to the user
-    type ViewModel: Serialize;
+    type ViewModel;
     /// `Capabilities`, usually a `struct`, lists the capabilities used by this application.
     ///
     /// Typically, Capabilities should contain at least an instance of the built-in [`Render`](crate::render::Render) capability.

--- a/crux_core/src/middleware/bridge.rs
+++ b/crux_core/src/middleware/bridge.rs
@@ -4,7 +4,7 @@ use erased_serde::Serialize;
 use serde::Deserialize;
 
 use crate::{
-    Effect,
+    EffectFFI,
     bridge::{BridgeError, EffectId, ResolveRegistry},
 };
 
@@ -42,7 +42,7 @@ impl<Next, Format> Bridge<Next, Format>
 where
     Next: Layer,
     Next::Event: for<'a> Deserialize<'a>,
-    Next::Effect: Effect,
+    Next::Effect: EffectFFI,
     Format: FfiFormat,
     for<'se, 'b> &'se mut Format::Serializer<'b>: serde::Serializer,
     for<'de, 'b> &'de mut Format::Deserializer<'b>: serde::Deserializer<'b>,

--- a/crux_core/src/middleware/mod.rs
+++ b/crux_core/src/middleware/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! Note: In the documentation we refer to the directions in the middleware chain
 //! as "down" - towards the core, and "up" - away from the Core, towards the Shell.
-use crate::{App, Core, Effect, Request, Resolvable, ResolveError, bridge::BridgeError};
+use crate::{App, Core, EffectFFI, Request, Resolvable, ResolveError, bridge::BridgeError};
 
 mod bridge;
 mod effect_conversion;
@@ -133,7 +133,7 @@ pub trait Layer: Send + Sync + Sized {
         effect_callback: impl Fn(Result<Vec<u8>, BridgeError>) + Send + Sync + 'static,
     ) -> Bridge<Self, Format>
     where
-        Self::Effect: Effect,
+        Self::Effect: EffectFFI,
         Self::Event: for<'a> Deserialize<'a>,
         for<'de, 'b> &'de mut Format::Deserializer<'b>: serde::Deserializer<'b>,
         for<'se, 'b> &'se mut Format::Serializer<'b>: serde::Serializer,

--- a/crux_core/tests/json_bridge.rs
+++ b/crux_core/tests/json_bridge.rs
@@ -16,7 +16,7 @@ mod app {
         Get,
     }
 
-    #[effect]
+    #[effect(typegen)]
     pub enum Effect {
         Http(HttpRequest),
         Render(RenderOperation),

--- a/crux_core/tests/middleware.rs
+++ b/crux_core/tests/middleware.rs
@@ -466,7 +466,7 @@ mod tests {
         assert_eq!(RenderOperation, render_operation);
     }
 
-    #[effect]
+    #[effect(typegen)]
     pub enum BridgeEffect {
         Http(HttpRequest),
         Render(RenderOperation),

--- a/crux_core/tests/testing.rs
+++ b/crux_core/tests/testing.rs
@@ -1,10 +1,12 @@
 //! Test for the testing APIs
-#![expect(deprecated)]
-
 use crux_core::testing::AppTester;
 
 mod app {
-    use crux_core::{App, Command, macros::Effect, render::render};
+    use crux_core::{
+        App, Command,
+        render::{RenderOperation, render},
+    };
+    use crux_macros::effect;
     use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -12,10 +14,9 @@ mod app {
         Hello,
     }
 
-    #[derive(Effect)]
-    #[allow(dead_code)]
-    pub struct Capabilities {
-        render: crux_core::render::Render<Event>,
+    #[effect]
+    pub enum Effect {
+        Render(RenderOperation),
     }
 
     #[derive(Default)]
@@ -25,14 +26,14 @@ mod app {
         type Event = Event;
         type Model = String;
         type ViewModel = String;
-        type Capabilities = Capabilities;
+        type Capabilities = ();
         type Effect = Effect;
 
         fn update(
             &self,
             _event: Self::Event,
             _model: &mut Self::Model,
-            _caps: &Self::Capabilities,
+            _caps: &(),
         ) -> Command<Effect, Event> {
             render()
         }

--- a/crux_macros/src/effect/tests.rs
+++ b/crux_macros/src/effect/tests.rs
@@ -29,7 +29,7 @@ fn single_with_typegen() {
 
     let actual = effect_impl(args, input);
 
-    insta::assert_snapshot!(pretty_print(&actual), @r#"
+    insta::assert_snapshot!(pretty_print(&actual), @r##"
     #[derive(Debug)]
     pub enum Effect {
         Render(::crux_core::Request<RenderOperation>),
@@ -39,7 +39,8 @@ fn single_with_typegen() {
     pub enum EffectFfi {
         Render(RenderOperation),
     }
-    impl crux_core::Effect for Effect {
+    impl crux_core::Effect for Effect {}
+    impl crux_core::EffectFFI for Effect {
         type Ffi = EffectFfi;
         fn serialize(self) -> (Self::Ffi, crux_core::bridge::ResolveSerialized) {
             match self {
@@ -86,7 +87,7 @@ fn single_with_typegen() {
             Ok(())
         }
     }
-    "#);
+    "##);
 }
 
 #[test]
@@ -100,7 +101,7 @@ fn single_with_new_name() {
 
     let actual = effect_impl(args, input);
 
-    insta::assert_snapshot!(pretty_print(&actual), @r#"
+    insta::assert_snapshot!(pretty_print(&actual), @r##"
     #[derive(Debug)]
     pub enum MyEffect {
         Render(::crux_core::Request<RenderOperation>),
@@ -110,7 +111,8 @@ fn single_with_new_name() {
     pub enum MyEffectFfi {
         Render(RenderOperation),
     }
-    impl crux_core::Effect for MyEffect {
+    impl crux_core::Effect for MyEffect {}
+    impl crux_core::EffectFFI for MyEffect {
         type Ffi = MyEffectFfi;
         fn serialize(self) -> (Self::Ffi, crux_core::bridge::ResolveSerialized) {
             match self {
@@ -157,7 +159,7 @@ fn single_with_new_name() {
             Ok(())
         }
     }
-    "#);
+    "##);
 }
 
 #[test]
@@ -171,7 +173,7 @@ fn single_with_facet_typegen() {
 
     let actual = effect_impl(args, input);
 
-    insta::assert_snapshot!(pretty_print(&actual), @r#"
+    insta::assert_snapshot!(pretty_print(&actual), @r##"
     #[derive(Debug)]
     pub enum Effect {
         Render(::crux_core::Request<RenderOperation>),
@@ -184,7 +186,8 @@ fn single_with_facet_typegen() {
     pub enum EffectFfi {
         Render(RenderOperation),
     }
-    impl crux_core::Effect for Effect {
+    impl crux_core::Effect for Effect {}
+    impl crux_core::EffectFFI for Effect {
         type Ffi = EffectFfi;
         fn serialize(self) -> (Self::Ffi, crux_core::bridge::ResolveSerialized) {
             match self {
@@ -231,7 +234,7 @@ fn single_with_facet_typegen() {
             Ok(())
         }
     }
-    "#);
+    "##);
 }
 
 #[test]
@@ -245,7 +248,7 @@ fn single_facet_typegen_with_new_name() {
 
     let actual = effect_impl(args, input);
 
-    insta::assert_snapshot!(pretty_print(&actual), @r#"
+    insta::assert_snapshot!(pretty_print(&actual), @r##"
     #[derive(Debug)]
     pub enum MyEffect {
         Render(::crux_core::Request<RenderOperation>),
@@ -258,7 +261,8 @@ fn single_facet_typegen_with_new_name() {
     pub enum MyEffectFfi {
         Render(RenderOperation),
     }
-    impl crux_core::Effect for MyEffect {
+    impl crux_core::Effect for MyEffect {}
+    impl crux_core::EffectFFI for MyEffect {
         type Ffi = MyEffectFfi;
         fn serialize(self) -> (Self::Ffi, crux_core::bridge::ResolveSerialized) {
             match self {
@@ -305,7 +309,7 @@ fn single_facet_typegen_with_new_name() {
             Ok(())
         }
     }
-    "#);
+    "##);
 }
 
 #[test]
@@ -323,19 +327,7 @@ fn single_without_typegen() {
     pub enum Effect {
         Render(::crux_core::Request<RenderOperation>),
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename = "Effect")]
-    pub enum EffectFfi {
-        Render(RenderOperation),
-    }
-    impl crux_core::Effect for Effect {
-        type Ffi = EffectFfi;
-        fn serialize(self) -> (Self::Ffi, crux_core::bridge::ResolveSerialized) {
-            match self {
-                Effect::Render(request) => request.serialize(EffectFfi::Render),
-            }
-        }
-    }
+    impl crux_core::Effect for Effect {}
     impl From<::crux_core::Request<RenderOperation>> for Effect {
         fn from(value: ::crux_core::Request<RenderOperation>) -> Self {
             Self::Render(value)
@@ -379,7 +371,7 @@ fn multiple_with_typegen() {
 
     let actual = effect_impl(args, input);
 
-    insta::assert_snapshot!(pretty_print(&actual), @r#"
+    insta::assert_snapshot!(pretty_print(&actual), @r##"
     #[derive(Debug)]
     pub enum Effect {
         Render(::crux_core::Request<RenderOperation>),
@@ -391,7 +383,8 @@ fn multiple_with_typegen() {
         Render(RenderOperation),
         Http(HttpRequest),
     }
-    impl crux_core::Effect for Effect {
+    impl crux_core::Effect for Effect {}
+    impl crux_core::EffectFFI for Effect {
         type Ffi = EffectFfi;
         fn serialize(self) -> (Self::Ffi, crux_core::bridge::ResolveSerialized) {
             match self {
@@ -467,7 +460,7 @@ fn multiple_with_typegen() {
             Ok(())
         }
     }
-    "#);
+    "##);
 }
 
 #[allow(clippy::too_many_lines)]
@@ -483,7 +476,7 @@ fn multiple_with_facet_typegen() {
 
     let actual = effect_impl(args, input);
 
-    insta::assert_snapshot!(pretty_print(&actual), @r#"
+    insta::assert_snapshot!(pretty_print(&actual), @r##"
     #[derive(Debug)]
     pub enum Effect {
         Render(::crux_core::Request<RenderOperation>),
@@ -498,7 +491,8 @@ fn multiple_with_facet_typegen() {
         Render(RenderOperation),
         Http(HttpRequest),
     }
-    impl crux_core::Effect for Effect {
+    impl crux_core::Effect for Effect {}
+    impl crux_core::EffectFFI for Effect {
         type Ffi = EffectFfi;
         fn serialize(self) -> (Self::Ffi, crux_core::bridge::ResolveSerialized) {
             match self {
@@ -574,7 +568,7 @@ fn multiple_with_facet_typegen() {
             Ok(())
         }
     }
-    "#);
+    "##);
 }
 
 #[test]
@@ -588,27 +582,13 @@ fn multiple_without_typegen() {
 
     let actual = effect_impl(None, input);
 
-    insta::assert_snapshot!(pretty_print(&actual), @r#"
+    insta::assert_snapshot!(pretty_print(&actual), @r##"
     #[derive(Debug)]
     pub enum Effect {
         Render(::crux_core::Request<RenderOperation>),
         Http(::crux_core::Request<HttpRequest>),
     }
-    #[derive(::serde::Serialize, ::serde::Deserialize)]
-    #[serde(rename = "Effect")]
-    pub enum EffectFfi {
-        Render(RenderOperation),
-        Http(HttpRequest),
-    }
-    impl crux_core::Effect for Effect {
-        type Ffi = EffectFfi;
-        fn serialize(self) -> (Self::Ffi, crux_core::bridge::ResolveSerialized) {
-            match self {
-                Effect::Render(request) => request.serialize(EffectFfi::Render),
-                Effect::Http(request) => request.serialize(EffectFfi::Http),
-            }
-        }
-    }
+    impl crux_core::Effect for Effect {}
     impl From<::crux_core::Request<RenderOperation>> for Effect {
         fn from(value: ::crux_core::Request<RenderOperation>) -> Self {
             Self::Render(value)
@@ -663,5 +643,5 @@ fn multiple_without_typegen() {
             }
         }
     }
-    "#);
+    "##);
 }

--- a/crux_macros/src/effect_derive.rs
+++ b/crux_macros/src/effect_derive.rs
@@ -165,7 +165,8 @@ impl ToTokens for EffectStructReceiver {
                 #(#ffi_variants ,)*
             }
 
-            impl ::crux_core::Effect for #effect_name {
+            impl ::crux_core::Effect for #effect_name {}
+            impl ::crux_core::EffectFFI for #effect_name {
                 type Ffi = #ffi_effect_name;
 
                 fn serialize(self) -> (Self::Ffi, ::crux_core::bridge::ResolveSerialized) {
@@ -263,7 +264,8 @@ mod tests {
         pub enum EffectFfi {
             Render(<Render<Event> as ::crux_core::capability::Capability<Event>>::Operation),
         }
-        impl ::crux_core::Effect for Effect {
+        impl ::crux_core::Effect for Effect {}
+        impl ::crux_core::EffectFFI for Effect {
             type Ffi = EffectFfi;
             fn serialize(self) -> (Self::Ffi, ::crux_core::bridge::ResolveSerialized) {
                 match self {
@@ -351,7 +353,8 @@ mod tests {
         pub enum EffectFfi {
             Render(<Render<Event> as ::crux_core::capability::Capability<Event>>::Operation),
         }
-        impl ::crux_core::Effect for Effect {
+        impl ::crux_core::Effect for Effect {}
+        impl ::crux_core::EffectFFI for Effect {
             type Ffi = EffectFfi;
             fn serialize(self) -> (Self::Ffi, ::crux_core::bridge::ResolveSerialized) {
                 match self {
@@ -437,7 +440,7 @@ mod tests {
 
         let actual = quote!(#input);
 
-        insta::assert_snapshot!(pretty_print(&actual), @r#"
+        insta::assert_snapshot!(pretty_print(&actual), @r##"
         #[derive(Debug)]
         pub enum MyEffect {
             Http(
@@ -489,7 +492,8 @@ mod tests {
             Render(<Render<MyEvent> as ::crux_core::capability::Capability<MyEvent>>::Operation),
             Time(<Time<MyEvent> as ::crux_core::capability::Capability<MyEvent>>::Operation),
         }
-        impl ::crux_core::Effect for MyEffect {
+        impl ::crux_core::Effect for MyEffect {}
+        impl ::crux_core::EffectFFI for MyEffect {
             type Ffi = MyEffectFfi;
             fn serialize(self) -> (Self::Ffi, ::crux_core::bridge::ResolveSerialized) {
                 match self {
@@ -725,7 +729,7 @@ mod tests {
                 Self::Time(value)
             }
         }
-        "#);
+        "##);
     }
 
     #[test]

--- a/examples/counter-next/shared/src/ffi.rs
+++ b/examples/counter-next/shared/src/ffi.rs
@@ -13,7 +13,7 @@ pub mod uniffi_ffi {
 
     use crate::{App, middleware::RngMiddleware, sse::SseRequest};
 
-    #[effect]
+    #[effect(facet_typegen)]
     pub enum Effect {
         Render(RenderOperation),
         Http(HttpRequest),

--- a/examples/hello_world/Cargo.lock
+++ b/examples/hello_world/Cargo.lock
@@ -227,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "a79c4acb1fd5fa3d9304be4c76e031c54d2e92d172a393e24b19a14fe8532fe9"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "74875de90daf30eb59609910b84d4d368103aaec4c924824c6799b28f77d6a1d"
 dependencies = [
  "fnv",
  "ident_case",
@@ -251,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "e79f8e61677d5df9167cd85265f8e5f64b215cdea3fb55eebc3e622e44c7a146"
 dependencies = [
  "darling_core",
  "quote",

--- a/examples/hello_world/Cargo.lock
+++ b/examples/hello_world/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -169,7 +169,7 @@ version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -208,9 +208,11 @@ dependencies = [
  "facet",
  "futures",
  "serde",
+ "serde-generate",
+ "serde-reflection",
  "serde_json",
  "slab",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -218,7 +220,7 @@ name = "crux_macros"
 version = "0.7.0-rc2"
 dependencies = [
  "darling",
- "heck",
+ "heck 0.5.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -459,6 +461,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -466,7 +479,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -494,6 +507,15 @@ checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -509,6 +531,30 @@ name = "impls"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
+
+[[package]]
+name = "include_dir"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b56e147e6187d61e9d0f039f10e070d0c0a887e24fe0bb9ca3f29bfde62cab"
+dependencies = [
+ "glob",
+ "include_dir_impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "include_dir_impl"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0c890c85da4bab7bce4204c707396bbd3c6c8a681716a51c8814cfc2b682df"
+dependencies = [
+ "anyhow",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "indexmap"
@@ -585,6 +631,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +691,15 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -627,6 +726,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +754,36 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
+]
 
 [[package]]
 name = "rustc-hash"
@@ -717,6 +852,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-generate"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8309fc8d475cf5884e92a463b3a003d433684335be19c3f739af0451b027254b"
+dependencies = [
+ "heck 0.3.3",
+ "include_dir",
+ "phf",
+ "serde",
+ "serde-reflection",
+ "textwrap 0.13.4",
+]
+
+[[package]]
+name = "serde-reflection"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b6798a64289ff550d8d79847467789a5fd30b42c9c406a4d6dc0bc9b567e55c"
+dependencies = [
+ "once_cell",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -795,6 +955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -816,10 +977,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd05616119e612a8041ef58f2b578906cc2531a6069047ae092cfb86a325d835"
+dependencies = [
+ "smawk",
+ "unicode-width",
 ]
 
 [[package]]
@@ -833,11 +1004,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -873,6 +1064,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "uniffi"
 version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,12 +1105,12 @@ dependencies = [
  "fs-err",
  "glob",
  "goblin",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "once_cell",
  "serde",
  "tempfile",
- "textwrap",
+ "textwrap 0.16.2",
  "toml",
  "uniffi_internal_macros",
  "uniffi_meta",
@@ -987,7 +1190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b925b6421df15cf4bedee27714022cd9626fb4d7eee0923522a608b274ba4371"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "tempfile",
  "uniffi_internal_macros",
@@ -1000,7 +1203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c42649b721df759d9d4692a376b82b62ce3028ec9fc466f4780fb8cdf728996"
 dependencies = [
  "anyhow",
- "textwrap",
+ "textwrap 0.16.2",
  "uniffi_meta",
  "weedle2",
 ]
@@ -1022,6 +1225,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -1188,4 +1397,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]

--- a/examples/hello_world/shared/Cargo.toml
+++ b/examples/hello_world/shared/Cargo.toml
@@ -22,3 +22,6 @@ uniffi = { version = "0.29.3", features = ["build"] }
 
 [target.uniffi-bindgen.dependencies]
 uniffi = { version = "0.29.3", features = ["cli"] }
+
+[features]
+typegen = ["crux_core/typegen"]

--- a/examples/hello_world/shared/src/app.rs
+++ b/examples/hello_world/shared/src/app.rs
@@ -6,7 +6,7 @@ use crux_core::{
 };
 use serde::{Deserialize, Serialize};
 
-#[effect]
+#[effect(typegen)]
 pub enum Effect {
     Render(RenderOperation),
 }


### PR DESCRIPTION
The `Serialize`/`Deserialize` bounds are only really required when working with FFI and type generation, but are currently on the `App` trait and the `Effect` type for all uses.

This moves them up to the two bridge implementations and splits the effect derive macros to allow use without serialization, if no typegen is requested.