### PR TITLE
feat: expose root waker

### DIFF
--- a/crux_core/src/command/mod.rs
+++ b/crux_core/src/command/mod.rs
@@ -592,6 +592,11 @@ where
             aborted: self.aborted.clone(),
         }
     }
+
+    #[must_use]
+    pub(crate) fn waker(&self) -> &AtomicWaker {
+        &self.waker
+    }
 }
 
 impl<Effect, Event> FromIterator<Command<Effect, Event>> for Command<Effect, Event>

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -4,6 +4,7 @@ mod resolve;
 
 use std::collections::VecDeque;
 use std::sync::{Mutex, RwLock};
+use std::task::Waker;
 
 pub use effect::{Effect, EffectFFI};
 pub use request::Request;
@@ -35,6 +36,7 @@ where
     app: A,
 
     // internals
+    root_waker: Option<Waker>,
     root_command: Mutex<Command<A::Effect, A::Event>>,
 }
 // ANCHOR_END: core
@@ -57,6 +59,7 @@ where
         Self {
             model: RwLock::default(),
             app: A::default(),
+            root_waker: None,
             root_command: Mutex::new(Command::done()),
         }
     }
@@ -79,8 +82,20 @@ where
         Self {
             model: RwLock::new(model),
             app,
+            root_waker: None,
             root_command: Mutex::new(Command::done()),
         }
+    }
+
+    /// Register a [`Waker`] that gets called every time a task spawned on the
+    /// runtime is ready to progress.
+    ///
+    /// This comes handy for injecting async dependencies that you can't model
+    /// via effects - the waker should then just call [`Self::process()`].
+    #[must_use]
+    pub fn with_waker(mut self, waker: Waker) -> Self {
+        self.root_waker = Some(waker);
+        self
     }
 
     /// Run the app's `update` function with a given `event`, returning a vector of
@@ -139,13 +154,28 @@ where
     }
     // ANCHOR_END: resolve
 
+    /// Process pending tasks.
+    ///
+    /// This is called automatically as a part of [`Self::process_event()`] and
+    /// [`Self::resolve()`], so usually there's no need for you to call this
+    /// function.
+    ///
+    /// See: [`Self::with_waker()`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inner `RwLock` was poisoned.
     // used in docs/internals/runtime.md
     // ANCHOR: process
-    pub(crate) fn process(&self) -> Vec<A::Effect> {
+    pub fn process(&self) -> Vec<A::Effect> {
         let mut root_command = self
             .root_command
             .lock()
             .expect("Capability runtime lock was poisoned");
+
+        if let Some(waker) = &self.root_waker {
+            root_command.waker().register(waker);
+        }
 
         let mut events: VecDeque<_> = root_command.events().collect();
 

--- a/crux_core/src/middleware/bridge.rs
+++ b/crux_core/src/middleware/bridge.rs
@@ -71,6 +71,15 @@ where
         self.process(Some(id), output, requests_out)
     }
 
+    /// Process any tasks in the effect runtime of the Core, which are able to proceed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`BridgeError`] when serialization fails.
+    pub fn process_tasks(&self, requests_out: &mut Vec<u8>) -> Result<(), BridgeError<Format>> {
+        self.process(None, &[], requests_out)
+    }
+
     fn process(
         &self,
         id: Option<EffectId>,
@@ -99,10 +108,14 @@ where
 
         let effects = match id {
             None => {
-                let shell_event =
-                    Format::deserialize(event_or_output).map_err(BridgeError::DeserializeEvent)?;
+                if event_or_output.is_empty() {
+                    self.next.process_tasks(effect_callback)
+                } else {
+                    let shell_event = Format::deserialize(event_or_output)
+                        .map_err(BridgeError::DeserializeEvent)?;
 
-                self.next.update(shell_event, effect_callback)
+                    self.next.update(shell_event, effect_callback)
+                }
             }
             Some(id) => {
                 self.registry.resume(id, event_or_output)?;


### PR DESCRIPTION
This merge request provides `Core::with_waker()` that allows to register a waker attached to the root command.

Having such waker comes handy for injecting async dependencies that you can't (or don't bother to) model via effects - with the code here you can do:

```rust
pub struct App {
    db: Arc<dyn Database>,
}

impl App {
    pub fn new(db: Arc<dyn Database>) -> Self {
        Self { db }
    }
}

impl crux_core::App for App {
    /* ... */
     
    fn update(&self, event: Event, model: &mut Model) -> Command<Effect, Event> {
        let db = self.db.clone();

        Command::new(async |ctx| {
            db.something().await;
        })
    }

   /* ... */
}
```
... with an example integration being:
```rust
use futures::task::{self, ArcWake};
use std::sync::Arc;
use tokio::sync::Notify;

#[derive(Default)]
struct NotifyWaker(Notify);

impl ArcWake for NotifyWaker {
    fn wake_by_ref(this: &Arc<Self>) {
        this.0.notify_one();
    }
}

// ---

let waker = Arc::new(NotifyWaker::default());

let core = {
    let database = Database::new().await?;  

    let app = App::new(Arc::new(database));
    let model = Default::default();
    let waker = task::waker(waker.clone());

    Core::new_with(app, model)
        .with_waker(waker)
};

// use tokio::select! etc. for listening on the waker and then do core.process() / core.process_tasks()
```