### PR TITLE
Book stable corrections

### DIFF
--- a/docs/src/part-1/basic_app.md
+++ b/docs/src/part-1/basic_app.md
@@ -60,7 +60,7 @@ eventually be crossing the FFI boundary. We will get to that soon.
 
 Model holds our application's internal state. You can probably guess what this will look like:
 
-```rust
+```rust,noplayground
 #[derive(Default)]
 pub struct Model {
     count: isize,
@@ -93,11 +93,11 @@ some navigation into the mix in Part II.
 For now, the counter has no side effects. Except it wants to update the user interface, and
 that is also a side effect. We'll go with this:
 
-```rust
+```rust,noplayground
 use crux_core::macros::effect;
 use crux_core::render::RenderOperation;
 
-#[effect(typegen)]
+#[effect]
 #[derive(Debug)]
 pub enum Effect {
     Render(RenderOperation),

--- a/docs/src/part-1/getting_started.md
+++ b/docs/src/part-1/getting_started.md
@@ -56,7 +56,7 @@ edition = "2024"
 rust-version = "1.88"
 
 [workspace.dependencies]
-anyhow = "1.0.100"
+anyhow = "1.0.102"
 crux_core = "0.17.0"
 serde = "1.0.228"
 ```
@@ -108,15 +108,17 @@ for your app code.
 
 For now, the `lib.rs` file looks as follows:
 
-```rust
+```rust,noplayground
 // src/lib.rs
-pub mod app;
+mod app;
+
+pub use app::*;
 ```
 
 and `app.rs` can be empty, but let's put our app's main type in it,
 call it `Counter`:
 
-```rust
+```rust,noplayground
 // src/app.rs
 
 #[derive(Default)]

--- a/docs/src/part-1/shell.md
+++ b/docs/src/part-1/shell.md
@@ -21,13 +21,13 @@ Crux provides code generation support for all of the above.
 
 ```admonish note
 It isn't in any way actual black magic. What happens is Crux exposes FFI calls taking and returning
-the values serialized with `bincode` (by default), and generated "foreign" (Swift, Kotlin, ...)
+the values serialized with `bincode` (by default), and generated "foreign" (Swift, Kotlin, TypeScript, ...)
 types handling the foreign side of the serialization.
 
 Yes, this introduces some extra work to the FFI, but generally, for each user interaction we
 make a relatively small number of round-trips (almost certainly less than ten), and our benchmarks say
 we can make thousands of them per second. The real throughput _is_ dependent on how much data gets serialized,
-but it only becomes a problem with _really_ large messages, and advanced workarounds exists. You
+but it only becomes a problem with _really_ large messages, and advanced workarounds exist. You
 most likely don't need to worry about it, at least not for now.
 ```
 
@@ -53,7 +53,7 @@ A lot has changed! The key things we added are:
 
 And since we've declared the `codegen` target, we need to add the code for it.
 
-```rust
+```rust,noplayground
 // shared/src/bin/codegen.rs
 {{#include ../../../examples/simple_counter/shared/src/bin/codegen.rs}}
 ```
@@ -78,6 +78,39 @@ For most platforms we use UniFFI, except for WebAssembly, where we use `wasm_bin
 
 **codegen** – you guessed it, "code generation" – is the two things above combined.
 
+## Updating our `app.rs`
+
+There's a few things we need to do to our `app.rs` module to support typegen. The first thing we need to do is update the annotation of the `Effect` type to tell our `effect` attribute macro that we want to use the Facet-based typegen.
+
+```rust,noplayground
+#[derive(Debug)]
+#[effect(facet_typegen)] // previously #[effect]
+pub enum Effect {
+    Render(RenderOperation),
+}
+```
+
+We also need to annotate the other types that cross the FFI boundary with the `Facet` derive macro. Note that we are using Facet v0.31 (with `crux_core` v0.17), and so we also need to specify a layout for enums, e.g. `repr(C)` or `repr(u8)`.
+
+```rust,noplayground
+use facet::Facet;
+
+// derive Facet and specify layout
+#[derive(Facet, Serialize, Deserialize, Clone, Debug)]
+#[repr(C)]
+pub enum Event {
+    Increment,
+    Decrement,
+    Reset,
+}
+
+// derive Facet
+#[derive(Facet, Serialize, Deserialize, Clone, Default)]
+pub struct ViewModel {
+    pub count: String,
+}
+```
+
 ## Bindings code
 
 Now we need to add the Rust side of the bindings into our code. Update your `lib.rs` to look like this:
@@ -92,7 +125,7 @@ in use.
 
 More importantly, it introduced a new `ffi.rs` module. Let's look at it closer:
 
-```rust
+```rust,noplayground
 // shared/src/ffi.rs
 {{#include ../../../examples/simple_counter/shared/src/ffi.rs}}
 ```

--- a/docs/src/part-1/shell/android/android.md
+++ b/docs/src/part-1/shell/android/android.md
@@ -33,7 +33,7 @@ Open Android Studio and create a new project, for "Phone and Tablet", of type
 - "Package name": `com.example.simple_counter`
 - "Save Location": a directory called `Android` at the root of our monorepo
 - "Minimum SDK" `API 34`
-- "Build configuration language": `Groovy DSL (build.gradle)`
+- "Build configuration language": `Kotlin DSL (build.gradle.kts)`
 
 Your repo's directory structure might now look something like this (some files
 elided):
@@ -42,7 +42,7 @@ elided):
 .
 ├── Android
 │  ├── app
-│  │  ├── build.gradle
+│  │  ├── build.gradle.kts
 │  │  ├── libs
 │  │  └── src
 │  │     └── main
@@ -52,7 +52,7 @@ elided):
 │  │              └── example
 │  │                 └── simple_counter
 │  │                    └── MainActivity.kt
-│  ├── build.gradle
+│  ├── build.gradle.kts
 │  ├── gradle.properties
 │  ├── local.properties
 │  └── settings.gradle
@@ -82,18 +82,18 @@ Under `File -> New -> New Module`, choose "Android Library" and give it the "Mod
 `shared`. Set the "Package name" to match the one from your
 `/shared/uniffi.toml`, which in this example is `com.example.simple_counter.shared`.
 
-Again, set the "Build configuration language" to `Groovy DSL (build.gradle)`.
+Again, set the "Build configuration language" to `Kotlin DSL (build.gradle.kts)`.
 
 For more information on how to add an Android library see
 <https://developer.android.com/studio/projects/android-library>.
 
 We can now add this library as a _dependency_ of our app.
 
-Edit the **app**'s `build.gradle` (`/Android/app/build.gradle`) to look like
+Edit the **app**'s `build.gradle.kts` (`/Android/app/build.gradle.kts`) to look like
 this:
 
 ```gradle
-{{#include ../../../../examples/simple_counter/Android/app/build.gradle}}
+{{#include ../../../../../examples/simple_counter/Android/app/build.gradle.kts}}
 ```
 
 ````admonish
@@ -103,7 +103,7 @@ will need to ensure this is kept up to date.
 Our catalog (`Android/gradle/libs.versions.toml`) will end up looking like this:
 
 ```toml
-{{#include ../../../../examples/simple_counter/Android/gradle/libs.versions.toml}}
+{{#include ../../../../../examples/simple_counter/Android/gradle/libs.versions.toml}}
 ```
 ````
 
@@ -130,23 +130,23 @@ Add the four rust android toolchains to your system:
 $ rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 ```
 
-Edit the **project**'s `build.gradle` (`/Android/build.gradle`) to look like
+Edit the **project**'s `build.gradle.kts` (`/Android/build.gradle.kts`) to look like
 this:
 
 ```gradle
-{{#include ../../../../examples/simple_counter/Android/build.gradle}}
+{{#include ../../../../../examples/simple_counter/Android/build.gradle.kts}}
 ```
 
-Edit the **library**'s `build.gradle` (`/Android/shared/build.gradle`) to look
+Edit the **library**'s `build.gradle.kts` (`/Android/shared/build.gradle.kts`) to look
 like this:
 
 ```gradle
-{{#include ../../../../examples/simple_counter/Android/shared/build.gradle}}
+{{#include ../../../../../examples/simple_counter/Android/shared/build.gradle.kts}}
 
 ```
 
 ```admonish warning title="Sharp edge"
-You will need to set the `ndkVersion` to one you have installed, go to "**Tools, SDK Manager, SDK Tools**" and check "**Show Package Details**" to get your installed version, or to install the version matching `build.gradle` above.
+You will need to set the `ndkVersion` to one you have installed, go to "**Tools, SDK Manager, SDK Tools**" and check "**Show Package Details**" to get your installed version, or to install the version matching `build.gradle.kts` above.
 ```
 
 ```admonish tip
@@ -252,7 +252,7 @@ so we just handle this render effect by updating the published view model from
 the core.
 
 ```swift
-{{#include ../../../../examples/simple_counter/Android/app/src/main/java/com/example/simple_counter/Core.kt}}
+{{#include ../../../../../examples/simple_counter/Android/app/src/main/java/com/crux/examples/simplecounter/Core.kt}}
 ```
 
 ```admonish tip
@@ -268,7 +268,7 @@ Edit `/Android/app/src/main/java/com/example/simple_counter/MainActivity.kt` to
 look like the following:
 
 ```kotlin
-{{#include ../../../../examples/simple_counter/Android/app/src/main/java/com/example/simple_counter/MainActivity.kt}}
+{{#include ../../../../../examples/simple_counter/Android/app/src/main/java/com/crux/examples/simplecounter/MainActivity.kt}}
 ```
 
 ```admonish success

--- a/docs/src/part-1/shell/web/leptos.md
+++ b/docs/src/part-1/shell/web/leptos.md
@@ -40,7 +40,7 @@ Now we can `cd` into the `web-leptos` directory and start fleshing out our
 project. Let's add some dependencies to `shared/Cargo.toml`.
 
 ```toml
-{{#include ../../../../examples/simple_counter/web-leptos/Cargo.toml}}
+{{#include ../../../../../examples/simple_counter/web-leptos/Cargo.toml}}
 ```
 
 ```admonish tip
@@ -54,7 +54,7 @@ the `get()` and `update()` functions explicitly.
 We'll also need a file called `index.html`, to serve our app.
 
 ```html
-{{#include ../../../../examples/simple_counter/web-leptos/index.html}}
+{{#include ../../../../../examples/simple_counter/web-leptos/index.html}}
 ```
 
 ## Create some UI
@@ -96,7 +96,7 @@ in the same memory space), we do not need to serialize and deserialize the data
 that we pass between them. We can just pass the data directly.
 
 ```rust,noplayground
-{{#include ../../../../examples/simple_counter/web-leptos/src/core.rs}}
+{{#include ../../../../../examples/simple_counter/web-leptos/src/core.rs}}
 ```
 
 ```admonish tip
@@ -115,7 +115,7 @@ event). We also create an effect that sends these events into the core whenever
 they are raised.
 
 ```rust,noplayground
-{{#include ../../../../examples/simple_counter/web-leptos/src/main.rs}}
+{{#include ../../../../../examples/simple_counter/web-leptos/src/main.rs}}
 ```
 
 ## Build and serve our app

--- a/docs/src/part-1/shell/web/react.md
+++ b/docs/src/part-1/shell/web/react.md
@@ -167,7 +167,7 @@ the core and the shell. This is because the core is running in a separate
 WebAssembly instance, and so we can't just pass the data directly.
 
 ```typescript
-{{#include ../../../../examples/simple_counter/web-nextjs/src/app/core.ts}}
+{{#include ../../../../../examples/simple_counter/web-nextjs/src/app/core.ts}}
 ```
 
 ```admonish tip
@@ -187,7 +187,7 @@ WebAssembly core and sends it an initial event. Notice that we pass the
 response to a render effect from the core.
 
 ```typescript
-{{#include ../../../../examples/simple_counter/web-nextjs/src/app/page.tsx}}
+{{#include ../../../../../examples/simple_counter/web-nextjs/src/app/page.tsx}}
 ```
 
 Now all we need is some CSS. First add the `Bulma` package, and then import it
@@ -198,7 +198,7 @@ pnpm add bulma
 ```
 
 ```typescript
-{{#include ../../../../examples/simple_counter/web-nextjs/src/app/layout.tsx}}
+{{#include ../../../../../examples/simple_counter/web-nextjs/src/app/layout.tsx}}
 ```
 
 ## Build and serve our app

--- a/docs/src/part-4/bridge.md
+++ b/docs/src/part-4/bridge.md
@@ -60,7 +60,8 @@ interested in the gory details. For our purposes, the type definition will
 suffice.
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/bridge/mod.rs:bridge_with_serializer}}
+// Note: BridgeWithSerializer has been refactored into Bridge<A, F>.
+// See crux_core/src/bridge/mod.rs for the current implementation.
 ```
 
 The bridge holds an instance of the `Core` and a `ResolveRegistry` to store the
@@ -152,7 +153,9 @@ uniffi::include_scaffolding!("shared");
 which refers to the `shared.udl` file in the same folder
 
 ```
-{{#include ../../../examples/bridge_echo/shared/src/shared.udl}}
+// Note: The shared.udl file has been removed. UniFFI now uses
+// uniffi::setup_scaffolding!() in lib.rs and a uniffi.toml config file.
+// See examples/bridge_echo/shared/uniffi.toml for the current configuration.
 ```
 
 This is UniFFI's interface definition used to generate the scaffolding for the
@@ -162,14 +165,16 @@ and their counterparts in the "foreign" languages (like Swift or Kotlin).
 The scaffolding is built in the `build.rs` script of the crate
 
 ```rust,no_run,noplayground
-{{#include ../../../examples/bridge_echo/shared/build.rs}}
+// Note: build.rs has been removed. UniFFI scaffolding is now generated
+// via the uniffi::setup_scaffolding!() macro in lib.rs.
 ```
 
 The foreign language code is built by an additional binary target for the same
 crate, in `src/bin/uniffi-bindgen.rs`
 
 ```rust,no_run,noplayground
-{{#include ../../../examples/bridge_echo/shared/src/bin/uniffi-bindgen.rs}}
+// Note: uniffi-bindgen.rs has been replaced by src/bin/codegen.rs.
+// See examples/bridge_echo/shared/src/bin/codegen.rs for the current implementation.
 ```
 
 this builds a CLI which can be used as part of the build process for clients of

--- a/docs/src/part-4/runtime.md
+++ b/docs/src/part-4/runtime.md
@@ -135,7 +135,8 @@ The first step for anything to happen is spawning a task from a capability. Each
 capability is created with a `CapabilityContext`. This is the definition:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/mod.rs:capability_context}}
+// Note: CapabilityContext has been removed in favour of the Command-based API.
+// See crux_core/src/command/ for the current implementation.
 ```
 
 There are a couple of sending ends of channels for requests and events, which we
@@ -143,7 +144,9 @@ will get to soon, and also a spawner, from the executor module. The `Spawner`
 looks like this:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/executor.rs:spawner}}
+// Note: The capability executor has been refactored.
+// crux_core/src/capability/executor.rs no longer exists.
+// The executor is now part of the Command system in crux_core/src/command/executor.rs.
 ```
 
 also holding a sending end of a channel, this one for `Task`s.
@@ -153,13 +156,15 @@ end of the tasks channel, because tasks need to be able to submit themselves
 when awoken.
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/executor.rs:task}}
+// Note: The Task type has been refactored.
+// See crux_core/src/command/executor.rs for the current implementation.
 ```
 
 Tasks are spawned by the Spawner as follows:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/executor.rs:spawning}}
+// Note: Task spawning has been refactored.
+// See crux_core/src/command/executor.rs for the current implementation.
 ```
 
 after constructing a task, it is submitted using the task sender.
@@ -167,7 +172,8 @@ after constructing a task, it is submitted using the task sender.
 The final piece of the puzzle is the executor itself:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/executor.rs:executor}}
+// Note: The Executor type has been refactored.
+// See crux_core/src/command/executor.rs for the current implementation.
 ```
 
 This is the receiving end of the channel from the spawner.
@@ -175,7 +181,8 @@ This is the receiving end of the channel from the spawner.
 The executor has a single public method, `run_all`:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/executor.rs:run_all}}
+// Note: run_all has been refactored into run_until_settled.
+// See crux_core/src/command/executor.rs for the current implementation.
 ```
 
 besides the locking and waker mechanics, the gist is quite simple - while there
@@ -186,7 +193,8 @@ call. The `waker_ref` creates a waker which, when asked to wake up, will call
 this method on the task:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/executor.rs:wake}}
+// Note: The waker implementation has been refactored.
+// See crux_core/src/command/executor.rs for the current implementation.
 ```
 
 this is where the task resubmits itself for processing on the next run.
@@ -297,7 +305,8 @@ We've already mentioned the resolve function itself briefly, but for
 completeness, here's an example from `request_from_shell`:
 
 ```rust,no_run,noplayground
-{{#include ../../../crux_core/src/capability/shell_request.rs:resolve}}
+// Note: crux_core/src/capability/shell_request.rs no longer exists.
+// The resolve callback is now part of RequestHandle in crux_core/src/core/resolve.rs.
 ```
 
 Bar the locking and sharing mechanics, all it does is update the state of the


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — for review only
### fix(docs): update Part 1 docs and fix broken `{{#include}}` directives in mdbook

`mdbook build` was failing with a large number of errors due to stale `{{#include}}` paths, and several pages in Part 1 were out of date with the 0.17 release. This PR fixes all of that.

---

#### `docs/src/part-1/getting_started.md`

- Bumped the `anyhow` workspace dependency example to `1.0.102`.
- `lib.rs` snippet: changed `pub mod app` to `mod app` + `pub use app::*` to match the current pattern.
- Changed bare ` ```rust ` fences to ` ```rust,noplayground ` throughout to avoid the playground button appearing on non-runnable snippets.

#### `docs/src/part-1/basic_app.md`

- Same ` ```rust ` → ` ```rust,noplayground ` fix.
- Updated the `#[effect]` attribute: the example was using `#[effect(typegen)]` which has been superseded — changed to `#[effect]` (with a separate section below explaining `#[effect(facet_typegen)]`).

#### `docs/src/part-1/shell.md`

- Added TypeScript to the list of generated "foreign" languages in the FFI note.
- Fixed a typo: "workarounds exists" → "workarounds exist".
- Changed bare ` ```rust ` fences to ` ```rust,noplayground `.
- Added a new **"Updating our `app.rs`"** section explaining the changes needed for Facet-based typegen in 0.17: switching to `#[effect(facet_typegen)]`, deriving `Facet` on `Event` and `ViewModel`, and adding the required `repr` layout annotations.

---

#### `docs/src/part-1/shell/android/android.md`

- **Wrong path depth**: all `{{#include}}` paths used `../../../../examples/…` which resolves to `docs/examples/…` (one level too shallow). Fixed to `../../../../../examples/…` to correctly reach the repo root.
- **Groovy → Kotlin DSL**: the `simple_counter` Android example has migrated to Kotlin DSL (`.gradle.kts`). Updated all `{{#include}}` paths and all prose references (`build.gradle` → `build.gradle.kts`, `Groovy DSL` → `Kotlin DSL`), including the directory tree and the `ndkVersion` warning.
- **Package name change**: the example app's package was renamed from `com.example.simple_counter` to `com.crux.examples.simplecounter`, so the paths to `Core.kt` and `MainActivity.kt` were updated accordingly.

#### `docs/src/part-1/shell/web/react.md` and `leptos.md`

- Same wrong path depth fix as above (`../../../../` → `../../../../../`). The target files exist and were fine; only the include paths were broken.

#### `docs/src/part-4/runtime.md`

- `crux_core/src/capability/executor.rs` and `crux_core/src/capability/shell_request.rs` no longer exist — the old `CapabilityContext` / `Spawner` / `Task` executor was replaced by the `Command`-based system in `crux_core/src/command/`. The seven broken `{{#include}}` directives are replaced with inline notes pointing to the new location. (This page already carries an "outdated, needs rewriting" admonish warning.)

#### `docs/src/part-4/bridge.md`

- The `BridgeWithSerializer` type has been refactored into `Bridge<A, F>` — the `bridge_with_serializer` anchor no longer exists in `bridge/mod.rs`.
- The `bridge_echo` example has dropped the `.udl`-based UniFFI approach in favour of `uniffi::setup_scaffolding!()` + `uniffi.toml`, so `shared.udl`, `build.rs`, and `src/bin/uniffi-bindgen.rs` no longer exist. The broken includes are replaced with notes. (This page also already carries an "outdated, needs rewriting" admonish warning.)