### PR TITLE
crux_core/command: Clear spawn_queue when a command is aborted

### DIFF
--- a/crux_core/src/command/executor.rs
+++ b/crux_core/src/command/executor.rs
@@ -148,6 +148,9 @@ impl<Effect, Event> Command<Effect, Event> {
     // Run all tasks until all of them are pending
     pub(crate) fn run_until_settled(&mut self) {
         if self.was_aborted() {
+            // Spawn new tasks to clear the spawn_queue as well
+            self.spawn_new_tasks();
+
             self.tasks.clear();
 
             return;


### PR DESCRIPTION
This allows to drop the pending tasks futures.

This was discovered with the failing doctest of https://github.com/redbadger/crux/pull/423