### PR TITLE
core: add the `unsync` feature

### DIFF
--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -47,6 +47,10 @@ uuid = { version = "1.18.1", features = ["serde", "v4"] }
 
 [features]
 default = ["crux_macros"]
+unsync = []
 cli = ["dep:crux_cli"]
 facet_typegen = ["crux_macros/facet_typegen", "dep:facet_generate", "dep:log"]
 typegen = ["crux_macros/typegen", "dep:serde-generate", "dep:serde-reflection"]
+
+[target.'cfg(target_arch = "wasm32")'.features]
+default = ["crux_macros", "unsync"]

--- a/crux_core/src/bounds.rs
+++ b/crux_core/src/bounds.rs
@@ -1,0 +1,19 @@
+pub use thread_safety::{MaybeSend, MaybeSync};
+
+#[cfg(feature = "unsync")]
+mod thread_safety {
+    pub trait MaybeSend {}
+    pub trait MaybeSync {}
+
+    impl<T> MaybeSend for T {}
+    impl<T> MaybeSync for T {}
+}
+
+#[cfg(not(feature = "unsync"))]
+mod thread_safety {
+    pub trait MaybeSend: Send {}
+    pub trait MaybeSync: Sync {}
+
+    impl<T: Send> MaybeSend for T {}
+    impl<T: Sync> MaybeSync for T {}
+}

--- a/crux_core/src/capabilities/compose.rs
+++ b/crux_core/src/capabilities/compose.rs
@@ -9,7 +9,7 @@
 
 #[expect(deprecated)]
 use crate::{
-    Capability,
+    Capability, MaybeSend, MaybeSync,
     capability::{CapabilityContext, Never},
 };
 use futures::Future;
