### PR TITLE
fix: Make sure middlewares cannot run synchronously.

### DIFF
--- a/crux_core/tests/middleware_overflow.rs
+++ b/crux_core/tests/middleware_overflow.rs
@@ -1,0 +1,122 @@
+use crux_core::capability::Operation;
+use crux_core::macros::effect;
+use crux_core::middleware::{EffectMiddleware, Layer};
+use crux_core::render::RenderOperation;
+use crux_core::{Command, Core, Request, RequestHandle};
+use facet::Facet;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default)]
+pub struct App;
+
+impl crux_core::App for App {
+    type Effect = Effect;
+    type Event = Event;
+    type Model = Model;
+    type ViewModel = ViewModel;
+
+    fn update(&self, _: Event, _: &mut Model) -> Command<Effect, Event> {
+        Command::new(async |ctx| {
+            for _ in 0..100_000 {
+                ctx.request_from_shell(PingOperation).await;
+            }
+        })
+    }
+
+    fn view(&self, _: &Model) -> Self::ViewModel {
+        ViewModel
+    }
+}
+
+#[derive(Facet, Serialize, Deserialize)]
+pub struct PingOperation;
+
+impl Operation for PingOperation {
+    type Output = PingOutput;
+}
+
+#[derive(Facet, Serialize, Deserialize)]
+pub struct PingOutput;
+
+pub struct PingMiddleware {
+    sync: bool,
+}
+
+impl PingMiddleware {
+    fn sync() -> Self {
+        Self { sync: true }
+    }
+    fn spawned() -> Self {
+        Self { sync: false }
+    }
+}
+
+impl<Effect> EffectMiddleware<Effect> for PingMiddleware
+where
+    Effect: TryInto<Request<PingOperation>, Error = Effect>,
+{
+    type Op = PingOperation;
+
+    fn try_process_effect_with(
+        &self,
+        effect: Effect,
+        resolve: impl FnOnce(&mut RequestHandle<PingOutput>, PingOutput) + Send + 'static,
+    ) -> Result<(), Effect> {
+        let mut request = effect.try_into()?;
+
+        if self.sync {
+            resolve(&mut request.handle, PingOutput);
+        } else {
+            std::thread::spawn(move || {
+                resolve(&mut request.handle, PingOutput);
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[effect(facet_typegen)]
+pub enum Effect {
+    Ping(PingOperation),
+    Render(RenderOperation),
+}
+
+#[derive(Facet, Serialize, Deserialize)]
+#[repr(C)]
+pub enum Event {
+    Init,
+}
+
+#[derive(Default)]
+pub struct Model;
+
+#[derive(Facet, Serialize, Deserialize)]
+pub struct ViewModel;
+
+#[test]
+#[should_panic(
+    expected = "Blocking middleware detected. Middlewares must not block the crux runtime. Make sure the middleware runs in a separate task."
+)]
+fn test_sync() {
+    let effects = Core::<App>::new()
+        .handle_effects_using(PingMiddleware::sync())
+        .update(Event::Init, |_| todo!());
+
+    assert!(
+        effects.is_empty(),
+        "All effects must have been dealt with by the middleware"
+    );
+}
+
+#[test]
+fn test_spawned() {
+    let effects = Core::<App>::new()
+        .handle_effects_using(PingMiddleware::spawned())
+        .update(Event::Init, |_| todo!());
+
+    assert!(
+        effects.is_empty(),
+        "All effects must have been dealt with by the middleware"
+    );
+}


### PR DESCRIPTION
Fixes #492

This change set prevents middlewares from returning synchronously, and hints that implementers must either:
- run the middleware logic in a separate task to prevent stalling the crux runtime
- run the sync logic in the capability definition, and not in the middleware