### PR TITLE
update to serde_qs v1.0, relaxes querystring encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,11 +751,12 @@ dependencies = [
  "futures-util",
  "http",
  "http-types-red-badger-temporary-fork",
+ "insta",
  "pin-project-lite",
  "serde",
  "serde_bytes",
  "serde_json",
- "serde_qs",
+ "serde_qs 1.0.0",
  "thiserror 2.0.17",
  "url",
  "web-sys",
@@ -1591,7 +1592,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
- "serde_qs",
+ "serde_qs 0.15.0",
  "serde_urlencoded",
  "url",
 ]
@@ -1884,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.46.0"
+version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b66886d14d18d420ab5052cbff544fc5d34d0b2cdd35eb5976aaa10a4a472e5"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
 dependencies = [
  "console 0.15.11",
  "once_cell",
@@ -2830,6 +2831,18 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "serde_qs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac22439301a0b6f45a037681518e3169e8db1db76080e2e9600a08d1027df037"
+dependencies = [
+ "itoa",
+ "percent-encoding",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -32,7 +32,7 @@ pin-project-lite = "0.2.16"
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1.0.149"
-serde_qs = "0.15.0"
+serde_qs = "1.0.0"
 thiserror.workspace = true
 url = "2.5.8"
 
@@ -43,3 +43,4 @@ web-sys = { optional = true, version = "0.3.83", features = ["TextDecoder"] }
 assert_fs = "1.1.3"
 futures-test = "0.3"
 assert_matches = "1.5"
+insta = "1.46.3"


### PR DESCRIPTION
We are using `serde_qs` in `crux_http` for query string encoding. It recently went 1.0, which relaxes some unnecessary encoding in query strings. This modifies the tests to reflect this (and demonstrate what is and isn't encoded now). This may well be a breaking change in that some user's tests may now fail.