@@ -155,7 +155,7 @@ impl<Ev> Compose<Ev> {
     pub fn spawn<F, Fut>(&self, effects_task: F)
     where
         F: FnOnce(ComposeContext<Ev>) -> Fut,
-        Fut: Future<Output = ()> + 'static + Send,
+        Fut: Future<Output = ()> + 'static + MaybeSend,
         Ev: 'static,
     {
         let context = self.context.clone();
@@ -179,7 +179,7 @@ impl<Ev> Capability<Ev> for Compose<Ev> {
 
     fn map_event<F, NewEv>(&self, f: F) -> Self::MappedSelf<NewEv>
     where
-        F: Fn(NewEv) -> Ev + Send + Sync + 'static,
+        F: Fn(NewEv) -> Ev + MaybeSend + MaybeSync + 'static,
         Ev: 'static,
         NewEv: 'static,
     {

--- a/crux_core/src/capabilities/render.rs
+++ b/crux_core/src/capabilities/render.rs
@@ -6,7 +6,7 @@ use facet::Facet;
 use serde::{Deserialize, Serialize};
 
 #[expect(deprecated)]
-use crate::{Capability, capability::CapabilityContext};
+use crate::{Capability, MaybeSend, MaybeSync, capability::CapabilityContext};
 use crate::{Command, Request, capability::Operation, command::NotificationBuilder};
 
 /// Use an instance of `Render` to notify the Shell that it should update the user
@@ -70,7 +70,7 @@ impl<Ev> Capability<Ev> for Render<Ev> {
 
     fn map_event<F, NewEv>(&self, f: F) -> Self::MappedSelf<NewEv>
     where
-        F: Fn(NewEv) -> Ev + Send + Sync + 'static,
+        F: Fn(NewEv) -> Ev + MaybeSend + MaybeSync + 'static,
         Ev: 'static,
         NewEv: 'static,
     {
@@ -103,8 +103,8 @@ impl<Ev> Capability<Ev> for Render<Ev> {
 pub fn render_builder<Effect, Event>()
 -> NotificationBuilder<Effect, Event, impl Future<Output = ()>>
 where
-    Effect: From<Request<RenderOperation>> + Send + 'static,
-    Event: Send + 'static,
+    Effect: From<Request<RenderOperation>> + MaybeSend + 'static,
+    Event: MaybeSend + 'static,
 {
     Command::notify_shell(RenderOperation)
 }
@@ -113,8 +113,8 @@ where
 /// Returns a [`Command`].
 pub fn render<Effect, Event>() -> Command<Effect, Event>
 where
-    Effect: From<Request<RenderOperation>> + Send + 'static,
-    Event: Send + 'static,
+    Effect: From<Request<RenderOperation>> + MaybeSend + 'static,
+    Event: MaybeSend + 'static,
 {
     render_builder().into()
 }

--- a/crux_core/src/capability/shell_request.rs
+++ b/crux_core/src/capability/shell_request.rs
@@ -31,13 +31,13 @@ impl ShellRequest<()> {
 // for advancing the state from Pending to Complete
 //
 // FIXME this should be a tri-state enum instead:
-// - ReadyToSend(Box<dyn FnOnce() + Send + 'static>)
+// - ReadyToSend(Box<dyn super::SendRequest>)
 // - Pending(Waker)
 // - Complete(T)
 struct SharedState<T> {
     // the effect's output
     result: Option<T>,
-    send_request: Option<Box<dyn FnOnce() + Send + 'static>>,
+    send_request: Option<Box<dyn super::SendRequest>>,
     waker: Option<Waker>,
 }
 

--- a/crux_core/src/capability/shell_stream.rs
+++ b/crux_core/src/capability/shell_stream.rs
@@ -15,7 +15,7 @@ pub struct ShellStream<T> {
 struct SharedState<T> {
     receiver: Receiver<T>,
     waker: Option<Waker>,
-    send_request: Option<Box<dyn FnOnce() + Send + 'static>>,
+    send_request: Option<Box<dyn super::SendRequest>>,
 }
 
 impl<T> Stream for ShellStream<T> {

--- a/crux_core/src/command/executor.rs
+++ b/crux_core/src/command/executor.rs
@@ -7,13 +7,19 @@ use std::task::{Context, Poll, Wake, Waker};
 
 use crossbeam_channel::{Receiver, Sender};
 
-use futures::future::BoxFuture;
+use futures::future;
 
 use std::sync::atomic::AtomicBool;
 
 use futures::task::AtomicWaker;
 
 use std::sync::Arc;
+
+#[cfg(not(feature = "unsync"))]
+pub type BoxFuture<'a, T> = future::BoxFuture<'a, T>;
+
+#[cfg(feature = "unsync")]
+pub type BoxFuture<'a, T> = future::LocalBoxFuture<'a, T>;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct TaskId(pub(crate) usize);

--- a/crux_core/src/command/stream.rs
+++ b/crux_core/src/command/stream.rs
@@ -12,6 +12,7 @@ use crossbeam_channel::Sender;
 use thiserror::Error;
 
 use super::Command;
+use crate::MaybeSend;
 
 /// An item emitted from a Command when used as a Stream.
 #[derive(Debug)]
@@ -22,8 +23,8 @@ pub enum CommandOutput<Effect, Event> {
 
 impl<Effect, Event> Stream for Command<Effect, Event>
 where
-    Effect: Unpin + Send + 'static,
-    Event: Unpin + Send + 'static,
+    Effect: Unpin + MaybeSend + 'static,
+    Event: Unpin + MaybeSend + 'static,
 {
     type Item = CommandOutput<Effect, Event>;
 
@@ -113,7 +114,7 @@ pub(crate) trait CommandStreamExt<Effect, Event>:
     /// effects and events - like Crux does.
     fn host(self, effects: Sender<Effect>, events: Sender<Event>) -> impl Future
     where
-        Self: Send + Sized,
+        Self: MaybeSend + Sized,
     {
         self.map(Ok).forward(CommandSink::new(effects, events))
     }

--- a/crux_core/src/command/tests/capability_api.rs
+++ b/crux_core/src/command/tests/capability_api.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::super::Command;
 use crate::{
-    Request,
+    MaybeSend, Request,
     capability::Operation,
     command::builder::{RequestBuilder, StreamBuilder},
 };
@@ -50,8 +50,8 @@ struct Capability;
 // FIXME: can the return types be made less verbose...?
 impl Capability
 where
-    Effect: Send + 'static,
-    Event: Send + 'static,
+    Effect: MaybeSend + 'static,
+    Event: MaybeSend + 'static,
 {
     fn request(
         number: usize,

--- a/crux_core/src/command/tests/integration.rs
+++ b/crux_core/src/command/tests/integration.rs
@@ -1,11 +1,11 @@
 use http::Http;
 use serde::{Deserialize, Serialize};
 
-use crate::{Command, Request};
+use crate::{Command, MaybeSend, Request};
 
 // The future version of the app trait
 pub trait App: Default {
-    type Event: Send + 'static;
+    type Event: MaybeSend + 'static;
     type Model: Default;
     type ViewModel: Serialize;
     type Effect;
@@ -25,7 +25,7 @@ mod http {
 
     use serde::{Deserialize, Serialize};
 
-    use crate::{Command, capability::Operation, command::builder::RequestBuilder};
+    use crate::{Command, MaybeSend, capability::Operation, command::builder::RequestBuilder};
 
     pub struct Http;
 
@@ -51,8 +51,8 @@ mod http {
             url: impl Into<String>,
         ) -> RequestBuilder<Effect, Event, impl Future<Output = Response>>
         where
-            Effect: From<crate::Request<Request>> + Send + 'static,
-            Event: Send + 'static,
+            Effect: From<crate::Request<Request>> + MaybeSend + 'static,
+            Event: MaybeSend + 'static,
         {
             let request = Request {
                 method: "GET".to_string(),
@@ -68,8 +68,8 @@ mod http {
             body: impl Into<String>,
         ) -> RequestBuilder<Effect, Event, impl Future<Output = Response>>
         where
-            Effect: From<crate::Request<Request>> + Send + 'static,
-            Event: Send + 'static,
+            Effect: From<crate::Request<Request>> + MaybeSend + 'static,
+            Event: MaybeSend + 'static,
         {
             let body = body.into();
             let request = Request {

--- a/crux_core/src/core/effect.rs
+++ b/crux_core/src/core/effect.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::bridge::ResolveSerialized;
+use crate::{MaybeSend, bridge::ResolveSerialized};
 
 /// Implemented automatically with the effect macro from `crux_macros`.
 /// This is a marker trait to ensure the macro generated traits are present on the effect type.
@@ -8,7 +8,7 @@ use crate::bridge::ResolveSerialized;
 /// You should annotate your type with `#[effect]` to implement this trait.
 // used in docs/internals/bridge.md
 // ANCHOR: effect
-pub trait Effect: Send + 'static {}
+pub trait Effect: MaybeSend + 'static {}
 // ANCHOR_END: effect
 
 /// Implemented automatically with the effect macro from `crux_macros`.

--- a/crux_core/src/core/request.rs
+++ b/crux_core/src/core/request.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Debug};
 
 use crate::{
+    MaybeSend,
     capability::Operation,
     core::resolve::{RequestHandle, Resolvable, ResolveError},
 };
@@ -44,7 +45,7 @@ where
 
     pub(crate) fn resolves_once<F>(operation: Op, resolve: F) -> Self
     where
-        F: FnOnce(Op::Output) + Send + 'static,
+        F: FnOnce(Op::Output) + MaybeSend + 'static,
     {
         Self {
             operation,
@@ -54,7 +55,7 @@ where
 
     pub(crate) fn resolves_many_times<F>(operation: Op, resolve: F) -> Self
     where
-        F: Fn(Op::Output) -> Result<(), ()> + Send + 'static,
+        F: Fn(Op::Output) -> Result<(), ()> + MaybeSend + 'static,
     {
         Self {
             operation,

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -161,16 +161,19 @@ pub mod testing;
 #[cfg(any(feature = "typegen", feature = "facet_typegen"))]
 pub mod type_generation;
 
+mod bounds;
 mod capabilities;
 mod core;
 
+pub use bounds::{MaybeSend, MaybeSync};
 pub use capabilities::*;
 #[expect(deprecated)]
 pub use capability::{Capability, WithContext};
-pub use command::Command;
+pub use command::{BoxFuture, Command};
 pub use core::{Core, Effect, EffectFFI, Request, RequestHandle, Resolvable, ResolveError};
 #[cfg(feature = "cli")]
 pub use crux_cli as cli;
+#[cfg(feature = "crux_macros")]
 pub use crux_macros as macros;
 #[cfg(feature = "typegen")]
 pub use type_generation::serde as typegen;
@@ -179,7 +182,7 @@ pub use type_generation::serde as typegen;
 /// as the type argument to [`Core`] or [`Bridge`](crate::bridge::Bridge).
 pub trait App: Default {
     /// `Event`, typically an `enum`, defines the actions that can be taken to update the application state.
-    type Event: Unpin + Send + 'static;
+    type Event: Unpin + MaybeSend + 'static;
     /// `Model`, typically a `struct` defines the internal state of the application
     type Model: Default;
     /// `ViewModel`, typically a `struct` describes the user interface that should be

--- a/crux_core/src/middleware/effect_conversion.rs
+++ b/crux_core/src/middleware/effect_conversion.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::{Resolvable, ResolveError};
+use crate::{MaybeSend, MaybeSync, Resolvable, ResolveError};
 
 use super::Layer;
 
@@ -31,7 +31,7 @@ where
 
     fn map_effects(effects: Vec<Next::Effect>) -> Vec<Effect>
     where
-        Effect: From<Next::Effect> + Send + 'static,
+        Effect: From<Next::Effect> + MaybeSend + 'static,
     {
         effects.into_iter().map(From::from).collect()
     }
@@ -40,7 +40,7 @@ where
 impl<Next, Effect> Layer for MapEffectLayer<Next, Effect>
 where
     Next: Layer,
-    Effect: From<Next::Effect> + Send + 'static,
+    Effect: From<Next::Effect> + MaybeSend + 'static,
 {
     type Event = Next::Event;
     type Effect = Effect;
@@ -49,7 +49,7 @@ where
 
     fn update<F>(&self, event: Self::Event, effect_callback: F) -> Vec<Self::Effect>
     where
-        F: Fn(Vec<Self::Effect>) + Sync + Send + 'static,
+        F: Fn(Vec<Self::Effect>) + MaybeSync + MaybeSend + 'static,
     {
         Self::map_effects(self.next.update(event, move |effects: Vec<Next::Effect>| {
             effect_callback(Self::map_effects(effects));
@@ -63,7 +63,7 @@ where
         effect_callback: F,
     ) -> Result<Vec<Self::Effect>, ResolveError>
     where
-        F: Fn(Vec<Self::Effect>) + Sync + Send + 'static,
+        F: Fn(Vec<Self::Effect>) + MaybeSync + MaybeSend + 'static,
     {
         Ok(Self::map_effects(self.next.resolve(
             request,
@@ -78,7 +78,7 @@ where
 
     fn process_tasks<F>(&self, effect_callback: F) -> Vec<Self::Effect>
     where
-        F: Fn(Vec<Self::Effect>) + Sync + Send + 'static,
+        F: Fn(Vec<Self::Effect>) + MaybeSync + MaybeSend + 'static,
     {
         Self::map_effects(
             self.next

--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -5,7 +5,7 @@ use std::{collections::VecDeque, sync::Arc};
 #[expect(deprecated)]
 use crate::WithContext;
 use crate::{
-    Command, Request, Resolvable,
+    Command, MaybeSend, Request, Resolvable,
     capability::{
         CommandSpawner, Operation, ProtoContext, QueuingExecutor, channel::Receiver,
         executor_and_spawner,
@@ -275,8 +275,8 @@ impl<Ef, Ev> Update<Ef, Ev> {
 
 impl<Effect, Event> Command<Effect, Event>
 where
-    Effect: Send + 'static,
-    Event: Send + 'static,
+    Effect: MaybeSend + 'static,
+    Event: MaybeSend + 'static,
 {
     /// Assert that the Command contains _exactly_ one effect and zero events,
     /// and return the effect

--- a/crux_core/tests/capability_orchestration.rs
+++ b/crux_core/tests/capability_orchestration.rs
@@ -66,6 +66,7 @@ mod app {
 
 pub mod capabilities {
     pub mod one {
+        use crux_core::MaybeSend;
         #[expect(deprecated)]
         use crux_core::capability::CapabilityContext;
         use crux_core::capability::Operation;
@@ -106,7 +107,7 @@ pub mod capabilities {
 
             pub fn one<F>(&self, number: usize, event: F)
             where
-                F: FnOnce(usize) -> E + Send + 'static,
+                F: FnOnce(usize) -> E + MaybeSend + 'static,
                 E: 'static,
             {
                 let this = Clone::clone(self);
@@ -132,6 +133,7 @@ pub mod capabilities {
     }
 
     pub mod two {
+        use crux_core::MaybeSend;
         #[expect(deprecated)]
         use crux_core::capability::CapabilityContext;
         use crux_core::capability::Operation;
@@ -172,7 +174,7 @@ pub mod capabilities {
 
             pub fn two<F>(&self, number: usize, event: F)
             where
-                F: FnOnce(usize) -> E + Send + 'static,
+                F: FnOnce(usize) -> E + MaybeSend + 'static,
                 E: 'static,
             {
                 let this = Clone::clone(self);

--- a/crux_core/tests/capability_runtime.rs
+++ b/crux_core/tests/capability_runtime.rs
@@ -1,5 +1,6 @@
 mod capability {
     use async_channel::Sender;
+    use crux_core::MaybeSend;
     #[expect(deprecated)]
     use crux_core::capability::CapabilityContext;
     use crux_core::capability::Operation;
@@ -135,7 +136,7 @@ mod capability {
 
         pub fn fetch_tree<F>(&self, id: usize, ev: F)
         where
-            F: FnOnce(Vec<usize>) -> Ev + Send + 'static,
+            F: FnOnce(Vec<usize>) -> Ev + MaybeSend + 'static,
         {
             let (results_tx, results_rx) = async_channel::unbounded::<usize>();
             let tasks_tx = self.tasks_tx.clone();

--- a/crux_core/tests/middleware.rs
+++ b/crux_core/tests/middleware.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "unsync"))]
 mod app {
     use crux_core::{App, Command, capability::Operation, macros::effect, render::render};
     use crux_http::command::Http;
@@ -142,11 +143,14 @@ mod app {
     }
 }
 
+#[cfg(not(feature = "unsync"))]
 mod middleware {
     use std::thread::spawn;
 
     use crossbeam_channel::Receiver;
-    use crux_core::{Request, RequestHandle, capability::Operation, middleware::EffectMiddleware};
+    use crux_core::{
+        MaybeSend, Request, RequestHandle, capability::Operation, middleware::EffectMiddleware,
+    };
     use crux_http::protocol::{HttpRequest, HttpResponse, HttpResult};
 
     use crate::app::{RandomNumber, RandomNumberRequest};
@@ -199,7 +203,7 @@ mod middleware {
             &self,
             effect: Effect,
             mut resolve_callback: impl FnMut(&mut RequestHandle<RandomNumber>, RandomNumber)
-            + Send
+            + MaybeSend
             + 'static,
         ) -> Result<(), Effect> {
             let rand_request = effect.try_into()?;
@@ -230,7 +234,7 @@ mod middleware {
             mut resolve_callback: impl FnMut(
                 &mut RequestHandle<<Self::Op as Operation>::Output>,
                 <Self::Op as Operation>::Output,
-            ) + Send
+            ) + MaybeSend
             + 'static,
         ) -> Result<(), Effect> {
             let http_request = effect.try_into()?;
@@ -273,7 +277,7 @@ mod middleware {
             mut resolve_callback: impl FnMut(
                 &mut RequestHandle<<Self::Op as Operation>::Output>,
                 <Self::Op as Operation>::Output,
-            ) + Send
+            ) + MaybeSend
             + 'static,
         ) -> Result<(), Effect> {
             let http_request = effect.try_into()?;
@@ -302,6 +306,7 @@ mod middleware {
     }
 }
 
+#[cfg(not(feature = "unsync"))]
 mod tests {
     use std::{thread::sleep, time::Duration};
 

--- a/crux_http/src/client.rs
+++ b/crux_http/src/client.rs
@@ -14,7 +14,7 @@ use http_types::{Method, Url};
 /// # Examples
 ///
 /// ```no_run
-/// use futures_util::future::BoxFuture;
+/// use crux_core::BoxFuture;
 /// use crux_http::middleware::{Next, Middleware};
 /// use crux_http::{client::Client, Request, RequestBuilder, ResponseAsync, Result};
 /// use std::time;
@@ -34,7 +34,7 @@ use http_types::{Method, Url};
 /// ```
 pub struct Client {
     config: Config,
-    effect_sender: Arc<dyn EffectSender + Send + Sync>,
+    effect_sender: Arc<dyn EffectSender>,
     /// Holds the middleware stack.
     ///
     /// Note(Fishrock123): We do actually want this structure.
@@ -71,7 +71,7 @@ impl fmt::Debug for Client {
 impl Client {
     pub(crate) fn new<Sender>(sender: Sender) -> Self
     where
-        Sender: EffectSender + Send + Sync + 'static,
+        Sender: EffectSender + 'static,
     {
         Self {
             config: Config::default(),

--- a/crux_http/src/command.rs
+++ b/crux_http/src/command.rs
@@ -18,7 +18,7 @@
 
 use std::{fmt, future::Future, marker::PhantomData};
 
-use crux_core::{Command, command};
+use crux_core::{Command, MaybeSend, command};
 use http_types::{
     Body, Method, Mime, Url,
     convert::DeserializeOwned,
@@ -40,8 +40,8 @@ pub struct Http<Effect, Event> {
 
 impl<Effect, Event> Http<Effect, Event>
 where
-    Effect: Send + From<crux_core::Request<HttpRequest>> + 'static,
-    Event: Send + 'static,
+    Effect: MaybeSend + From<crux_core::Request<HttpRequest>> + 'static,
+    Event: MaybeSend + 'static,
 {
     /// Instruct the Shell to perform a HTTP GET request to the provided `url`.
     ///
@@ -328,12 +328,12 @@ pub struct RequestBuilder<Effect, Event, ExpectBody = Vec<u8>> {
     req: Option<Request>,
     effect: PhantomData<Effect>,
     event: PhantomData<fn() -> Event>,
-    expectation: Box<dyn ResponseExpectation<Body = ExpectBody> + Send>,
+    expectation: Box<dyn ResponseExpectation<Body = ExpectBody>>,
 }
 
 impl<Effect, Event> RequestBuilder<Effect, Event, Vec<u8>>
 where
-    Effect: Send + From<crux_core::Request<HttpRequest>> + 'static,
+    Effect: MaybeSend + From<crux_core::Request<HttpRequest>> + 'static,
     Event: 'static,
 {
     pub(crate) fn new(method: Method, url: Url) -> Self {
@@ -348,8 +348,8 @@ where
 
 impl<Effect, Event, ExpectBody> RequestBuilder<Effect, Event, ExpectBody>
 where
-    Effect: Send + From<crux_core::Request<HttpRequest>> + 'static,
-    Event: Send + 'static,
+    Effect: MaybeSend + From<crux_core::Request<HttpRequest>> + 'static,
+    Event: MaybeSend + 'static,
     ExpectBody: 'static,
 {
     /// Sets a header on the request.

--- a/crux_http/src/expect.rs
+++ b/crux_http/src/expect.rs
@@ -1,10 +1,10 @@
 use std::marker::PhantomData;
 
+use crate::{Response, Result};
+use crux_core::MaybeSend;
 use http_types::convert::DeserializeOwned;
 
-use crate::{Response, Result};
-
-pub trait ResponseExpectation {
+pub trait ResponseExpectation: MaybeSend {
     type Body;
 
     fn decode(&self, resp: crate::Response<Vec<u8>>) -> Result<Response<Self::Body>>;

--- a/crux_http/src/lib.rs
+++ b/crux_http/src/lib.rs
@@ -35,6 +35,7 @@ pub use self::{
 };
 
 use client::Client;
+use crux_core::{MaybeSend, MaybeSync};
 
 pub type Result<T> = std::result::Result<T, HttpError>;
 
@@ -57,9 +58,9 @@ impl<Ev> crux_core::Capability<Ev> for Http<Ev> {
 
     fn map_event<F, NewEv>(&self, f: F) -> Self::MappedSelf<NewEv>
     where
-        F: Fn(NewEv) -> Ev + Send + Sync + 'static,
+        F: Fn(NewEv) -> Ev + MaybeSend + MaybeSync + 'static,
         Ev: 'static,
-        NewEv: 'static + Send,
+        NewEv: 'static + MaybeSend,
     {
         Http::new(self.context.map_event(f))
     }

--- a/crux_http/src/request.rs
+++ b/crux_http/src/request.rs
@@ -6,6 +6,7 @@ use http_types::{
 
 use serde::Serialize;
 
+use crux_core::{MaybeSend, MaybeSync};
 use std::fmt;
 use std::ops::Index;
 use std::sync::Arc;
@@ -187,7 +188,7 @@ impl Request {
 
     /// Get a request extension value.
     #[must_use]
-    pub fn ext<T: Send + Sync + 'static>(&self) -> Option<&T> {
+    pub fn ext<T: MaybeSend + MaybeSync + 'static>(&self) -> Option<&T> {
         self.req.ext().get()
     }
 

--- a/crux_http/src/response/response_async.rs
+++ b/crux_http/src/response/response_async.rs
@@ -6,13 +6,13 @@ use http_types::{
 use futures_util::io::AsyncRead;
 use serde::de::DeserializeOwned;
 
+use super::decode::decode_body;
+use crux_core::{MaybeSend, MaybeSync};
 use std::fmt;
 use std::io;
 use std::ops::Index;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-
-use super::decode::decode_body;
 
 pin_project_lite::pin_project! {
     /// An HTTP response that exposes async methods. This is to support async
@@ -125,7 +125,7 @@ impl ResponseAsync {
 
     /// Get a response scoped extension value.
     #[must_use]
-    pub fn ext<T: Send + Sync + 'static>(&self) -> Option<&T> {
+    pub fn ext<T: MaybeSend + MaybeSync + 'static>(&self) -> Option<&T> {
         self.res.ext().get()
     }
 

--- a/crux_kv/src/command.rs
+++ b/crux_kv/src/command.rs
@@ -2,7 +2,7 @@
 
 use std::{future::Future, marker::PhantomData};
 
-use crux_core::{Command, Request, command::RequestBuilder};
+use crux_core::{Command, MaybeSend, Request, command::RequestBuilder};
 
 use crate::{KeyValueOperation, error::KeyValueError};
 
@@ -18,8 +18,8 @@ type ListResult = Result<(Vec<String>, u64), KeyValueError>;
 
 impl<Effect, Event> KeyValue<Effect, Event>
 where
-    Effect: Send + From<Request<KeyValueOperation>> + 'static,
-    Event: Send + 'static,
+    Effect: MaybeSend + From<Request<KeyValueOperation>> + 'static,
+    Event: MaybeSend + 'static,
 {
     /// Read a value under `key`
     pub fn get(

--- a/crux_kv/src/lib.rs
+++ b/crux_kv/src/lib.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 #[expect(deprecated)]
 use crux_core::capability::CapabilityContext;
 use crux_core::capability::Operation;
-
+use crux_core::{MaybeSend, MaybeSync};
 use error::KeyValueError;
 use value::Value;
 
@@ -155,9 +155,9 @@ impl<Ev> crux_core::Capability<Ev> for KeyValue<Ev> {
 
     fn map_event<F, NewEv>(&self, f: F) -> Self::MappedSelf<NewEv>
     where
-        F: Fn(NewEv) -> Ev + Send + Sync + 'static,
+        F: Fn(NewEv) -> Ev + MaybeSend + MaybeSync + 'static,
         Ev: 'static,
-        NewEv: 'static + Send,
+        NewEv: 'static + MaybeSend,
     {
         KeyValue::new(self.context.map_event(f))
     }
@@ -186,7 +186,7 @@ where
     /// `KeyValueResult::Get { value: Vec<u8> }` as payload
     pub fn get<F>(&self, key: String, make_event: F)
     where
-        F: FnOnce(Result<Option<Vec<u8>>, KeyValueError>) -> Ev + Send + Sync + 'static,
+        F: FnOnce(Result<Option<Vec<u8>>, KeyValueError>) -> Ev + MaybeSend + MaybeSync + 'static,
     {
         self.context.spawn({
             let context = self.context.clone();
@@ -213,7 +213,7 @@ where
     /// Will dispatch the event with a `KeyValueResult::Set { previous: Vec<u8> }` as payload
     pub fn set<F>(&self, key: String, value: Vec<u8>, make_event: F)
     where
-        F: FnOnce(Result<Option<Vec<u8>>, KeyValueError>) -> Ev + Send + Sync + 'static,
+        F: FnOnce(Result<Option<Vec<u8>>, KeyValueError>) -> Ev + MaybeSend + MaybeSync + 'static,
     {
         self.context.spawn({
             let context = self.context.clone();
@@ -242,7 +242,7 @@ where
     /// `KeyValueResult::Delete { previous: Vec<u8> }` as payload
     pub fn delete<F>(&self, key: String, make_event: F)
     where
-        F: FnOnce(Result<Option<Vec<u8>>, KeyValueError>) -> Ev + Send + Sync + 'static,
+        F: FnOnce(Result<Option<Vec<u8>>, KeyValueError>) -> Ev + MaybeSend + MaybeSync + 'static,
     {
         self.context.spawn({
             let context = self.context.clone();
@@ -267,7 +267,7 @@ where
     /// `KeyValueResult::Exists { is_present: bool }` as payload
     pub fn exists<F>(&self, key: String, make_event: F)
     where
-        F: FnOnce(Result<bool, KeyValueError>) -> Ev + Send + Sync + 'static,
+        F: FnOnce(Result<bool, KeyValueError>) -> Ev + MaybeSend + MaybeSync + 'static,
     {
         self.context.spawn({
             let context = self.context.clone();
@@ -302,7 +302,10 @@ where
     /// (if there are more keys to list, the cursor will be non-zero, otherwise it will be zero)
     pub fn list_keys<F>(&self, prefix: String, cursor: u64, make_event: F)
     where
-        F: FnOnce(Result<(Vec<String>, u64), KeyValueError>) -> Ev + Send + Sync + 'static,
+        F: FnOnce(Result<(Vec<String>, u64), KeyValueError>) -> Ev
+            + MaybeSend
+            + MaybeSync
+            + 'static,
     {
         self.context.spawn({
             let context = self.context.clone();

--- a/crux_macros/src/capability.rs
+++ b/crux_macros/src/capability.rs
@@ -38,9 +38,9 @@ impl ToTokens for CapabilityStructReceiver {
 
             fn map_event<F, NewEv>(&self, f: F) -> Self::MappedSelf<NewEv>
             where
-                F: Fn(NewEv) -> Ev + Send + Sync + 'static,
+                F: Fn(NewEv) -> Ev + crux_core::MaybeSend + crux_core::MaybeSync + 'static,
                 Ev: 'static,
-                NewEv: 'static + Send,
+                NewEv: 'static + crux_core::MaybeSend,
             {
               #name::new(self.context.map_event(f))
             }
@@ -115,9 +115,9 @@ mod tests {
             type MappedSelf<MappedEv> = Render<MappedEv>;
             fn map_event<F, NewEv>(&self, f: F) -> Self::MappedSelf<NewEv>
             where
-                F: Fn(NewEv) -> Ev + Send + Sync + 'static,
+                F: Fn(NewEv) -> Ev + crux_core::MaybeSend + crux_core::MaybeSync + 'static,
                 Ev: 'static,
-                NewEv: 'static + Send,
+                NewEv: 'static + crux_core::MaybeSend,
             {
                 Render::new(self.context.map_event(f))
             }

--- a/crux_platform/src/command.rs
+++ b/crux_platform/src/command.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, marker::PhantomData};
 
-use crux_core::{Command, Request, command::RequestBuilder};
+use crux_core::{Command, MaybeSend, Request, command::RequestBuilder};
 
 use crate::{PlatformRequest, PlatformResponse};
 
@@ -11,8 +11,8 @@ pub struct Platform<Effect, Event> {
 
 impl<Effect, Event> Platform<Effect, Event>
 where
-    Effect: From<Request<PlatformRequest>> + Send + 'static,
-    Event: Send + 'static,
+    Effect: From<Request<PlatformRequest>> + MaybeSend + 'static,
+    Event: MaybeSend + 'static,
 {
     /// Get the platform of the shell
     #[must_use]

--- a/crux_platform/src/lib.rs
+++ b/crux_platform/src/lib.rs
@@ -8,6 +8,7 @@ use crux_core::capability::CapabilityContext;
 
 use crux_core::capability::Operation;
 use crux_core::macros::Capability;
+use crux_core::{MaybeSend, MaybeSync};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -43,7 +44,7 @@ where
 
     pub fn get<F>(&self, callback: F)
     where
-        F: FnOnce(PlatformResponse) -> Ev + Send + Sync + 'static,
+        F: FnOnce(PlatformResponse) -> Ev + MaybeSend + MaybeSync + 'static,
     {
         self.context.spawn({
             let context = self.context.clone();

--- a/crux_time/src/command.rs
+++ b/crux_time/src/command.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use crux_core::{Command, Request, command::RequestBuilder};
+use crux_core::{Command, MaybeSend, Request, command::RequestBuilder};
 use facet::Facet;
 use futures::{
     FutureExt,
@@ -39,8 +39,8 @@ pub struct Time<Effect, Event> {
 
 impl<Effect, Event> Time<Effect, Event>
 where
-    Effect: Send + From<Request<TimeRequest>> + 'static,
-    Event: Send + 'static,
+    Effect: MaybeSend + From<Request<TimeRequest>> + 'static,
+    Event: MaybeSend + 'static,
 {
     /// Ask for the current wall-clock time.
     ///

--- a/crux_time/src/lib.rs
+++ b/crux_time/src/lib.rs
@@ -22,7 +22,7 @@ use std::{
 
 #[expect(deprecated)]
 use crux_core::capability::CapabilityContext;
-
+use crux_core::{MaybeSend, MaybeSync};
 pub use protocol::{TimeRequest, TimeResponse, TimerId, duration::Duration, instant::Instant};
 
 fn get_timer_id() -> TimerId {
@@ -47,9 +47,9 @@ impl<Ev> crux_core::Capability<Ev> for Time<Ev> {
 
     fn map_event<F, NewEv>(&self, f: F) -> Self::MappedSelf<NewEv>
     where
-        F: Fn(NewEv) -> Ev + Send + Sync + 'static,
+        F: Fn(NewEv) -> Ev + MaybeSend + MaybeSync + 'static,
         Ev: 'static,
-        NewEv: 'static + Send,
+        NewEv: 'static + MaybeSend,
     {
         Time::new(self.context.map_event(f))
     }
@@ -78,7 +78,7 @@ where
     /// wrapped in the event produced by the `callback`.
     pub fn now<F>(&self, callback: F)
     where
-        F: FnOnce(TimeResponse) -> Ev + Send + Sync + 'static,
+        F: FnOnce(TimeResponse) -> Ev + MaybeSend + MaybeSync + 'static,
     {
         self.context.spawn({
             let context = self.context.clone();
@@ -100,7 +100,7 @@ where
     /// [`SystemTime`] has arrived.
     pub fn notify_at<F>(&self, system_time: SystemTime, callback: F) -> TimerId
     where
-        F: FnOnce(TimeResponse) -> Ev + Send + Sync + 'static,
+        F: FnOnce(TimeResponse) -> Ev + MaybeSend + MaybeSync + 'static,
     {
         let (future, id) = self.notify_at_async(system_time);
         self.context.spawn({
@@ -134,7 +134,7 @@ where
     /// Ask to receive a notification when the specified [`Duration`](std::time::Duration) has elapsed.
     pub fn notify_after<F>(&self, duration: std::time::Duration, callback: F) -> TimerId
     where
-        F: FnOnce(TimeResponse) -> Ev + Send + Sync + 'static,
+        F: FnOnce(TimeResponse) -> Ev + MaybeSend + MaybeSync + 'static,
     {
         let (future, id) = self.notify_after_async(duration);
         self.context.spawn({

--- a/doctest_support/src/basic_delay.rs
+++ b/doctest_support/src/basic_delay.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-use crux_core::{Command, Request, command::RequestBuilder};
+use crux_core::{Command, MaybeSend, Request, command::RequestBuilder};
 use facet::Facet;
 use serde::{Deserialize, Serialize};
 
@@ -24,8 +24,8 @@ pub fn milliseconds<Effect, Event>(
     millis: usize,
 ) -> RequestBuilder<Effect, Event, impl Future<Output = ()>>
 where
-    Effect: Send + From<Request<DelayOperation>> + 'static,
-    Event: Send + 'static,
+    Effect: MaybeSend + From<Request<DelayOperation>> + 'static,
+    Event: MaybeSend + 'static,
 {
     Command::request_from_shell(DelayOperation { millis })
 }

--- a/doctest_support/src/delay.rs
+++ b/doctest_support/src/delay.rs
@@ -1,6 +1,6 @@
 use std::future::Future;
 
-use crux_core::{Command, Request, capability::Operation, command::RequestBuilder};
+use crux_core::{Command, MaybeSend, Request, capability::Operation, command::RequestBuilder};
 use facet::Facet;
 use serde::{Deserialize, Serialize};
 
@@ -34,8 +34,8 @@ pub fn milliseconds<Effect, Event>(
     millis: usize,
 ) -> RequestBuilder<Effect, Event, impl Future<Output = DelayOutput>>
 where
-    Effect: Send + From<Request<DelayOperation>> + 'static,
-    Event: Send + 'static,
+    Effect: MaybeSend + From<Request<DelayOperation>> + 'static,
+    Event: MaybeSend + 'static,
 {
     Command::request_from_shell(DelayOperation::Delay(millis))
 }
@@ -52,8 +52,8 @@ pub fn random<Effect, Event>(
     max: usize,
 ) -> RequestBuilder<Effect, Event, impl Future<Output = DelayOutput>>
 where
-    Effect: Send + From<Request<DelayOperation>> + 'static,
-    Event: Send + 'static,
+    Effect: MaybeSend + From<Request<DelayOperation>> + 'static,
+    Event: MaybeSend + 'static,
 {
     assert!(min <= max, "min must be less than or equal to max");
 

--- a/doctest_support/src/lib.rs
+++ b/doctest_support/src/lib.rs
@@ -125,6 +125,7 @@ pub mod compose {
     pub mod capabilities {
         pub mod capability_one {
             use crux_core::capability::{CapabilityContext, Operation};
+            use crux_core::{MaybeSend, MaybeSync};
             use serde::{Deserialize, Serialize};
 
             #[derive(PartialEq, Clone, Serialize, Deserialize, Debug)]
@@ -158,7 +159,7 @@ pub mod compose {
 
                 pub fn one<F>(&self, number: usize, event: F)
                 where
-                    F: FnOnce(usize) -> E + Send + 'static,
+                    F: FnOnce(usize) -> E + MaybeSend + 'static,
                     E: 'static,
                 {
                     let this = Clone::clone(self);
@@ -188,7 +189,7 @@ pub mod compose {
 
                 fn map_event<F, NewEv>(&self, f: F) -> Self::MappedSelf<NewEv>
                 where
-                    F: Fn(NewEv) -> Ev + Send + Sync + 'static,
+                    F: Fn(NewEv) -> Ev + MaybeSend + MaybeSync + 'static,
                     Ev: 'static,
                     NewEv: 'static,
                 {
@@ -199,6 +200,7 @@ pub mod compose {
 
         pub mod capability_two {
             use crux_core::capability::{CapabilityContext, Operation};
+            use crux_core::{MaybeSend, MaybeSync};
             use serde::{Deserialize, Serialize};
 
             #[derive(PartialEq, Clone, Serialize, Deserialize, Debug)]
@@ -232,7 +234,7 @@ pub mod compose {
 
                 pub fn two<F>(&self, number: usize, event: F)
                 where
-                    F: FnOnce(usize) -> E + Send + 'static,
+                    F: FnOnce(usize) -> E + MaybeSend + 'static,
                     E: 'static,
                 {
                     let this = Clone::clone(self);
@@ -262,7 +264,7 @@ pub mod compose {
 
                 fn map_event<F, NewEv>(&self, f: F) -> Self::MappedSelf<NewEv>
                 where
-                    F: Fn(NewEv) -> Ev + Send + Sync + 'static,
+                    F: Fn(NewEv) -> Ev + MaybeSend + MaybeSync + 'static,
                     Ev: 'static,
                     NewEv: 'static,
                 {


### PR DESCRIPTION
Submitting as draft to open the discussion.

This feature allow a single-threaded mode for `crux` to allow for non-Send non-Sync tasks, and enable it by default for the `wasm32` target.

Additionally we could re-use the [`futures::executor::LocalPool`](https://docs.rs/futures/latest/futures/executor/struct.LocalPool.html) executor when `unsync` is enabled