### PR TITLE
refactor: Simplify `CatFacts::view`

### DIFF
--- a/examples/cat_facts/shared/src/app.rs
+++ b/examples/cat_facts/shared/src/app.rs
@@ -217,8 +217,7 @@ impl App for CatFacts {
             _ => "No fact".to_string(),
         };
 
-        let platform =
-            <platform::Platform as crux_core::App>::view(&self.platform, &model.platform).platform;
+        let platform = self.platform.view(&model.platform).platform;
 
         ViewModel {
             platform,


### PR DESCRIPTION
There doesn’t seem to be any reason to use the fully qualified syntax here: the `App` trait is already in scope, so we can call `view()` directly.