### PR TITLE
TypeRegistry and CodeGenerator for typesafe transition between stages

### DIFF
--- a/crux_core/src/capability/mod.rs
+++ b/crux_core/src/capability/mod.rs
@@ -243,15 +243,15 @@ pub trait Operation: Send + 'static {
     #[cfg(feature = "facet_typegen")]
     #[allow(clippy::missing_errors_doc)]
     fn register_types_facet<'a>(
-        generator: &mut crate::type_generation::facet::TypeGen,
-    ) -> crate::type_generation::facet::Result
+        generator: &mut crate::type_generation::facet::TypeRegistry,
+    ) -> &mut crate::type_generation::facet::TypeRegistry
     where
         Self: facet::Facet<'a> + serde::Serialize + for<'de> serde::de::Deserialize<'de>,
         <Self as Operation>::Output: facet::Facet<'a> + for<'de> serde::de::Deserialize<'de>,
     {
-        generator.register_type::<Self>()?;
-        generator.register_type::<Self::Output>()?;
-        Ok(())
+        generator
+            .register_type::<Self>()
+            .register_type::<Self::Output>()
     }
 }
 

--- a/crux_macros/src/effect/macro_impl.rs
+++ b/crux_macros/src/effect/macro_impl.rs
@@ -170,21 +170,20 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
                 let operation = &effect.operation;
 
                 quote! {
-                    #operation::register_types_facet(generator)?;
+                    let generator = #operation::register_types_facet(generator);
                 }
             });
             quote! {
                 #[cfg(feature = "facet_typegen")]
                 impl ::crux_core::type_generation::facet::Export for #enum_ident {
                     fn register_types(
-                        generator: &mut ::crux_core::type_generation::facet::TypeGen
-                    ) -> ::crux_core::type_generation::facet::Result {
+                        generator: &mut ::crux_core::type_generation::facet::TypeRegistry,
+                    ) -> &mut ::crux_core::type_generation::facet::TypeRegistry {
                         use ::crux_core::capability::Operation;
                         #(#effect_gen)*
-                        generator.register_type::<#ffi_enum_ident>()?;
-                        generator.register_type::<::crux_core::bridge::Request<#ffi_enum_ident>>()?;
-
-                        Ok(())
+                        generator
+                            .register_type::<#ffi_enum_ident>()
+                            .register_type::<::crux_core::bridge::Request<#ffi_enum_ident>>()
                     }
                 }
             }

--- a/crux_macros/src/effect/tests.rs
+++ b/crux_macros/src/effect/tests.rs
@@ -222,13 +222,13 @@ fn single_with_facet_typegen() {
     #[cfg(feature = "facet_typegen")]
     impl ::crux_core::type_generation::facet::Export for Effect {
         fn register_types(
-            generator: &mut ::crux_core::type_generation::facet::TypeGen,
-        ) -> ::crux_core::type_generation::facet::Result {
+            generator: &mut ::crux_core::type_generation::facet::TypeRegistry,
+        ) -> &mut ::crux_core::type_generation::facet::TypeRegistry {
             use ::crux_core::capability::Operation;
-            RenderOperation::register_types_facet(generator)?;
-            generator.register_type::<EffectFfi>()?;
-            generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
-            Ok(())
+            let generator = RenderOperation::register_types_facet(generator);
+            generator
+                .register_type::<EffectFfi>()
+                .register_type::<::crux_core::bridge::Request<EffectFfi>>()
         }
     }
     "#);
@@ -296,13 +296,13 @@ fn single_facet_typegen_with_new_name() {
     #[cfg(feature = "facet_typegen")]
     impl ::crux_core::type_generation::facet::Export for MyEffect {
         fn register_types(
-            generator: &mut ::crux_core::type_generation::facet::TypeGen,
-        ) -> ::crux_core::type_generation::facet::Result {
+            generator: &mut ::crux_core::type_generation::facet::TypeRegistry,
+        ) -> &mut ::crux_core::type_generation::facet::TypeRegistry {
             use ::crux_core::capability::Operation;
-            RenderOperation::register_types_facet(generator)?;
-            generator.register_type::<MyEffectFfi>()?;
-            generator.register_type::<::crux_core::bridge::Request<MyEffectFfi>>()?;
-            Ok(())
+            let generator = RenderOperation::register_types_facet(generator);
+            generator
+                .register_type::<MyEffectFfi>()
+                .register_type::<::crux_core::bridge::Request<MyEffectFfi>>()
         }
     }
     "#);
@@ -551,14 +551,14 @@ fn multiple_with_facet_typegen() {
     #[cfg(feature = "facet_typegen")]
     impl ::crux_core::type_generation::facet::Export for Effect {
         fn register_types(
-            generator: &mut ::crux_core::type_generation::facet::TypeGen,
-        ) -> ::crux_core::type_generation::facet::Result {
+            generator: &mut ::crux_core::type_generation::facet::TypeRegistry,
+        ) -> &mut ::crux_core::type_generation::facet::TypeRegistry {
             use ::crux_core::capability::Operation;
-            RenderOperation::register_types_facet(generator)?;
-            HttpRequest::register_types_facet(generator)?;
-            generator.register_type::<EffectFfi>()?;
-            generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
-            Ok(())
+            let generator = RenderOperation::register_types_facet(generator);
+            let generator = HttpRequest::register_types_facet(generator);
+            generator
+                .register_type::<EffectFfi>()
+                .register_type::<::crux_core::bridge::Request<EffectFfi>>()
         }
     }
     "#);


### PR DESCRIPTION
Note: applies to facet-based typegen only.

Replace `TypeGen` (whose `ensure_registry()` would panic if misused) with `TypeRegistry` and `CodeGenerator` to ensure a type safe transition between the 2 stages. Also provides a nicer api:

```rust
TypeRegistry::new()
    .register_app::<App>()
    .register_type::<OtherType>()
    .build()
    .swift(config)?;
```