### PR TITLE
Replace `add_extensions()` with a generated `Requests` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1202,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "facet-generate-attrs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b59c82c2c40c64d157e102d4fa437394dc3768780903546129700fe5911884d"
+checksum = "3b430b495d59ffcf07dabe103a796d8d3ba809d12bb25a5960b605883835b3de"
 dependencies = [
  "facet 0.44.1",
 ]
@@ -1287,9 +1287,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7adb3e4cd72f80272b4db2ee6a6c7132e599e4b5982d6b112e41387bea2c1"
+checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
 dependencies = [
  "derive_builder",
  "facet 0.44.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ keywords = ["cross-platform-ui", "crux", "crux_core", "ffi", "wasm"]
 
 [workspace.dependencies]
 anyhow = "1.0"
-facet = "0.44"
-facet_generate = "0.16"
-facet-generate-attrs = "0.16"
+facet = "=0.44"
+facet_generate = "0.17"
+facet-generate-attrs = "0.17"
 # facet_generate = { path = "../facet-generate/crates/facet_generate" }
 # facet-generate-attrs = { path = "../facet-generate/crates/facet-generate-attrs" }
 serde = "1.0"

--- a/crux_core/src/bridge/mod.rs
+++ b/crux_core/src/bridge/mod.rs
@@ -53,6 +53,24 @@ where
 }
 // ANCHOR_END: request
 
+/// A batch of effect requests from the Core to the Shell, as serialised by
+/// [`Bridge::update`] and [`Bridge::resolve`].
+///
+/// The wire format is identical to `Vec<Request<Eff>>` (the newtype is
+/// `serde(transparent)`), so existing shell code that already deserialises
+/// a `Vec<Request>` remains binary-compatible.
+///
+/// Registering this type with the type-generation system causes the code
+/// generators to emit a `Requests` type (with a `value` field containing the
+/// list) together with a top-level `bincodeDeserialize` / `BincodeDeserialize`
+/// helper, replacing the hand-written extension files that were previously
+/// appended by `add_extensions()`.
+#[derive(Facet, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Requests<Eff>(pub Vec<Request<Eff>>)
+where
+    Eff: Serialize;
+
 /// Bridge is a core wrapper presenting the same interface as the [`Core`] but in a
 /// serialized form, using bincode as the serialization format.
 pub struct Bridge<A, F = BincodeFfiFormat>

--- a/crux_core/src/type_generation/facet.rs
+++ b/crux_core/src/type_generation/facet.rs
@@ -48,40 +48,37 @@
 //! #         }
 //! #     }
 //! # }
-//! # use std::path::PathBuf;
-//!use crux_core::type_generation::facet::{Config, TypeRegistry};
-//!use tempfile::tempdir;
-//!use shared::App;
+//! use crux_core::type_generation::facet::{Config, TypeRegistry};
+//! use tempfile::tempdir;
+//! use shared::App;
 //!
-//!  let tmp_dir = tempdir()?;
-//!  let output_root = tmp_dir.path();
+//! # fn main() -> Result<(), crux_core::type_generation::facet::TypeGenError> {
+//! let tmp_dir = tempdir()?;
+//! let output_root = tmp_dir.path();
 //!
-//!  let typegen = TypeRegistry::new().register_app::<App>()?.build()?;
+//! let typegen = TypeRegistry::new().register_app::<App>()?.build()?;
 //!
-//!  typegen.swift(
-//!      &Config::builder("SharedTypes", &output_root.join("swift"))
-//!      .add_extensions()
-//!      .build()
-//!  )?;
+//! typegen.swift(
+//!     &Config::builder("SharedTypes", &output_root.join("swift"))
+//!     .build()
+//! )?;
 //!
-//!  typegen.java(
-//!      &Config::builder("com.crux.example.counter.shared", output_root.join("java"))
-//!      .add_extensions()
-//!      .build()
-//!  )?;
+//! typegen.kotlin(
+//!     &Config::builder("com.crux.example.counter.shared", output_root.join("kotlin"))
+//!     .build()
+//! )?;
 //!
-//!  typegen.csharp(
-//!      &Config::builder("CounterApp.Shared", output_root.join("csharp"))
-//!      .add_extensions()
-//!      .build()
-//!  )?;
+//! typegen.csharp(
+//!     &Config::builder("CounterApp.Shared", output_root.join("csharp"))
+//!     .build()
+//! )?;
 //!
