### PR TITLE
refactor: streamline codegen examples

### DIFF
--- a/examples/bridge_echo/shared/src/bin/codegen.rs
+++ b/examples/bridge_echo/shared/src/bin/codegen.rs
@@ -32,41 +32,35 @@ fn main() -> Result<()> {
 
     let typegen_app = TypeRegistry::new().register_app::<BridgeEcho>()?.build()?;
 
+    let name = match args.language {
+        Language::Swift => "App",
+        Language::Kotlin => "com.crux.example.bridge_echo",
+        Language::Typescript => "app",
+    };
+    let config = Config::builder(name, &args.output_dir)
+        .add_extensions()
+        .add_runtimes()
+        .build();
+
     match args.language {
         Language::Swift => {
             info!("Typegen for Swift");
-            typegen_app.swift(
-                &Config::builder("App", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.swift(&config)?;
         }
         Language::Kotlin => {
             info!("Typegen for Kotlin");
-            typegen_app.kotlin(
-                &Config::builder("com.crux.example.bridge_echo", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.kotlin(&config)?;
 
             info!("Bindgen for Kotlin");
-            bindgen(
-                &BindgenArgsBuilder::default()
-                    .crate_name(env!("CARGO_PKG_NAME").to_string())
-                    .kotlin(&args.output_dir)
-                    .build()?,
-            )?;
+            let bindgen_args = BindgenArgsBuilder::default()
+                .crate_name(env!("CARGO_PKG_NAME").to_string())
+                .kotlin(&args.output_dir)
+                .build()?;
+            bindgen(&bindgen_args)?;
         }
         Language::Typescript => {
             info!("Typegen for TypeScript");
-            typegen_app.typescript(
-                &Config::builder("app", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.typescript(&config)?;
         }
     }
 

--- a/examples/cat_facts/shared/src/bin/codegen.rs
+++ b/examples/cat_facts/shared/src/bin/codegen.rs
@@ -32,41 +32,35 @@ fn main() -> Result<()> {
 
     let typegen_app = TypeRegistry::new().register_app::<CatFacts>()?.build()?;
 
+    let name = match args.language {
+        Language::Swift => "App",
+        Language::Kotlin => "com.crux.example.cat_facts",
+        Language::Typescript => "app",
+    };
+    let config = Config::builder(name, &args.output_dir)
+        .add_extensions()
+        .add_runtimes()
+        .build();
+
     match args.language {
         Language::Swift => {
             info!("Typegen for Swift");
-            typegen_app.swift(
-                &Config::builder("App", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.swift(&config)?;
         }
         Language::Kotlin => {
             info!("Typegen for Kotlin");
-            typegen_app.kotlin(
-                &Config::builder("com.crux.example.cat_facts", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.kotlin(&config)?;
 
             info!("Bindgen for Kotlin");
-            bindgen(
-                &BindgenArgsBuilder::default()
-                    .crate_name(env!("CARGO_PKG_NAME").to_string())
-                    .kotlin(&args.output_dir)
-                    .build()?,
-            )?;
+            let bindgen_args = BindgenArgsBuilder::default()
+                .crate_name(env!("CARGO_PKG_NAME").to_string())
+                .kotlin(&args.output_dir)
+                .build()?;
+            bindgen(&bindgen_args)?;
         }
         Language::Typescript => {
             info!("Typegen for TypeScript");
-            typegen_app.typescript(
-                &Config::builder("app", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.typescript(&config)?;
         }
     }
 

--- a/examples/counter-next/shared/src/bin/codegen.rs
+++ b/examples/counter-next/shared/src/bin/codegen.rs
@@ -160,17 +160,16 @@ fn serde(args: &Args) -> Result<(), TypeGenError> {
     let typegen_serde = TypeRegistry::new().build()?;
     let out_dir = args.output_dir.join("serde");
 
+    let name = match args.language {
+        Language::Swift => "Serde",
+        Language::Kotlin => "com.crux.example.counter.serde",
+        Language::Typescript => "serde",
+    };
+    let config = Config::builder(name, &out_dir).add_runtimes().build();
+
     match args.language {
-        Language::Swift => {
-            typegen_serde.swift(&Config::builder("Serde", &out_dir).add_runtimes().build())
-        }
-        Language::Kotlin => typegen_serde.kotlin(
-            &Config::builder("com.crux.example.counter.serde", &out_dir)
-                .add_runtimes()
-                .build(),
-        ),
-        Language::Typescript => {
-            typegen_serde.typescript(&Config::builder("serde", &out_dir).add_runtimes().build())
-        }
+        Language::Swift => typegen_serde.swift(&config),
+        Language::Kotlin => typegen_serde.kotlin(&config),
+        Language::Typescript => typegen_serde.typescript(&config),
     }
 }

--- a/examples/counter/shared/src/bin/codegen.rs
+++ b/examples/counter/shared/src/bin/codegen.rs
@@ -10,8 +10,6 @@ use uniffi::deps::anyhow::Result;
 
 use shared::Counter;
 
-const PACKAGE_NAME: &str = "com.crux.examples.counter";
-
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum Language {
     Swift,
@@ -34,41 +32,35 @@ fn main() -> Result<()> {
 
     let typegen_app = TypeRegistry::new().register_app::<Counter>()?.build()?;
 
+    let name = match args.language {
+        Language::Swift => "App",
+        Language::Kotlin => "com.crux.examples.counter",
+        Language::Typescript => "app",
+    };
+    let config = Config::builder(name, &args.output_dir)
+        .add_extensions()
+        .add_runtimes()
+        .build();
+
     match args.language {
         Language::Swift => {
             info!("Typegen for Swift");
-            typegen_app.swift(
-                &Config::builder("App", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.swift(&config)?;
         }
         Language::Kotlin => {
             info!("Typegen for Kotlin");
-            typegen_app.kotlin(
-                &Config::builder(PACKAGE_NAME, &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.kotlin(&config)?;
 
             info!("Bindgen for Kotlin");
-            bindgen(
-                &BindgenArgsBuilder::default()
-                    .crate_name(env!("CARGO_PKG_NAME").to_string())
-                    .kotlin(&args.output_dir)
-                    .build()?,
-            )?;
+            let bindgen_args = BindgenArgsBuilder::default()
+                .crate_name(env!("CARGO_PKG_NAME").to_string())
+                .kotlin(&args.output_dir)
+                .build()?;
+            bindgen(&bindgen_args)?;
         }
         Language::Typescript => {
             info!("Typegen for TypeScript");
-            typegen_app.typescript(
-                &Config::builder("app", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.typescript(&config)?;
         }
     }
 

--- a/examples/hello_world/shared/src/bin/codegen.rs
+++ b/examples/hello_world/shared/src/bin/codegen.rs
@@ -10,8 +10,6 @@ use uniffi::deps::anyhow::Result;
 
 use shared::HelloWorld;
 
-const PACKAGE: &str = "com.crux.example.hello_world";
-
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum Language {
     Swift,
@@ -34,41 +32,35 @@ fn main() -> Result<()> {
 
     let typegen_app = TypeRegistry::new().register_app::<HelloWorld>()?.build()?;
 
+    let name = match args.language {
+        Language::Swift => "App",
+        Language::Kotlin => "com.crux.example.hello_world",
+        Language::Typescript => "app",
+    };
+    let config = Config::builder(name, &args.output_dir)
+        .add_extensions()
+        .add_runtimes()
+        .build();
+
     match args.language {
         Language::Swift => {
             info!("Typegen for Swift");
-            typegen_app.swift(
-                &Config::builder("App", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.swift(&config)?;
         }
         Language::Kotlin => {
             info!("Typegen for Kotlin");
-            typegen_app.kotlin(
-                &Config::builder(PACKAGE, &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.kotlin(&config)?;
 
             info!("Bindgen for Kotlin");
-            bindgen(
-                &BindgenArgsBuilder::default()
-                    .crate_name(env!("CARGO_PKG_NAME").to_string())
-                    .kotlin(&args.output_dir)
-                    .build()?,
-            )?;
+            let bindgen_args = BindgenArgsBuilder::default()
+                .crate_name(env!("CARGO_PKG_NAME").to_string())
+                .kotlin(&args.output_dir)
+                .build()?;
+            bindgen(&bindgen_args)?;
         }
         Language::Typescript => {
             info!("Typegen for TypeScript");
-            typegen_app.typescript(
-                &Config::builder("app", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.typescript(&config)?;
         }
     }
 

--- a/examples/notes/shared/src/bin/codegen.rs
+++ b/examples/notes/shared/src/bin/codegen.rs
@@ -10,8 +10,6 @@ use uniffi::deps::anyhow::Result;
 
 use shared::NoteEditor;
 
-const PACKAGE: &str = "com.crux.example.notes";
-
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum Language {
     Swift,
@@ -34,41 +32,35 @@ fn main() -> Result<()> {
 
     let typegen_app = TypeRegistry::new().register_app::<NoteEditor>()?.build()?;
 
+    let name = match args.language {
+        Language::Swift => "App",
+        Language::Kotlin => "com.crux.example.notes",
+        Language::Typescript => "app",
+    };
+    let config = Config::builder(name, &args.output_dir)
+        .add_extensions()
+        .add_runtimes()
+        .build();
+
     match args.language {
         Language::Swift => {
             info!("Typegen for Swift");
-            typegen_app.swift(
-                &Config::builder("App", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.swift(&config)?;
         }
         Language::Kotlin => {
             info!("Typegen for Kotlin");
-            typegen_app.kotlin(
-                &Config::builder(PACKAGE, &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.kotlin(&config)?;
 
             info!("Bindgen for Kotlin");
-            bindgen(
-                &BindgenArgsBuilder::default()
-                    .crate_name(env!("CARGO_PKG_NAME").to_string())
-                    .kotlin(&args.output_dir)
-                    .build()?,
-            )?;
+            let bindgen_args = BindgenArgsBuilder::default()
+                .crate_name(env!("CARGO_PKG_NAME").to_string())
+                .kotlin(&args.output_dir)
+                .build()?;
+            bindgen(&bindgen_args)?;
         }
         Language::Typescript => {
             info!("Typegen for TypeScript");
-            typegen_app.typescript(
-                &Config::builder("app", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.typescript(&config)?;
         }
     }
 

--- a/examples/simple_counter/shared/src/bin/codegen.rs
+++ b/examples/simple_counter/shared/src/bin/codegen.rs
@@ -10,8 +10,6 @@ use uniffi::deps::anyhow::Result;
 
 use shared::Counter;
 
-const PACKAGE_NAME: &str = "com.crux.examples.simplecounter";
-
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 enum Language {
     Swift,
@@ -34,41 +32,35 @@ fn main() -> Result<()> {
 
     let typegen_app = TypeRegistry::new().register_app::<Counter>()?.build()?;
 
+    let name = match args.language {
+        Language::Swift => "App",
+        Language::Kotlin => "com.crux.examples.simplecounter",
+        Language::Typescript => "app",
+    };
+    let config = Config::builder(name, &args.output_dir)
+        .add_extensions()
+        .add_runtimes()
+        .build();
+
     match args.language {
         Language::Swift => {
             info!("Typegen for Swift");
-            typegen_app.swift(
-                &Config::builder("App", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.swift(&config)?;
         }
         Language::Kotlin => {
             info!("Typegen for Kotlin");
-            typegen_app.kotlin(
-                &Config::builder(PACKAGE_NAME, &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.kotlin(&config)?;
 
             info!("Bindgen for Kotlin");
-            bindgen(
-                &BindgenArgsBuilder::default()
-                    .crate_name(env!("CARGO_PKG_NAME").to_string())
-                    .kotlin(&args.output_dir)
-                    .build()?,
-            )?;
+            let bindgen_args = BindgenArgsBuilder::default()
+                .crate_name(env!("CARGO_PKG_NAME").to_string())
+                .kotlin(&args.output_dir)
+                .build()?;
+            bindgen(&bindgen_args)?;
         }
         Language::Typescript => {
             info!("Typegen for TypeScript");
-            typegen_app.typescript(
-                &Config::builder("app", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.typescript(&config)?;
         }
     }
 

--- a/examples/weather/shared/src/bin/codegen.rs
+++ b/examples/weather/shared/src/bin/codegen.rs
@@ -32,41 +32,35 @@ fn main() -> Result<()> {
         .register_app::<shared::Weather>()?
         .build()?;
 
+    let name = match args.language {
+        Language::Swift => "App",
+        Language::Kotlin => "com.crux.example.weather",
+        Language::Typescript => "app",
+    };
+    let config = Config::builder(name, &args.output_dir)
+        .add_extensions()
+        .add_runtimes()
+        .build();
+
     match args.language {
         Language::Swift => {
             info!("Typegen for Swift");
-            typegen_app.swift(
-                &Config::builder("App", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.swift(&config)?;
         }
         Language::Kotlin => {
             info!("Typegen for Kotlin");
-            typegen_app.kotlin(
-                &Config::builder("com.crux.example.weather", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.kotlin(&config)?;
 
             info!("Bindgen for Kotlin");
-            bindgen(
-                &BindgenArgsBuilder::default()
-                    .crate_name(env!("CARGO_PKG_NAME").to_string())
-                    .kotlin(&args.output_dir)
-                    .build()?,
-            )?;
+            let bindgen_args = BindgenArgsBuilder::default()
+                .crate_name(env!("CARGO_PKG_NAME").to_string())
+                .kotlin(&args.output_dir)
+                .build()?;
+            bindgen(&bindgen_args)?;
         }
         Language::Typescript => {
             info!("Typegen for TypeScript");
-            typegen_app.typescript(
-                &Config::builder("app", &args.output_dir)
-                    .add_extensions()
-                    .add_runtimes()
-                    .build(),
-            )?;
+            typegen_app.typescript(&config)?;
         }
     }
 


### PR DESCRIPTION
This refactors some very repetitive/duplicate code in the example codegen files.

I feel it’s important to make the examples as simple and “crisp” as possible, especially since I’ve seen people new to Rust copy this code directly into our internal code base.