### PR TITLE
feat: Support passing App and Model object to construct the Core

### DIFF
--- a/crux_core/src/command/tests/integration.rs
+++ b/crux_core/src/command/tests/integration.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 use crate::{Command, Request};
 
 // The future version of the app trait
-pub trait App: Default {
+pub trait App {
     type Event: Send + 'static;
-    type Model: Default;
+    type Model;
     type ViewModel: Serialize;
     type Effect;
 

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -41,9 +41,12 @@ where
 
 impl<A> Core<A>
 where
-    A: App,
+    A: App + Default,
+    A::Model: Default,
 {
     /// Create an instance of the Crux core to start a Crux application, e.g.
+    ///
+    /// If you want to construct [App] and [`App::Model`] yourself instead of using default, call [`Self::new_with`]
     ///
     /// ```rust,ignore
     /// let core: Core<MyApp> = Core::new();
@@ -54,6 +57,28 @@ where
         Self {
             model: RwLock::default(),
             app: A::default(),
+            root_command: Mutex::new(Command::done()),
+        }
+    }
+}
+
+impl<A> Core<A>
+where
+    A: App,
+{
+    /// Create an instance of the Crux core to start a Crux application with a given [App] and [`App::Model`]
+    ///
+    /// ```rust,ignore
+    /// let app = MyApp::new();
+    /// let model = MyModel::new();
+    /// let core = Core::new_with(app, model);
+    /// ```
+    ///
+    #[must_use]
+    pub fn new_with(app: A, model: A::Model) -> Self {
+        Self {
+            model: RwLock::new(model),
+            app,
             root_command: Mutex::new(Command::done()),
         }
     }
@@ -152,7 +177,8 @@ where
 
 impl<A> Default for Core<A>
 where
-    A: App,
+    A: App + Default,
+    A::Model: Default,
 {
     fn default() -> Self {
         Self::new()

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -175,11 +175,11 @@ pub use type_generation::serde as typegen;
 
 /// Implement [`App`] on your type to make it into a Crux app. Use your type implementing [`App`]
 /// as the type argument to [`Core`] or [`Bridge`](crate::bridge::Bridge).
-pub trait App: Default {
+pub trait App {
     /// `Event`, typically an `enum`, defines the actions that can be taken to update the application state.
     type Event: Unpin + Send + 'static;
     /// `Model`, typically a `struct` defines the internal state of the application
-    type Model: Default;
+    type Model;
     /// `ViewModel`, typically a `struct` describes the user interface that should be
     /// displayed to the user
     type ViewModel;

--- a/crux_core/src/testing.rs
+++ b/crux_core/src/testing.rs
@@ -39,7 +39,8 @@ where
 #[expect(deprecated)]
 impl<App> AppTester<App>
 where
-    App: crate::App,
+    App: crate::App + Default,
+    App::Model: Default,
 {
     /// Create an `AppTester` instance for an existing app instance. This can be used if your App
     /// has a constructor other than `Default`, for example when used as a child app and expecting
@@ -136,7 +137,8 @@ where
 #[expect(deprecated)]
 impl<App> Default for AppTester<App>
 where
-    App: crate::App,
+    App: crate::App + Default,
+    App::Model: Default,
 {
     fn default() -> Self {
         Self {


### PR DESCRIPTION
Previously it was impossible to pass a custom constructor for app or model. Meaning you can't pass init params to the Model a constructor. 

This MR keeps back-compatibility by still supporting `new` if `App` and `App::Model` have `Default` implemented. But don't require those bonds to be present on `App` and `App::Model`. In which, case `map_with` can be called with an already constructed `App` and `App::Model`. 

Closes #487