-//!  typegen.typescript(
-//!      &Config::builder("shared_types", output_root.join("typescript"))
-//!      .add_extensions()
-//!      .build()
-//!  )?;
-//! # Ok::<(), crux_core::type_generation::facet::TypeGenError>(())
+//! typegen.typescript(
+//!     &Config::builder("shared_types", output_root.join("typescript"))
+//!     .build()
+//! )?;
+//! # Ok(())
+//! # }
 //! ```
 use std::{
     fs::{self, File},
@@ -94,10 +91,7 @@ use facet::Facet;
 pub use facet_generate::generation::{Config, ExternalPackage, PackageLocation};
 use facet_generate::{
     Registry,
-    generation::{
-        Encoding, csharp, java, kotlin, swift,
-        typescript::{self, InstallTarget},
-    },
+    generation::{bincode::BincodePlugin, csharp, kotlin, swift, typescript},
     reflection::RegistryBuilder,
 };
 use log::info;
@@ -105,12 +99,6 @@ use serde_json::json;
 use thiserror::Error;
 
 use crate::App;
-
-macro_rules! extension_data {
-    ($path:literal) => {
-        include_str!(concat!("../../typegen_extensions/", $path))
-    };
-}
 
 #[derive(Error, Debug)]
 pub enum TypeGenError {
@@ -250,7 +238,6 @@ impl CodeGenerator {
     /// # let output_root = temp_dir().join("crux_core_typegen_doctest");
     /// typegen.swift(
     ///     &Config::builder("SharedTypes", output_root.join("swift"))
-    ///     .add_extensions()
     ///     .build()
     /// )?;
     /// # Ok::<(), crux_core::type_generation::facet::TypeGenError>(())
@@ -261,72 +248,13 @@ impl CodeGenerator {
     pub fn swift(&self, config: &Config) -> Result<(), TypeGenError> {
         info!("Generating Swift types");
         let path = config.out_dir.join(&config.package_name);
-        let sources = path.join("Sources");
 
         fs::create_dir_all(&path)?;
 
         swift::Installer::new(&config.package_name, &path)
-            .encoding(Encoding::Bincode)
+            .plugin(BincodePlugin)
             .external_packages(&config.external_packages)
             .generate(&self.0)?;
-
-        if config.add_extensions {
-            // add bincode deserialization for Vec<Request>
-            let output_dir = sources.join(&config.package_name);
-            fs::create_dir_all(&output_dir)?;
-            let mut output = File::create(output_dir.join("Requests.swift"))?;
-
-            let requests_data = extension_data!("swift/requests.swift");
-            write!(output, "{requests_data}")?;
-        }
-
-        Ok(())
-    }
-
-    /// Generates types for Java
-    /// e.g.
-    /// ```rust
-    /// # use crux_core::type_generation::facet::{Config, TypeRegistry};
-    /// # use std::env::temp_dir;
-    /// # let mut typegen = TypeRegistry::new().build()?;
-    /// # let output_root = temp_dir().join("crux_core_typegen_doctest");
-    /// typegen.java(
-    ///     &Config::builder("com.crux.example", output_root.join("java"))
-    ///     .add_extensions()
-    ///     .build()
-    /// )?;
-    /// # Ok::<(), crux_core::type_generation::facet::TypeGenError>(())
-    /// ```
-    ///
-    /// # Errors
-    /// Errors that can occur during type generation.
-    #[deprecated(
-        since = "0.17.0",
-        note = "The Java typegen is deprecated. Use Kotlin typegen instead."
-    )]
-    pub fn java(&self, config: &Config) -> Result<(), TypeGenError> {
-        info!("Generating Java types");
-        fs::create_dir_all(&config.out_dir)?;
-
-        let package_path = config.package_name.replace('.', "/");
-
-        // remove any existing generated shared types, this ensures that we remove no longer used types
-        fs::remove_dir_all(config.out_dir.join(&package_path)).unwrap_or(());
-
-        #[allow(deprecated)]
-        java::Installer::new(&config.package_name, &config.out_dir)
-            .encoding(Encoding::Bincode)
-            .external_packages(&config.external_packages)
-            .generate(&self.0)?;
-
-        if config.add_extensions {
-            let requests_data = extension_data!("java/Requests.java");
-            let requests = format!("package {};\n\n{requests_data}", config.package_name);
-
-            let output_dir = config.out_dir.join(package_path);
-            fs::create_dir_all(&output_dir)?;
-            fs::write(output_dir.join("Requests.java"), requests)?;
-        }
 
         Ok(())
     }
@@ -340,7 +268,6 @@ impl CodeGenerator {
     /// # let output_root = temp_dir().join("crux_core_typegen_doctest");
     /// typegen.kotlin(
     ///     &Config::builder("com.crux.example", output_root.join("kotlin"))
-    ///     .add_extensions()
     ///     .build()
     /// )?;
     /// # Ok::<(), crux_core::type_generation::facet::TypeGenError>(())
@@ -358,18 +285,9 @@ impl CodeGenerator {
         fs::remove_dir_all(config.out_dir.join(&package_path)).unwrap_or(());
 
         kotlin::Installer::new(&config.package_name, &config.out_dir)
-            .encoding(Encoding::Bincode)
+            .plugin(BincodePlugin)
             .external_packages(&config.external_packages)
             .generate(&self.0)?;
-
-        if config.add_extensions {
-            let requests_data = extension_data!("kotlin/Requests.kt");
-            let requests = format!("package {};\n\n{requests_data}", config.package_name);
-
-            let output_dir = config.out_dir.join(package_path);
-            fs::create_dir_all(&output_dir)?;
-            fs::write(output_dir.join("Requests.kt"), requests)?;
-        }
 
         Ok(())
     }
@@ -383,7 +301,6 @@ impl CodeGenerator {
     /// # let output_root = temp_dir().join("crux_core_typegen_doctest");
     /// typegen.csharp(
     ///     &Config::builder("CounterApp.Shared", output_root.join("csharp"))
-    ///     .add_extensions()
     ///     .build()
     /// )?;
     /// # Ok::<(), crux_core::type_generation::facet::TypeGenError>(())
@@ -401,18 +318,9 @@ impl CodeGenerator {
         fs::remove_dir_all(config.out_dir.join(&package_path)).unwrap_or(());
 
         csharp::Installer::new(&config.package_name, &config.out_dir)
-            .encoding(Encoding::Bincode)
+            .plugin(BincodePlugin)
             .external_packages(&config.external_packages)
             .generate(&self.0)?;
-
-        if config.add_extensions {
-            let requests_data = extension_data!("csharp/Requests.cs");
-            let requests = format!("namespace {}{requests_data}", config.package_name);
-
-            let output_dir = config.out_dir.join(package_path);
-            fs::create_dir_all(&output_dir)?;
-            fs::write(output_dir.join("Requests.cs"), requests)?;
-        }
 
         Ok(())
     }
@@ -426,7 +334,6 @@ impl CodeGenerator {
     /// # let output_root = temp_dir().join("crux_core_typegen_doctest");
     /// typegen.typescript(
     ///     &Config::builder("shared_types", output_root.join("typescript"))
-    ///     .add_extensions()
     ///     .build()
     /// )?;
     /// # Ok::<(), crux_core::type_generation::facet::TypeGenError>(())
@@ -438,8 +345,8 @@ impl CodeGenerator {
         fs::create_dir_all(&config.out_dir)?;
         let output_dir = &config.out_dir;
 
-        typescript::Installer::new(&config.package_name, output_dir, InstallTarget::Node)
-            .encoding(Encoding::Bincode)
+        typescript::Installer::new(&config.package_name, output_dir)
+            .plugin(BincodePlugin)
             .external_packages(&config.external_packages)
             .generate(&self.0)?;
 

--- a/crux_macros/src/effect/macro_impl.rs
+++ b/crux_macros/src/effect/macro_impl.rs
@@ -198,6 +198,8 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
                             .register_type::<#ffi_enum_ident>()
                             .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(err.to_string()))?
                             .register_type::<::crux_core::bridge::Request<#ffi_enum_ident>>()
+                            .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(err.to_string()))?
+                            .register_type::<::crux_core::bridge::Requests<#ffi_enum_ident>>()
                             .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(err.to_string()))?;
 
                         Ok(generator)

--- a/crux_macros/src/effect/tests.rs
+++ b/crux_macros/src/effect/tests.rs
@@ -249,6 +249,10 @@ fn single_with_facet_typegen() {
                 .register_type::<::crux_core::bridge::Request<EffectFfi>>()
                 .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
                     err.to_string(),
+                ))?
+                .register_type::<::crux_core::bridge::Requests<EffectFfi>>()
+                .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
+                    err.to_string(),
                 ))?;
             Ok(generator)
         }
