### PR TITLE
fix: Do not recurse again after a middleware roundtrip.

### DIFF
--- a/crux_core/src/middleware/effect_handling.rs
+++ b/crux_core/src/middleware/effect_handling.rs
@@ -1,4 +1,6 @@
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, Weak, atomic::AtomicBool};
+
+use crossbeam_channel::{Receiver, Sender, unbounded};
 
 use crate::{Request, RequestHandle, Resolvable, ResolveError, capability::Operation};
 
@@ -50,7 +52,7 @@ where
 struct EffectMiddlewareLayerInner<Next, EM>
 where
     Next: Layer + Sync + Send + 'static,
-    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect>,
+    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect> + Send,
     EM: EffectMiddleware<Next::Effect> + Send + Sync,
 {
     next: Next,
@@ -63,10 +65,11 @@ where
 pub struct HandleEffectLayer<Next, EM>
 where
     Next: Layer + Sync + Send + 'static,
-    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect>,
-    EM: EffectMiddleware<Next::Effect> + Send + Sync,
+    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect> + Send,
+    EM: EffectMiddleware<Next::Effect> + Send + Sync + 'static,
 {
     inner: Arc<EffectMiddlewareLayerInner<Next, EM>>,
+    worker: Worker<Next, EM>,
 }
 
 impl<Next, EM> Layer for HandleEffectLayer<Next, EM>
@@ -74,7 +77,7 @@ where
     // Next layer down, core being at the bottom
     Next: Layer,
     // Effect has to try_into the operation which the middleware handles
-    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect>,
+    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect> + Send,
     // The actual middleware effect handling implementation
     EM: EffectMiddleware<Next::Effect> + Send + Sync + 'static,
 {
@@ -114,7 +117,7 @@ where
 impl<Next, EM> HandleEffectLayer<Next, EM>
 where
     Next: Layer,
-    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect>,
+    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect> + Send,
     EM: EffectMiddleware<Next::Effect> + Send + Sync + 'static,
 {
     /// Typically, you would would use [`Layer::handle_effects_using`] to construct a `HandleEffectLayer` instance
@@ -122,6 +125,7 @@ where
     pub fn new(next: Next, middleware: EM) -> Self {
         Self {
             inner: Arc::new(EffectMiddlewareLayerInner { next, middleware }),
+            worker: Worker::default(),
         }
     }
 
@@ -131,19 +135,31 @@ where
         return_effects: impl Fn(Vec<Next::Effect>) + Send + Sync + 'static,
     ) -> Vec<Next::Effect> {
         let inner = Arc::downgrade(&self.inner);
-        let return_effects = Arc::new(return_effects);
+        let return_effects: Arc<dyn Fn(Vec<Next::Effect>) + Send + Sync + 'static> =
+            Arc::new(return_effects);
         let return_effects_copy = return_effects.clone();
 
+        let worker = self.worker.clone();
         let effects = self
             .inner
             .next
             .update(event, move |later_effects_from_next| {
                 // Eventual route
-                Self::process_known_effects_with(&inner, later_effects_from_next, &return_effects);
+                Self::process_known_effects_with(
+                    &worker,
+                    &inner,
+                    later_effects_from_next,
+                    &return_effects,
+                );
             });
 
         // Immediate route
-        Self::process_known_effects(&Arc::downgrade(&self.inner), effects, &return_effects_copy)
+        Self::process_known_effects(
+            &self.worker,
+            &Arc::downgrade(&self.inner),
+            effects,
+            &return_effects_copy,
+        )
     }
 
     fn resolve<Output>(
@@ -153,18 +169,26 @@ where
         return_effects: impl Fn(Vec<Next::Effect>) + Send + Sync + 'static,
     ) -> Result<Vec<Next::Effect>, ResolveError> {
         let inner = Arc::downgrade(&self.inner);
-        let return_effects = Arc::new(return_effects);
+        let return_effects: Arc<dyn Fn(Vec<Next::Effect>) + Send + Sync + 'static> =
+            Arc::new(return_effects);
         let return_effects_copy = return_effects.clone();
+        let worker = self.worker.clone();
 
         let effects = self
             .inner
             .next
             .resolve(request, result, move |later_effects_from_next| {
-                Self::process_known_effects_with(&inner, later_effects_from_next, &return_effects);
+                Self::process_known_effects_with(
+                    &worker,
+                    &inner,
+                    later_effects_from_next,
+                    &return_effects,
+                );
             })?;
 
         // Immediate route
         Ok(Self::process_known_effects(
+            &self.worker,
             &Arc::downgrade(&self.inner),
             effects,
             &return_effects_copy,
@@ -180,25 +204,39 @@ where
         F: Fn(Vec<Next::Effect>) + Sync + Send + 'static,
     {
         let inner = Arc::downgrade(&self.inner);
-        let return_effects = Arc::new(return_effects);
-        let return_effects_copy = return_effects.clone();
 
+        let return_effects: Arc<dyn Fn(Vec<Next::Effect>) + Send + Sync + 'static> =
+            Arc::new(return_effects);
+        let return_effects_copy = return_effects.clone();
+        let worker = self.worker.clone();
         let effects = self
             .inner
             .next
             .process_tasks(move |later_effects_from_next| {
                 // Eventual route
-                Self::process_known_effects_with(&inner, later_effects_from_next, &return_effects);
+                Self::process_known_effects_with(
+                    &worker,
+                    &inner,
+                    later_effects_from_next,
+                    &return_effects,
+                );
             });
 
         // Immediate route
-        Self::process_known_effects(&Arc::downgrade(&self.inner), effects, &return_effects_copy)
+        Self::process_known_effects(
+            &self.worker,
+            &Arc::downgrade(&self.inner),
+            effects,
+            &return_effects_copy,
+        )
     }
 
+    #[track_caller]
     fn process_known_effects(
+        worker: &Worker<Next, EM>,
         inner: &Weak<EffectMiddlewareLayerInner<Next, EM>>,
         effects: Vec<Next::Effect>,
-        return_effects: &Arc<impl Fn(Vec<Next::Effect>) + Send + Sync + 'static>,
+        return_effects: &Arc<dyn Fn(Vec<Next::Effect>) + Send + Sync + 'static>,
     ) -> Vec<Next::Effect> {
         effects
             .into_iter()
@@ -207,6 +245,7 @@ where
                 let resolve_callback = {
                     let return_effects = return_effects.clone();
                     let inner = inner.clone();
+                    let worker = worker.clone();
 
                     // Ideally, we'd want the `handle` to be an `impl Resolvable`, alas,
                     // generic closures are not a thing.
@@ -218,28 +257,37 @@ where
                             eprintln!("Inner cant't be upgraded after resolving effect");
                             return;
                         };
+                        let return_effects = return_effects.clone();
+                        let inner = inner.clone();
 
+                        // We don't want to overflow the stack by recursively calling
+                        // back and forth between middlewares and the core.
+                        //
+                        // So if we made one roundtrip, and we are asked to make more,
+                        // we deem it as good a time as any to enqueue further processing.
+                        // This is done via the `worker`.
                         if let Ok(immediate_effects) =
                             strong_inner.next.resolve(handle, effect_out_value, {
                                 let return_effects = return_effects.clone();
                                 let future_inner = inner.clone();
+                                let worker = worker.clone();
 
-                                // Eventual eventual route
                                 move |eventual_effects| {
-                                    // Process known effects
-                                    Self::process_known_effects_with(
-                                        &future_inner,
+                                    let return_effects = return_effects.clone();
+                                    let future_inner = future_inner.clone();
+                                    let more_effects_to_resolve = MiddlewareTask(
+                                        future_inner,
                                         eventual_effects,
-                                        &return_effects,
+                                        return_effects,
                                     );
+
+                                    worker.enqueue(more_effects_to_resolve);
                                 }
                             })
                         {
-                            Self::process_known_effects_with(
-                                &inner,
-                                immediate_effects,
-                                &return_effects,
-                            );
+                            let more_effects_to_resolve =
+                                MiddlewareTask(inner.clone(), immediate_effects, return_effects);
+                            worker.enqueue(more_effects_to_resolve);
                         }
                     } // TODO: handle/propagate resolve error?
                 };
@@ -261,14 +309,137 @@ where
     }
 
     fn process_known_effects_with(
+        worker: &Worker<Next, EM>,
         inner: &Weak<EffectMiddlewareLayerInner<Next, EM>>,
         effects: Vec<<Next as Layer>::Effect>,
-        return_effects: &Arc<impl Fn(Vec<<Next as Layer>::Effect>) + Send + Sync + 'static>,
+        return_effects: &Arc<dyn Fn(Vec<Next::Effect>) + Send + Sync + 'static>,
     ) {
-        let unknown_effects = Self::process_known_effects(inner, effects, return_effects);
+        let unknown_effects = Self::process_known_effects(worker, inner, effects, return_effects);
 
         if !unknown_effects.is_empty() {
             return_effects(unknown_effects);
+        }
+    }
+}
+
+struct MiddlewareTask<Next, EM, EffectCb>(
+    Weak<EffectMiddlewareLayerInner<Next, EM>>,
+    Vec<<Next as Layer>::Effect>,
+    Arc<EffectCb>,
+)
+where
+    Next: Layer + Send + 'static,
+    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect> + Send,
+    EM: EffectMiddleware<Next::Effect> + Send + Sync + 'static,
+    EffectCb: Fn(Vec<Next::Effect>) + Send + Sync + ?Sized + 'static;
+
+type SendMiddlewareTask<Next, EM> =
+    MiddlewareTask<Next, EM, dyn Fn(Vec<<Next as Layer>::Effect>) + Send + Sync + 'static>;
+
+struct Worker<Next, EM>
+where
+    Next: Layer + Send + 'static,
+    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect> + Send,
+    EM: EffectMiddleware<Next::Effect> + Send + Sync + 'static,
+{
+    sender: Sender<SendMiddlewareTask<Next, EM>>,
+    receiver: Receiver<SendMiddlewareTask<Next, EM>>,
+    is_working: Arc<AtomicBool>,
+}
+
+impl<Next, EM> Clone for Worker<Next, EM>
+where
+    Next: Layer + Send + 'static,
+    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect> + Send,
+    EM: EffectMiddleware<Next::Effect> + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            receiver: self.receiver.clone(),
+            is_working: self.is_working.clone(),
+        }
+    }
+}
+
+impl<Next, EM> Default for Worker<Next, EM>
+where
+    Next: Layer + Send + 'static,
+    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect> + Send,
+    EM: EffectMiddleware<Next::Effect> + Send + Sync + 'static,
+{
+    fn default() -> Self {
+        // Do we want any sort of backpressure here?
+        // I would assume no because:
+        // - We don't want the hot path to be stalled
+        // - As soon as a task is enqueued a worker should either:
+        //   - Start `pop()`ing the queue
+        //   - Notice an other part of the program is already doing it
+        // The channel should thus almost always be empty
+        // On the other hand there is no such thing as unbounded channel
+        // because machines have a finite set of resources...
+        let (sender, receiver) = unbounded();
+        Self {
+            sender,
+            receiver,
+            is_working: Arc::default(),
+        }
+    }
+}
+
+impl<Next, EM> Worker<Next, EM>
+where
+    Next: Layer + Send + 'static,
+    Next::Effect: TryInto<Request<EM::Op>, Error = Next::Effect> + Send,
+    EM: EffectMiddleware<Next::Effect> + Send + Sync + 'static,
+{
+    // Add a middleware task to be processed by the worker.
+    // If no part of the codebase is actively processing tasks,
+    // We do it ourselves.
+    //
+    // These steps act as a stackoverflow guard,
+    // as the topmost middleware tries to pop() as much work as possible
+    fn enqueue(&self, work: SendMiddlewareTask<Next, EM>) {
+        self.sender.send(work).unwrap();
+        self.work_if_needed();
+    }
+
+    fn work_if_needed(&self) {
+        if self
+            .is_working
+            .compare_exchange(
+                false,
+                true,
+                std::sync::atomic::Ordering::SeqCst,
+                std::sync::atomic::Ordering::SeqCst,
+            )
+            .is_ok()
+        {
+            // No one else is working, let's get going
+            self.clone().work();
+
+            self.is_working
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+            // There could be a situation in which is_working is about to be set to false.
+            // and someone is enqueuing work.
+            // This is why we work again, just in case.
+            // In the worst case scenario we start to work and yield immediately because there is nothing to do.
+            // In the best case scenario we catch some more work and execute it immediately
+            self.clone().work();
+        }
+    }
+
+    fn work(self) {
+        // No one else is doing the work, let's get to it
+        while let Ok(MiddlewareTask(maybe_middleware, effects_to_process, return_effects)) =
+            self.receiver.try_recv()
+        {
+            HandleEffectLayer::process_known_effects_with(
+                &self,
+                &maybe_middleware,
+                effects_to_process,
+                &return_effects,
+            );
         }
     }
 }

