### PR TITLE
Updating facet requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ keywords = ["cross-platform-ui", "crux", "crux_core", "ffi", "wasm"]
 
 [workspace.dependencies]
 anyhow = "1.0"
-facet = "=0.30"
+facet = "=0.31"
 serde = "1.0"
 thiserror = "2.0"
 uniffi = "=0.29.4"

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -20,7 +20,7 @@ crossbeam-channel = "0.5.15"
 crux_cli = { version = "0.2.0-rc1", optional = true, path = "../crux_cli" }
 crux_macros = { version = "0.8.0-rc1", path = "../crux_macros", optional = true }
 facet.workspace = true
-facet_generate = { version = "0.12.1", optional = true }
+facet_generate = { version = "0.13.0", optional = true }
 futures = "0.3.31"
 log = { version = "0.4.29", optional = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -27,7 +27,7 @@ encoding_rs = { version = "0.8.35", optional = true }
 facet.workspace = true
 futures-util = "0.3"
 http = { version = "1.4", optional = true }
-http-types = { package = "http-types-red-badger-temporary-fork", version = "5.0.0", default-features = false }
+http-types = { package = "http-types-red-badger-temporary-fork", version = "6.0.0", default-features = false }
 pin-project-lite = "0.2.16"
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = "0.11"


### PR DESCRIPTION
## Summary
- Update facet from 0.30 to 0.31
- Update facet_generate from 0.12.1 to 0.13.0
- Update http-types-red-badger-temporary-fork from 5.0.0 to 6.0.0