@@ -339,6 +343,10 @@ fn single_facet_typegen_with_new_name() {
                     err.to_string(),
                 ))?
                 .register_type::<::crux_core::bridge::Request<MyEffectFfi>>()
+                .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
+                    err.to_string(),
+                ))?
+                .register_type::<::crux_core::bridge::Requests<MyEffectFfi>>()
                 .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
                     err.to_string(),
                 ))?;
@@ -620,6 +628,10 @@ fn multiple_with_facet_typegen() {
                 .register_type::<::crux_core::bridge::Request<EffectFfi>>()
                 .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
                     err.to_string(),
+                ))?
+                .register_type::<::crux_core::bridge::Requests<EffectFfi>>()
+                .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
+                    err.to_string(),
                 ))?;
             Ok(generator)
         }
@@ -833,6 +845,10 @@ fn facet_typegen_with_namespace_attribute() {
                     err.to_string(),
                 ))?
                 .register_type::<::crux_core::bridge::Request<EffectFfi>>()
+                .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
+                    err.to_string(),
+                ))?
+                .register_type::<::crux_core::bridge::Requests<EffectFfi>>()
                 .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
                     err.to_string(),
                 ))?;

--- a/crux_macros/src/export.rs
+++ b/crux_macros/src/export.rs
@@ -78,6 +78,7 @@ impl ToTokens for ExportStructReceiver {
                     #(#output_type_exports_facet)*
                     generator.register_type::<#ffi_export_name>()?;
                     generator.register_type::<::crux_core::bridge::Request<#ffi_export_name>>()?;
+                    generator.register_type::<::crux_core::bridge::Requests<#ffi_export_name>>()?;
 
                     Ok(())
                 }
@@ -171,6 +172,7 @@ mod tests {
                 > as Capability<Event>>::Operation::register_types_facet(generator)?;
                 generator.register_type::<EffectFfi>()?;
                 generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
+                generator.register_type::<::crux_core::bridge::Requests<EffectFfi>>()?;
                 Ok(())
             }
         }
