### PR TITLE
chore: fix for new lint introduced in Rust 1.93

### DIFF
--- a/crux_core/src/type_generation/serde.rs
+++ b/crux_core/src/type_generation/serde.rs
@@ -43,7 +43,7 @@
 //! #             todo!();
 //! #         }
 //! #     }
-//! #     #[effect]
+//! #     #[effect(typegen)]
 //! #     pub enum Effect {
 //! #         Render(RenderOperation),
 //! #     }
@@ -52,7 +52,6 @@
 //!use crux_core::{bridge::Request, typegen::TypeGen};
 //!use uuid::Uuid;
 //!
-//!#[test]
 //!fn generate_types() -> anyhow::Result<()> {
 //!    let mut typegen = TypeGen::new();
 //!
@@ -69,6 +68,8 @@
 //!    typegen.java("com.example.counter.shared_types", output_root.join("java"))?;
 //!
 //!    typegen.typescript("shared_types", output_root.join("typescript"))?;
+//!
+//!    Ok(())
 //!}
 //! ```
 //!


### PR DESCRIPTION
Rust 1.93 introduced a new lint that warns when `#[test]` is used in weird places (like doctests). This removes an offending annotation, and fixes up the (broken) code that it was hiding.