### PR TITLE
crux_core/command: Keep Command pending if a context is alive

### DIFF
--- a/crux_core/src/command/context.rs
+++ b/crux_core/src/command/context.rs
@@ -21,6 +21,7 @@ pub struct CommandContext<Effect, Event> {
     pub(crate) effects: Sender<Effect>,
     pub(crate) events: Sender<Event>,
     pub(crate) tasks: Sender<Task>,
+    pub(crate) rc: Arc<()>,
 }
 
 // derive(Clone) wants Effect and Event to be clone which is not actually necessary
@@ -30,6 +31,7 @@ impl<Effect, Event> Clone for CommandContext<Effect, Event> {
             effects: self.effects.clone(),
             events: self.events.clone(),
             tasks: self.tasks.clone(),
+            rc: self.rc.clone(),
         }
     }
 }

--- a/crux_core/src/command/mod.rs
+++ b/crux_core/src/command/mod.rs
@@ -316,6 +316,7 @@ where
             effects: effect_sender,
             events: event_sender,
             tasks: spawn_sender,
+            rc: Arc::default(),
         };
 
         let aborted: Arc<AtomicBool> = Arc::default();
@@ -441,7 +442,13 @@ where
     pub fn is_done(&mut self) -> bool {
         self.run_until_settled();
 
-        self.effects.is_empty() && self.events.is_empty() && self.tasks.is_empty()
+        // If a context is alive, the command can still receive effects, events or tasks.
+        let all_context_dropped = Arc::strong_count(&self.context.rc) == 1;
+
+        all_context_dropped
+            && self.effects.is_empty()
+            && self.events.is_empty()
+            && self.tasks.is_empty()
     }
 
     /// Run the effect state machine until it settles and return an iterator over the effects


### PR DESCRIPTION
If a future using a CommandContext is stored (e.g. for caching)
but the associated Command terminates before, crux will panic when
using the context due to the inner channel being disconnected since
the Command (holding the Receiver) was dropped.

A nicer implementation would be to look at the try_recv error and
mark the stream Ready when both reports the Disconnected error,
but this cannot be done today as the Command holds a
CommandContext to be able to provide the `spawn` api.