### PR TITLE
chore(crux_core): relax version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ license = "Apache-2.0"
 keywords = ["cross-platform-ui", "crux", "crux_core", "ffi", "wasm"]
 
 [workspace.dependencies]
-anyhow = "1.0.100"
+anyhow = "1.0"
 facet = "=0.30"
-serde = "1.0.228"
-thiserror = "2.0.17"
+serde = "1.0"
+thiserror = "2.0"
 uniffi = "=0.29.4"
 uniffi_bindgen = "=0.29.4"
 

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -38,7 +38,7 @@ crux_http = { path = "../crux_http" }
 crux_time = { path = "../crux_time" }
 doctest_support = { path = "../doctest_support" }
 rand = "0.9"
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { workspace = true, features = ["derive"] }
 static_assertions = "1.1"
 tempfile = "3.23.0"
 url = "2.5.7"

--- a/crux_macros/Cargo.toml
+++ b/crux_macros/Cargo.toml
@@ -17,8 +17,8 @@ darling = "0.23.0"
 heck = "0.5.0"
 proc-macro2 = "1.0.103"
 proc-macro-error = "1.0.4"
-quote = "1.0.42"
-syn = "2.0.111"
+quote = "1.0"
+syn = "2.0"
 
 [dev-dependencies]
 crux_core = { path = "../crux_core" }
@@ -26,7 +26,7 @@ crux_http = { path = "../crux_http" }
 facet = { workspace = true }
 insta = "1.44.3"
 prettyplease = "0.2"
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 
 [features]
 typegen = ["crux_core/typegen"]

--- a/doctest_support/Cargo.toml
+++ b/doctest_support/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 crux_core = { path = "../crux_core", features = ["facet_typegen", "typegen"] }
 crux_http = { path = "../crux_http" }
 facet.workspace = true
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0.145"


### PR DESCRIPTION
Relaxes some version requirements on core and macros to allow cargo to select versions better.