@@ -252,6 +254,7 @@ mod tests {
                 > as Capability<MyEvent>>::Operation::register_types_facet(generator)?;
                 generator.register_type::<EffectFfi>()?;
                 generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
+                generator.register_type::<::crux_core::bridge::Requests<EffectFfi>>()?;
                 Ok(())
             }
         }
@@ -322,6 +325,7 @@ mod tests {
                 > as Capability<MyEvent>>::Operation::register_types_facet(generator)?;
                 generator.register_type::<EffectFfi>()?;
                 generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
+                generator.register_type::<::crux_core::bridge::Requests<EffectFfi>>()?;
                 Ok(())
             }
         }
@@ -368,6 +372,7 @@ mod tests {
                 > as Capability<Event>>::Operation::register_types_facet(generator)?;
                 generator.register_type::<MyEffectFfi>()?;
                 generator.register_type::<::crux_core::bridge::Request<MyEffectFfi>>()?;
+                generator.register_type::<::crux_core::bridge::Requests<MyEffectFfi>>()?;
                 Ok(())
             }
         }

--- a/examples/counter-http/Android/app/src/main/java/com/crux/examples/counter/http/core/Core.kt
+++ b/examples/counter-http/Android/app/src/main/java/com/crux/examples/counter/http/core/Core.kt
@@ -35,7 +35,7 @@ class Core(
     }
 
     private suspend fun handleEffects(effects: ByteArray) {
-        val requests = Requests.bincodeDeserialize(effects)
+        val requests = Requests.bincodeDeserialize(effects).value
         for (request in requests) {
             processRequest(request)
         }

--- a/examples/counter-http/Cargo.lock
+++ b/examples/counter-http/Cargo.lock
@@ -1272,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "facet-generate-attrs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b59c82c2c40c64d157e102d4fa437394dc3768780903546129700fe5911884d"
+checksum = "3b430b495d59ffcf07dabe103a796d8d3ba809d12bb25a5960b605883835b3de"
 dependencies = [
  "facet 0.44.5",
 ]
@@ -1357,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7adb3e4cd72f80272b4db2ee6a6c7132e599e4b5982d6b112e41387bea2c1"
+checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
 dependencies = [
  "derive_builder",
  "facet 0.44.5",

--- a/examples/counter-http/apple/CounterApp/core.swift
+++ b/examples/counter-http/apple/CounterApp/core.swift
@@ -19,7 +19,7 @@ class Core: ObservableObject {
         let effects = [UInt8](core.update(Data(try! event.bincodeSerialize())))
 
         // swiftlint:disable:next force_try
-        let requests: [Request] = try! .bincodeDeserialize(input: effects)
+        let requests = try! Requests.bincodeDeserialize(input: effects).value
         for request in requests {
             processEffect(request)
         }
@@ -32,21 +32,22 @@ class Core: ObservableObject {
                 // swiftlint:disable:next force_try
                 self.view = try! .bincodeDeserialize(input: [UInt8](self.core.view()))
             }
-        case let .http(httpRequest):
+        case .http(let httpRequest):
             Task {
                 let result = await performHttpRequest(httpRequest)
                 // swiftlint:disable force_try
-                let effects = [UInt8](self.core.resolve(
-                    request.id,
-                    Data(try! result.bincodeSerialize())
-                ))
-                let requests: [Request] = try! .bincodeDeserialize(input: effects)
+                let effects = [UInt8](
+                    self.core.resolve(
+                        request.id,
+                        Data(try! result.bincodeSerialize())
+                    ))
+                let requests = try! Requests.bincodeDeserialize(input: effects).value
                 // swiftlint:enable force_try
                 for request in requests {
                     self.processEffect(request)
                 }
             }
-        case let .serverSentEvents(sseRequest):
+        case .serverSentEvents(let sseRequest):
             Task {
                 await performSseRequest(sseRequest, requestId: request.id)
             }
@@ -96,11 +97,12 @@ class Core: ObservableObject {
                     let response = SseResponse.chunk([UInt8](buffer))
                     buffer = Data()
                     // swiftlint:disable force_try
-                    let effects = [UInt8](self.core.resolve(
-                        requestId,
-                        Data(try! response.bincodeSerialize())
-                    ))
-                    let requests: [Request] = try! .bincodeDeserialize(input: effects)
+                    let effects = [UInt8](
+                        self.core.resolve(
+                            requestId,
+                            Data(try! response.bincodeSerialize())
+                        ))
+                    let requests = try! Requests.bincodeDeserialize(input: effects).value
                     // swiftlint:enable force_try
                     for request in requests {
                         self.processEffect(request)
@@ -110,11 +112,12 @@ class Core: ObservableObject {
 
             let done = SseResponse.done
             // swiftlint:disable force_try
-            let effects = [UInt8](self.core.resolve(
-                requestId,
-                Data(try! done.bincodeSerialize())
-            ))
-            let requests: [Request] = try! .bincodeDeserialize(input: effects)
+            let effects = [UInt8](
+                self.core.resolve(
+                    requestId,
+                    Data(try! done.bincodeSerialize())
+                ))
+            let requests = try! Requests.bincodeDeserialize(input: effects).value
             // swiftlint:enable force_try
             for request in requests {
                 self.processEffect(request)

--- a/examples/counter-http/shared/src/bin/codegen.rs
+++ b/examples/counter-http/shared/src/bin/codegen.rs
@@ -37,9 +37,7 @@ fn main() -> Result<()> {
         Language::Kotlin => "com.crux.examples.counter",
         Language::Typescript => "app",
     };
-    let config = Config::builder(name, &args.output_dir)
-        .add_extensions()
-        .build();
+    let config = Config::builder(name, &args.output_dir).build();
 
     match args.language {
         Language::Swift => {

--- a/examples/counter-middleware/Android/app/src/main/java/com/crux/examples/counter/middleware/core/Core.kt
+++ b/examples/counter-middleware/Android/app/src/main/java/com/crux/examples/counter/middleware/core/Core.kt
@@ -43,7 +43,7 @@ class Core(
     }
 
     private suspend fun handleEffects(effects: ByteArray) {
-        val requests = Requests.bincodeDeserialize(effects)
+        val requests = Requests.bincodeDeserialize(effects).value
         for (request in requests) {
             processRequest(request)
         }

--- a/examples/counter-middleware/Cargo.lock
+++ b/examples/counter-middleware/Cargo.lock
@@ -1182,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "facet-generate-attrs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b59c82c2c40c64d157e102d4fa437394dc3768780903546129700fe5911884d"
+checksum = "3b430b495d59ffcf07dabe103a796d8d3ba809d12bb25a5960b605883835b3de"
 dependencies = [
  "facet 0.44.5",
 ]
@@ -1267,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7adb3e4cd72f80272b4db2ee6a6c7132e599e4b5982d6b112e41387bea2c1"
+checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
 dependencies = [
  "derive_builder",
  "facet 0.44.5",

--- a/examples/counter-middleware/apple/CounterApp/core.swift
+++ b/examples/counter-middleware/apple/CounterApp/core.swift
@@ -25,7 +25,7 @@ class Core: ObservableObject {
 
         handler.handler = { bytes in
             // swiftlint:disable:next force_try
-            let requests: [Request] = try! .bincodeDeserialize(input: [UInt8](bytes))
+            let requests = try! Requests.bincodeDeserialize(input: [UInt8](bytes)).value
             for request in requests {
                 self.processEffect(request)
             }
@@ -37,7 +37,7 @@ class Core: ObservableObject {
         let effects = [UInt8](core.update(Data(try! event.bincodeSerialize())))
 
         // swiftlint:disable:next force_try
-        let requests: [Request] = try! .bincodeDeserialize(input: effects)
+        let requests = try! Requests.bincodeDeserialize(input: effects).value
         for request in requests {
             processEffect(request)
         }
@@ -50,21 +50,22 @@ class Core: ObservableObject {
                 // swiftlint:disable:next force_try
                 self.view = try! .bincodeDeserialize(input: [UInt8](self.core.view()))
             }
-        case let .http(httpRequest):
+        case .http(let httpRequest):
             Task {
                 let result = await performHttpRequest(httpRequest)
                 // swiftlint:disable force_try
-                let effects = [UInt8](self.core.resolve(
-                    request.id,
-                    Data(try! result.bincodeSerialize())
-                ))
-                let requests: [Request] = try! .bincodeDeserialize(input: effects)
+                let effects = [UInt8](
+                    self.core.resolve(
+                        request.id,
+                        Data(try! result.bincodeSerialize())
+                    ))
+                let requests = try! Requests.bincodeDeserialize(input: effects).value
                 // swiftlint:enable force_try
                 for request in requests {
                     self.processEffect(request)
                 }
             }
-        case let .serverSentEvents(sseRequest):
+        case .serverSentEvents(let sseRequest):
             Task {
                 await performSseRequest(sseRequest, requestId: request.id)
             }
@@ -117,11 +118,12 @@ class Core: ObservableObject {
                     let response = SseResponse.chunk([UInt8](buffer))
                     buffer = Data()
                     // swiftlint:disable force_try
-                    let effects = [UInt8](self.core.resolve(
-                        requestId,
-                        Data(try! response.bincodeSerialize())
-                    ))
-                    let requests: [Request] = try! .bincodeDeserialize(input: effects)
+                    let effects = [UInt8](
+                        self.core.resolve(
+                            requestId,
+                            Data(try! response.bincodeSerialize())
+                        ))
+                    let requests = try! Requests.bincodeDeserialize(input: effects).value
                     // swiftlint:enable force_try
                     for request in requests {
                         self.processEffect(request)
@@ -131,11 +133,12 @@ class Core: ObservableObject {
 
             let done = SseResponse.done
             // swiftlint:disable force_try
-            let effects = [UInt8](self.core.resolve(
-                requestId,
-                Data(try! done.bincodeSerialize())
-            ))
-            let requests: [Request] = try! .bincodeDeserialize(input: effects)
+            let effects = [UInt8](
+                self.core.resolve(
+                    requestId,
+                    Data(try! done.bincodeSerialize())
+                ))
+            let requests = try! Requests.bincodeDeserialize(input: effects).value
             // swiftlint:enable force_try
             for request in requests {
                 self.processEffect(request)

--- a/examples/counter-middleware/shared/src/bin/codegen.rs
+++ b/examples/counter-middleware/shared/src/bin/codegen.rs
@@ -37,9 +37,7 @@ fn main() -> Result<()> {
         Language::Kotlin => "com.crux.examples.counter.middleware",
         Language::Typescript => "app",
     };
-    let config = Config::builder(name, &args.output_dir)
-        .add_extensions()
-        .build();
+    let config = Config::builder(name, &args.output_dir).build();
 
     match args.language {
         Language::Swift => {

--- a/examples/counter/Android/.idea/.name
+++ b/examples/counter/Android/.idea/.name
@@ -1,1 +1,1 @@
-Simple Counter
+Counter

--- a/examples/counter/Android/.idea/deploymentTargetSelector.xml
+++ b/examples/counter/Android/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/examples/counter/Android/app/src/main/java/com/crux/examples/counter/Core.kt
+++ b/examples/counter/Android/app/src/main/java/com/crux/examples/counter/Core.kt
@@ -14,7 +14,7 @@ open class Core : androidx.lifecycle.ViewModel() {
     fun update(event: Event) {
         val effects = core.update(event.bincodeSerialize())
 
-        val requests = Requests.bincodeDeserialize(effects)
+        val requests = Requests.bincodeDeserialize(effects).value
         for (request in requests) {
             processEffect(request)
         }

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -2345,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "facet-generate-attrs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b59c82c2c40c64d157e102d4fa437394dc3768780903546129700fe5911884d"
+checksum = "3b430b495d59ffcf07dabe103a796d8d3ba809d12bb25a5960b605883835b3de"
 dependencies = [
  "facet",
 ]
@@ -2399,9 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7adb3e4cd72f80272b4db2ee6a6c7132e599e4b5982d6b112e41387bea2c1"
+checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/counter/apple/CounterApp/core.swift
+++ b/examples/counter/apple/CounterApp/core.swift
@@ -19,7 +19,7 @@ class Core: ObservableObject {
         let effects = [UInt8](core.update(data: Data(try! event.bincodeSerialize())))
 
         // swiftlint:disable:next force_try
-        let requests: [Request] = try! .bincodeDeserialize(input: effects)
+        let requests = try! Requests.bincodeDeserialize(input: effects).value
         for request in requests {
             processEffect(request)
         }

--- a/examples/counter/shared/src/bin/codegen.rs
+++ b/examples/counter/shared/src/bin/codegen.rs
@@ -39,9 +39,7 @@ fn main() -> Result<()> {
         Language::Csharp => "CounterApp.Shared",
         Language::Typescript => "app",
     };
-    let config = Config::builder(name, &args.output_dir)
-        .add_extensions()
-        .build();
+    let config = Config::builder(name, &args.output_dir).build();
 
     match args.language {
         Language::Swift => {

--- a/examples/counter/windows/CounterApp/Core.cs
+++ b/examples/counter/windows/CounterApp/Core.cs
@@ -14,10 +14,10 @@ public sealed class Core : IDisposable
         ViewModel.BincodeDeserialize(CoreFfi.View(handle));
 
     public IReadOnlyList<Request> Update(Event @event) =>
-        Requests.BincodeDeserialize(CoreFfi.Update(handle, EventBincode.BincodeSerialize(@event)));
+        Requests.BincodeDeserialize(CoreFfi.Update(handle, EventBincode.BincodeSerialize(@event))).Value;
 
     public IReadOnlyList<Request> Resolve(uint id, byte[] data) =>
-        Requests.BincodeDeserialize(CoreFfi.Resolve(handle, id, data));
+        Requests.BincodeDeserialize(CoreFfi.Resolve(handle, id, data)).Value;
 
     public void Dispose() => handle.Dispose();
 }

--- a/examples/notes/Cargo.lock
+++ b/examples/notes/Cargo.lock
@@ -818,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "facet-generate-attrs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b59c82c2c40c64d157e102d4fa437394dc3768780903546129700fe5911884d"
+checksum = "3b430b495d59ffcf07dabe103a796d8d3ba809d12bb25a5960b605883835b3de"
 dependencies = [
  "facet",
 ]
@@ -872,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7adb3e4cd72f80272b4db2ee6a6c7132e599e4b5982d6b112e41387bea2c1"
+checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/notes/shared/src/bin/codegen.rs
+++ b/examples/notes/shared/src/bin/codegen.rs
@@ -37,9 +37,7 @@ fn main() -> Result<()> {
         Language::Kotlin => "com.crux.example.notes",
         Language::Typescript => "app",
     };
-    let config = Config::builder(name, &args.output_dir)
-        .add_extensions()
-        .build();
+    let config = Config::builder(name, &args.output_dir).build();
 
     match args.language {
         Language::Swift => {

--- a/examples/weather/Android/app/src/main/java/com/crux/example/weather/core/Core.kt
+++ b/examples/weather/Android/app/src/main/java/com/crux/example/weather/core/Core.kt
@@ -75,7 +75,7 @@ class Core
                 Log.d(TAG, "handleEffects: empty response (no effects)")
                 return
             }
-            val requests = Requests.bincodeDeserialize(effects)
+            val requests = Requests.bincodeDeserialize(effects).value
             for (request in requests) {
                 processRequest(request)
             }

--- a/examples/weather/Cargo.lock
+++ b/examples/weather/Cargo.lock
@@ -1168,9 +1168,9 @@ dependencies = [
 
 [[package]]
 name = "facet-generate-attrs"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b59c82c2c40c64d157e102d4fa437394dc3768780903546129700fe5911884d"
+checksum = "3b430b495d59ffcf07dabe103a796d8d3ba809d12bb25a5960b605883835b3de"
 dependencies = [
  "facet 0.44.5",
 ]
@@ -1253,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7adb3e4cd72f80272b4db2ee6a6c7132e599e4b5982d6b112e41387bea2c1"
+checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
 dependencies = [
  "derive_builder",
  "facet 0.44.5",

--- a/examples/weather/apple/WeatherApp/LiveBridge.swift
+++ b/examples/weather/apple/WeatherApp/LiveBridge.swift
@@ -1,8 +1,8 @@
 import App
 import Foundation
-import os
 import Shared
 import WeatherKit
+import os
 
 private let logger = Logger(subsystem: "com.crux.examples.weather", category: "live-bridge")
 
@@ -18,7 +18,7 @@ struct LiveBridge: CoreBridge {
     }
 
     func processEvent(_ event: Event) -> [Request] {
-        let eventBytes = try! event.bincodeSerialize() // swiftlint:disable:this force_try
+        let eventBytes = try! event.bincodeSerialize()  // swiftlint:disable:this force_try
         logger.debug("sending \(eventBytes.count) event bytes")
 
         let effects = [UInt8](ffi.update(Data(eventBytes)))
@@ -45,6 +45,6 @@ struct LiveBridge: CoreBridge {
             logger.error("response too short (\(bytes.count) bytes)")
             return []
         }
-        return try! .bincodeDeserialize(input: bytes) // swiftlint:disable:this force_try
+        return try! Requests.bincodeDeserialize(input: bytes).value  // swiftlint:disable:this force_try
     }
 }

--- a/examples/weather/clippy.toml
+++ b/examples/weather/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["OpenWeatherMap", ".."]

--- a/examples/weather/shared/Cargo.toml
+++ b/examples/weather/shared/Cargo.toml
@@ -20,11 +20,11 @@ required-features = ["codegen"]
 uniffi = ["dep:uniffi"]
 wasm_bindgen = ["dep:wasm-bindgen", "dep:getrandom"]
 codegen = [
-  "crux_core/cli",
-  "dep:clap",
-  "dep:log",
-  "dep:pretty_env_logger",
-  "uniffi",
+    "crux_core/cli",
+    "dep:clap",
+    "dep:log",
+    "dep:pretty_env_logger",
+    "uniffi",
 ]
 facet_typegen = ["crux_core/facet_typegen"]
 
@@ -35,7 +35,7 @@ crux_http.workspace = true
 crux_kv.workspace = true
 crux_time.workspace = true
 derive_builder = "0.20.2"
-facet = { version = "0.44", features = ["chrono"] }
+facet = { version = "=0.44", features = ["chrono"] }
 getrandom = { version = "0.4", optional = true, features = ["wasm_js"] }
 log = { version = "0.4.29", optional = true }
 pretty_env_logger = { version = "0.5.0", optional = true }

--- a/examples/weather/shared/src/bin/codegen.rs
+++ b/examples/weather/shared/src/bin/codegen.rs
@@ -37,9 +37,7 @@ fn main() -> Result<()> {
         Language::Kotlin => "com.crux.example.weather",
         Language::Typescript => "app",
     };
-    let config = Config::builder(name, &args.output_dir)
-        .add_extensions()
-        .build();
+    let config = Config::builder(name, &args.output_dir).build();
 
     match args.language {
         Language::Swift => {

--- a/examples/weather/shared/src/model/active/mod.rs
+++ b/examples/weather/shared/src/model/active/mod.rs
@@ -96,9 +96,9 @@ pub struct ActiveModel {
 }
 
 impl ActiveModel {
-    pub(crate) fn start(api_key: ApiKey, favorites: Favorites) -> Started<Self, ActiveEvent> {
+    pub(crate) fn start(api_key: ApiKey, favorites: &Favorites) -> Started<Self, ActiveEvent> {
         tracing::debug!("starting active");
-        let (home_screen, start_cmd) = HomeScreen::start(&favorites, &api_key)
+        let (home_screen, start_cmd) = HomeScreen::start(favorites, &api_key)
             .map_event(ActiveEvent::home)
             .into_parts();
         Started::new(

--- a/examples/weather/shared/src/model/mod.rs
+++ b/examples/weather/shared/src/model/mod.rs
@@ -110,7 +110,7 @@ impl Model {
                 api_key,
                 favorites,
             )) => {
-                let (active, start_cmd) = ActiveModel::start(api_key, favorites)
+                let (active, start_cmd) = ActiveModel::start(api_key, &favorites)
                     .map_event(Event::Active)
                     .into_parts();
                 *self = Model::Active(active);
@@ -133,7 +133,7 @@ impl Model {
                 command
             }
             outcome::Status::Complete(onboard::OnboardTransition::Active(api_key, favorites)) => {
-                let (active, start_cmd) = ActiveModel::start(api_key, favorites)
+                let (active, start_cmd) = ActiveModel::start(api_key, &favorites)
                     .map_event(Event::Active)
                     .into_parts();
                 *self = Model::Active(active);

--- a/examples/weather/web-leptos/src/components/common/card.rs
+++ b/examples/weather/web-leptos/src/components/common/card.rs
@@ -3,7 +3,7 @@ use leptos::prelude::*;
 /// A rounded white panel with a soft shadow. The main layout container for
 /// screen content — every screen stacks one or more cards.
 #[component]
-pub fn card(children: Children, #[prop(optional, into)] class: String) -> impl IntoView {
+pub fn card(children: Children, #[prop(optional, into)] class: &'static str) -> impl IntoView {
     let full = format!("bg-white rounded-2xl shadow-lg p-6 {class}");
     view! { <div class=full>{children()}</div> }
 }


### PR DESCRIPTION
## Replace `add_extensions()` with a generated `Requests` type

### Motivation

The `add_extensions()` method on `Config` was removed from `facet_generate` in v0.17. It was previously used to copy hand-written, language-specific helper files into the generated output — one per target language — whose sole purpose was to provide a `bincodeDeserialize` / `BincodeDeserialize` static method for deserialising a `Vec<Request>` from the bridge's wire output.

These extensions were bespoke, difficult to maintain, and duplicated logic that the bincode plugin already knows how to emit for any named type in the registry.

### Approach

Add a `Requests<Eff>` newtype to `crux_core::bridge`:

```rust
#[derive(Facet, Debug, Serialize, Deserialize)]
#[serde(transparent)]
pub struct Requests<Eff>(pub Vec<Request<Eff>>)
where
    Eff: Serialize;
```

`#[serde(transparent)]` keeps the wire format bit-for-bit identical to the existing `Vec<Request<Eff>>` serialisation, so no changes are needed at the FFI boundary. `#[facet(transparent)]` is deliberately **not** used — that would collapse the type in the registry and defeat the purpose.

The `#[effect(facet_typegen)]` macro and the `#[derive(Export)]` macro are both updated to register `Requests<EffectFfi>` alongside the existing `Request<EffectFfi>` registration. Because `Requests<Eff>` is a single-field tuple struct without `#[facet(transparent)]`, `facet-generate` reflects it as `ContainerFormat::NewTypeStruct(Format::Seq(TypeName("Request")), …)`. Each language's existing bincode plugin then emits a proper named `Requests` type with a `bincodeDeserialize` / `BincodeDeserialize` static helper — no hand-written code required.

### Changes

- **`crux_core/src/bridge/mod.rs`** — add `pub struct Requests<Eff>(pub Vec<Request<Eff>>)`
- **`crux_macros/src/effect/macro_impl.rs`** — register `Requests<EffFfi>` in the `facet_typegen` `Export` impl
- **`crux_macros/src/export.rs`** — same for the `#[derive(Export)]` path; update snapshots
- **`crux_macros/src/effect/tests.rs`** — update all four facet typegen snapshots
- **`crux_core/src/type_generation/facet.rs`** — remove the `extension_data!` macro and all `if config.add_extensions { … }` blocks from `swift()`, `kotlin()`, and `csharp()`; fix the module-level doctest (broken `typegen.java()` call replaced with `kotlin()`, add explicit `fn main` wrapper)
- **`examples/*/shared/src/bin/codegen.rs`** (×5) — remove `.add_extensions()` from every codegen binary
- **Shell Swift files** (counter, counter-http, counter-middleware, weather) — update all call-sites from `[Request] = try! .bincodeDeserialize(input: effects)` to `try! Requests.bincodeDeserialize(input: effects).value`
- **Shell Kotlin files** (×4) — add `.value` to unwrap the `List<Request>` from the returned `Requests` object
- **Shell C# file** (counter) — add `.Value` to both `Update` and `Resolve` return expressions

### Notes

- TypeScript shells are unaffected (TypeScript was already excluded from `add_extensions` in this work).
- The hand-written extension files under `crux_core/typegen_extensions/{swift,kotlin,csharp}/` can be deleted in a follow-up once this is confirmed working end-to-end (although I need to check if they are still needed for serde based typegen)