### PR TITLE
docs: changelog for 0.18

### DIFF
--- a/crux_cli/CHANGELOG.md
+++ b/crux_cli/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚙️ Miscellaneous Tasks
+
+- Update to `facet_generate` 0.16 and `facet` 0.44. No changes to the `crux bindgen` CLI surface.
+- Align with `crux_core` 0.18.0.
+
 ## [0.2.0](https://github.com/redbadger/crux/compare/crux_cli-v0.1.1...crux_cli-v0.2.0) - 2026-03-20
 
 ### ⚠️ Breaking Changes

--- a/crux_core/CHANGELOG.md
+++ b/crux_core/CHANGELOG.md
@@ -10,6 +10,24 @@ and this project adheres to
 
 ### 🚀 Features
 
+**This is a breaking release.**
+
+#### Major Breaking Changes:
+
+- **`facet_generate` 0.16 / `facet` 0.44**: Runtime installation is now automatic. Remove
+  `.add_runtimes()` from any `Config::builder(...)` chain in your `codegen.rs` — it is no longer
+  available. No other call-site changes are needed; `typegen.swift(&config)`,
+  `typegen.kotlin(&config)`, `typegen.typescript(&config)`, and `typegen.csharp(&config)` work the
+  same as before.
+- **`typegen_extensions/` is no longer read from disk**: Template files for the `serde` typegen
+  backend are now embedded into the library at compile time, so type generation works in
+  sandboxed builds (e.g. Bazel) where the source tree may not exist on the host running `codegen`.
+  If you placed a `typegen_extensions/` directory next to your `build.rs` to override templates,
+  that override no longer takes effect — fork or contribute upstream instead. If you didn't
+  customize templates, no action is required.
+
+#### New Features:
+
 - **C# Typegen on `facet_generate`**: The newer `facet_generate` typegen backend now exposes
   `CodeGenerator::csharp(&Config)`, producing an `MSBuild` project targeting `net10.0` with a
   `CommunityToolkit.Mvvm` base reference and a Bincode runtime.

--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### ⚙️ Miscellaneous Tasks
+
+- Align with `crux_core` 0.18.0 and update to `facet_generate` 0.16 / `facet` 0.44. No public
+  API changes; users who consume only the `crux_http` API (e.g. `Http::get(...)`) need no
+  migration. Users running `crux_core` typegen on `crux_http` types should follow the
+  `crux_core` 0.18.0 migration notes.
+
 ## [0.16.0](https://github.com/redbadger/crux/compare/crux_http-v0.15.0...crux_http-v0.16.0) - 2026-03-20
 
 ### 🚀 Features

--- a/crux_kv/CHANGELOG.md
+++ b/crux_kv/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### ⚙️ Miscellaneous Tasks
+
+- Align with `crux_core` 0.18.0. No public API changes.
+
 ## [0.11.0](https://github.com/redbadger/crux/compare/crux_kv-v0.10.0...crux_kv-v0.11.0) - 2026-03-20
 
 ### 🚀 Features

--- a/crux_macros/CHANGELOG.md
+++ b/crux_macros/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### ⚙️ Miscellaneous Tasks
+
+- Update to `facet_generate` 0.16 and `facet` 0.44. No changes to the public derive surface
+  (`#[derive(Effect)]`, `#[effect]`); no migration needed for downstream apps.
+- Align with `crux_core` 0.18.0.
+
 ## [0.8.0](https://github.com/redbadger/crux/compare/crux_macros-v0.7.0...crux_macros-v0.8.0) - 2026-03-20
 
 ### 🚀 Features

--- a/crux_platform/CHANGELOG.md
+++ b/crux_platform/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### ⚙️ Miscellaneous Tasks
+
+- Align with `crux_core` 0.18.0 and update to `facet_generate` 0.16 / `facet` 0.44. No public
+  API changes.
+
 ## [0.8.0](https://github.com/redbadger/crux/compare/crux_platform-v0.7.0...crux_platform-v0.8.0) - 2026-03-20
 
 ### 🚀 Features

--- a/crux_time/CHANGELOG.md
+++ b/crux_time/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### ⚙️ Miscellaneous Tasks
+
+- Align with `crux_core` 0.18.0 and update to `facet_generate` 0.16 / `facet` 0.44. No public
+  API changes.
+
 ## [0.15.0](https://github.com/redbadger/crux/compare/crux_time-v0.14.0...crux_time-v0.15.0) - 2026-03-20
 
 ### 🚀 Features


### PR DESCRIPTION
This documents a changelog for what could be in 0.18, as a means of aligning on the release.