### PR TITLE
impl Clone for RequestHandle to allow streaming responses from middleware

### DIFF
--- a/crux_core/src/core/request.rs
+++ b/crux_core/src/core/request.rs
@@ -1,4 +1,7 @@
-use std::fmt::{self, Debug};
+use std::{
+    fmt::{self, Debug},
+    sync::Arc,
+};
 
 use crate::{
     capability::Operation,
@@ -54,11 +57,11 @@ where
 
     pub(crate) fn resolves_many_times<F>(operation: Op, resolve: F) -> Self
     where
-        F: Fn(Op::Output) -> Result<(), ()> + Send + 'static,
+        F: Fn(Op::Output) -> Result<(), ()> + Send + Sync + 'static,
     {
         Self {
             operation,
-            handle: RequestHandle::Many(Box::new(resolve)),
+            handle: RequestHandle::Many(Arc::new(resolve)),
         }
     }
 }

--- a/crux_core/src/middleware/effect_handling.rs
+++ b/crux_core/src/middleware/effect_handling.rs
@@ -39,7 +39,7 @@ where
     fn try_process_effect_with(
         &self,
         effect: Effect,
-        resolve_callback: impl FnOnce(
+        resolve_callback: impl Fn(
             RequestHandle<<Self::Op as Operation>::Output>,
             <Self::Op as Operation>::Output,
         ) + Send

--- a/examples/counter-next/shared/src/middleware.rs
+++ b/examples/counter-next/shared/src/middleware.rs
@@ -13,26 +13,33 @@ use crate::capabilities::{RandomNumber, RandomNumberRequest};
 
 #[allow(clippy::type_complexity)]
 pub struct RngMiddleware {
-    jobs_tx: Sender<(RandomNumberRequest, Box<dyn FnOnce(RandomNumber) + Send>)>,
+    jobs_tx: Sender<(
+        RandomNumberRequest,
+        RequestHandle<RandomNumber>,
+        Box<dyn Fn(RequestHandle<RandomNumber>, RandomNumber) + Send>,
+    )>,
 }
 
 impl RngMiddleware {
     pub fn new() -> Self {
-        let (jobs_tx, jobs_rx) =
-            channel::<(RandomNumberRequest, Box<dyn FnOnce(RandomNumber) + Send>)>();
+        let (jobs_tx, jobs_rx) = channel::<(
+            RandomNumberRequest,
+            RequestHandle<RandomNumber>,
+            Box<dyn Fn(RequestHandle<RandomNumber>, RandomNumber) + Send>,
+        )>();
 
         // Persistent background worker
         spawn(move || {
             let mut os_rng = OsRng;
             let mut rng = StdRng::seed_from_u64(os_rng.try_next_u64().expect("could not seed RNG"));
 
-            while let Ok((RandomNumberRequest(from, to), callback)) = jobs_rx.recv() {
+            while let Ok((RandomNumberRequest(from, to), handle, callback)) = jobs_rx.recv() {
                 #[allow(clippy::cast_sign_loss)]
                 let top = (to - from) as usize;
                 #[allow(clippy::cast_possible_wrap)]
                 let out = rng.random_range(0..top) as isize + from;
 
-                callback(RandomNumber(out));
+                callback(handle, RandomNumber(out));
             }
         });
 
@@ -49,16 +56,13 @@ where
     fn try_process_effect_with(
         &self,
         effect: Effect,
-        resolve_callback: impl FnOnce(RequestHandle<RandomNumber>, RandomNumber) + Send + 'static,
+        resolve_callback: impl Fn(RequestHandle<RandomNumber>, RandomNumber) + Send + 'static,
     ) -> Result<(), Effect> {
         let rand_request = effect.try_into()?;
         let (operation, handle): (RandomNumberRequest, _) = rand_request.split();
 
         self.jobs_tx
-            .send((
-                operation,
-                Box::new(move |number| resolve_callback(handle, number)),
-            ))
+            .send((operation, handle, Box::new(resolve_callback)))
             .expect("Job failed to send to worker thread");
 
         Ok(())


### PR DESCRIPTION
Cloning the RequestHandle allows calling the resolve_callback multiple times for streaming responses. Panic on cloning RequestHandle::Once and RequestHandle::Never provides a similar guardrail to FnOnce in the resolve_callback.