### PR TITLE
refactor: remove unnecessary `Arc` around `Sender`

### DIFF
--- a/examples/bridge_echo/cli/src/core.rs
+++ b/examples/bridge_echo/cli/src/core.rs
@@ -11,7 +11,7 @@ pub fn new() -> Core {
     Arc::new(shared::Core::new())
 }
 
-pub fn update(core: &Core, event: Event, tx: &Arc<Sender<Effect>>) -> Result<()> {
+pub fn update(core: &Core, event: Event, tx: &Sender<Effect>) -> Result<()> {
     debug!("event: {event:?}");
 
     for effect in core.process_event(event) {
@@ -20,7 +20,7 @@ pub fn update(core: &Core, event: Event, tx: &Arc<Sender<Effect>>) -> Result<()>
     Ok(())
 }
 
-pub fn process_effect(_core: &Core, effect: Effect, tx: &Arc<Sender<Effect>>) -> Result<()> {
+pub fn process_effect(_core: &Core, effect: Effect, tx: &Sender<Effect>) -> Result<()> {
     debug!("effect: {effect:?}");
 
     match effect {

--- a/examples/cat_facts/cli/src/core.rs
+++ b/examples/cat_facts/cli/src/core.rs
@@ -19,7 +19,7 @@ pub fn new() -> Core {
     Arc::new(shared::Core::new())
 }
 
-pub fn update(core: &Core, event: Event, tx: &Arc<Sender<Effect>>) -> Result<()> {
+pub fn update(core: &Core, event: Event, tx: &Sender<Effect>) -> Result<()> {
     debug!("event: {event:?}");
 
     for effect in core.process_event(event) {
@@ -28,7 +28,7 @@ pub fn update(core: &Core, event: Event, tx: &Arc<Sender<Effect>>) -> Result<()>
     Ok(())
 }
 
-pub fn process_effect(core: &Core, effect: Effect, tx: &Arc<Sender<Effect>>) -> Result<()> {
+pub fn process_effect(core: &Core, effect: Effect, tx: &Sender<Effect>) -> Result<()> {
     debug!("effect: {effect:?}");
 
     match effect {

--- a/examples/cat_facts/cli/src/main.rs
+++ b/examples/cat_facts/cli/src/main.rs
@@ -4,7 +4,6 @@ mod http;
 use anyhow::Result;
 use clap::Parser;
 use crossbeam_channel::unbounded;
-use std::sync::Arc;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
 use shared::{Effect, Event, ViewModel};
@@ -62,9 +61,8 @@ async fn main() -> Result<()> {
 fn run_loop(core: &core::Core, events: Vec<Event>) -> Result<()> {
     let (render_tx, render_rx) = unbounded::<Effect>();
     {
-        let render_tx = Arc::new(render_tx);
         for event in events {
-            update(core, event, &render_tx.clone())?;
+            update(core, event, &render_tx)?;
         }
     }
 

--- a/examples/counter/cli/src/core.rs
+++ b/examples/counter/cli/src/core.rs
@@ -15,7 +15,7 @@ pub fn new() -> Core {
     Arc::new(shared::Core::new())
 }
 
-pub fn update(core: &Core, event: Event, tx: &Arc<Sender<Effect>>) -> Result<()> {
+pub fn update(core: &Core, event: Event, tx: &Sender<Effect>) -> Result<()> {
     debug!("event: {:?}", event);
 
     for effect in core.process_event(event) {
@@ -24,7 +24,7 @@ pub fn update(core: &Core, event: Event, tx: &Arc<Sender<Effect>>) -> Result<()>
     Ok(())
 }
 
-pub fn process_effect(core: &Core, effect: Effect, tx: &Arc<Sender<Effect>>) -> Result<()> {
+pub fn process_effect(core: &Core, effect: Effect, tx: &Sender<Effect>) -> Result<()> {
     debug!("effect: {:?}", effect);
 
     match effect {

--- a/examples/counter/cli/src/main.rs
+++ b/examples/counter/cli/src/main.rs
@@ -2,8 +2,6 @@ mod core;
 mod http;
 mod sse;
 
-use std::sync::Arc;
-
 use anyhow::Result;
 use clap::Parser;
 use crossbeam_channel::unbounded;
@@ -52,7 +50,7 @@ async fn main() -> Result<()> {
     let event = command.into();
     let (tx, rx) = unbounded::<Effect>();
 
-    core::update(&core, event, &Arc::new(tx))?;
+    core::update(&core, event, &tx)?;
 
     while let Ok(effect) = rx.recv() {
         if let Effect::Render(_) = effect {


### PR DESCRIPTION
The send handle on a Crossbeam channel is already cheaply clonable. So wrapping it in an `Arc` is an anti-pattern.

Normally, I would `clone()` the send handle and pass it around as an owned value. But here, the functions are small and synchronous, so I just passed a reference.