--- a/crux_core/src/middleware/mod.rs
+++ b/crux_core/src/middleware/mod.rs
@@ -109,7 +109,7 @@ pub trait Layer: Send + Sync + Sized {
     fn handle_effects_using<EM>(self, middleware: EM) -> HandleEffectLayer<Self, EM>
     where
         EM: EffectMiddleware<Self::Effect> + Send + Sync + 'static,
-        Self::Effect: TryInto<Request<EM::Op>, Error = Self::Effect>,
+        Self::Effect: TryInto<Request<EM::Op>, Error = Self::Effect> + Send,
     {
         HandleEffectLayer::new(self, middleware)
     }

--- a/crux_core/tests/middleware_overflow.rs
+++ b/crux_core/tests/middleware_overflow.rs
@@ -1,0 +1,90 @@
+use crux_core::capability::Operation;
+use crux_core::macros::effect;
+use crux_core::middleware::{EffectMiddleware, Layer};
+use crux_core::render::RenderOperation;
+use crux_core::{Command, Core, Request, RequestHandle};
+use facet::Facet;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default)]
+pub struct App;
+
+impl crux_core::App for App {
+    type Effect = Effect;
+    type Event = Event;
+    type Model = Model;
+    type ViewModel = ViewModel;
+
+    fn update(&self, _: Event, _: &mut Model) -> Command<Effect, Event> {
+        Command::new(async |ctx| {
+            for _ in 0..100_000 {
+                ctx.request_from_shell(PingOperation).await;
+            }
+        })
+    }
+
+    fn view(&self, _: &Model) -> Self::ViewModel {
+        ViewModel
+    }
+}
+
+#[derive(Facet, Serialize, Deserialize)]
+pub struct PingOperation;
+
+impl Operation for PingOperation {
+    type Output = PingOutput;
+}
+
+#[derive(Facet, Serialize, Deserialize)]
+pub struct PingOutput;
+
+pub struct PingMiddleware;
+
+impl<Effect> EffectMiddleware<Effect> for PingMiddleware
+where
+    Effect: TryInto<Request<PingOperation>, Error = Effect>,
+{
+    type Op = PingOperation;
+
+    fn try_process_effect_with(
+        &self,
+        effect: Effect,
+        resolve: impl FnOnce(&mut RequestHandle<PingOutput>, PingOutput) + Send + 'static,
+    ) -> Result<(), Effect> {
+        let mut request = effect.try_into()?;
+
+        resolve(&mut request.handle, PingOutput);
+
+        Ok(())
+    }
+}
+
+#[effect(facet_typegen)]
+pub enum Effect {
+    Ping(PingOperation),
+    Render(RenderOperation),
+}
+
+#[derive(Facet, Serialize, Deserialize)]
+#[repr(C)]
+pub enum Event {
+    Init,
+}
+
+#[derive(Default)]
+pub struct Model;
+
+#[derive(Facet, Serialize, Deserialize)]
+pub struct ViewModel;
+
+#[test]
+fn test() {
+    let effects = Core::<App>::new()
+        .handle_effects_using(PingMiddleware)
+        .update(Event::Init, |_| todo!());
+
+    assert!(
+        effects.is_empty(),
+        "All effects must have been dealt with by the middleware"
+    );
+}


### PR DESCRIPTION
Fixes #492

This changeset adds a worker and a queue to ensure middleware and core back and forth calls via callback won't eventually cause a stack overflow.

This probably needs to be iterated on as I've:
- Added a `Send` bound to `Effect`
- cloned a lot of things
- agressively used SeqCst ordering which might not be that needed.

There is probably room for improvement, happy to iterate if you have any ideas

Edit: The `Send` bound is probably needed as I'm sending effects across the queue. I would assume it not being completely breaking since I cannot find a usecase for `Effects` not being `Send`, they're meant to make it to middlewares, and / or to the shell eventually 🤔.

Please correct me if I'm wrong here!