### PR TITLE
Make macro-generated test helpers available to integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ dependencies = [
  "bincode",
  "crossbeam-channel",
  "crux_cli",
+ "crux_core",
  "crux_http",
  "crux_macros",
  "crux_time",

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -32,6 +32,7 @@ slab = "0.4"
 thiserror.workspace = true
 
 [dev-dependencies]
+crux_core = { path = ".", features = ["testing"] }
 assert_fs = "1.1.3"
 assert_matches = "1.5"
 async-channel = "2.5.0"
@@ -49,4 +50,10 @@ uuid = { version = "1.22.0", features = ["serde", "v4"] }
 default = ["crux_macros"]
 cli = ["dep:crux_cli"]
 facet_typegen = ["crux_macros/facet_typegen", "dep:facet_generate", "dep:log"]
-typegen = ["crux_macros/typegen", "dep:serde-generate", "dep:serde-reflection", "dep:include_dir"]
+testing = []
+typegen = [
+    "crux_macros/typegen",
+    "dep:serde-generate",
+    "dep:serde-reflection",
+    "dep:include_dir",
+]

--- a/crux_core/src/command/mod.rs
+++ b/crux_core/src/command/mod.rs
@@ -204,7 +204,7 @@
 //!     .then_send(Event::GotPost);
 //!
 //! // Check the effect is an HTTP request ...
-//! let effect = cmd.expect_one_effect();
+//! let effect = cmd.effects().next().expect("expected an effect");
 //! let Effect::Http(mut request) = effect else {
 //!     panic!("Expected a HTTP effect")
 //! };
@@ -229,7 +229,7 @@
 //!     .expect("Resolve should succeed");
 //!
 //! // Check the event is a GotPost event with the successful response
-//! let actual = cmd.expect_one_event();
+//! let actual = cmd.events().next().expect("expected an event");
 //! let expected = Event::GotPost(Ok(ResponseBuilder::ok().body(body).build()));
 //! assert_eq!(actual, expected);
 //!

--- a/crux_core/src/lib.rs
+++ b/crux_core/src/lib.rs
@@ -156,6 +156,7 @@ pub mod bridge;
 pub mod capability;
 pub mod command;
 pub mod middleware;
+#[cfg(any(test, feature = "testing"))]
 pub mod testing;
 #[cfg(any(feature = "typegen", feature = "facet_typegen"))]
 pub mod type_generation;

--- a/crux_core/tests/effect_test_ext.rs
+++ b/crux_core/tests/effect_test_ext.rs
@@ -42,7 +42,7 @@ mod app {
                 Event::Render => render(),
                 Event::Ping => ping().then_send(Event::Echo),
                 Event::Both => render().and(ping().then_send(Event::Echo)),
-                Event::Echo(_) => Command::done(),
+                Event::Echo(()) => Command::done(),
             }
         }
 

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -45,3 +45,6 @@ assert_fs = "1.1.3"
 futures-test = "0.3"
 assert_matches = "1.5"
 insta = "1.46.3"
+crux_core = { version = "0.17.0", path = "../crux_core", features = [
+    "testing",
+] }

--- a/crux_kv/Cargo.toml
+++ b/crux_kv/Cargo.toml
@@ -18,6 +18,11 @@ serde = { workspace = true, features = ["derive"] }
 serde_bytes = "0.11"
 thiserror.workspace = true
 
+[dev-dependencies]
+crux_core = { version = "0.17.0", path = "../crux_core", features = [
+    "testing",
+] }
+
 [features]
 facet_typegen = ["crux_core/facet_typegen"]
 typegen = ["crux_core/typegen"]

--- a/crux_macros/src/effect/macro_impl.rs
+++ b/crux_macros/src/effect/macro_impl.rs
@@ -140,7 +140,7 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
                         None
                     }
                 }
-                #[cfg(test)]
+                #[doc(hidden)]
                 #[track_caller]
                 pub fn #expect_fn(self) -> ::crux_core::Request<#operation> {
                     if let #enum_ident::#effect_ident(request) = self {
@@ -276,7 +276,7 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
     });
 
     let test_ext = quote! {
-        #[cfg(test)]
+        #[doc(hidden)]
         pub trait #test_ext_trait_ident<Event>
         where
             Event: ::core::marker::Send + 'static,
@@ -288,7 +288,7 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
                 F: ::core::ops::FnOnce(&Event);
         }
 
-        #[cfg(test)]
+        #[doc(hidden)]
         impl<Event> #test_ext_trait_ident<Event> for ::crux_core::Command<#enum_ident, Event>
         where
             Event: ::core::marker::Send + 'static,

--- a/crux_macros/src/effect/macro_impl.rs
+++ b/crux_macros/src/effect/macro_impl.rs
@@ -234,7 +234,12 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
                 let effect = self.effects().next()
                     .unwrap_or_else(|| panic!(#no_more_msg));
                 let _ = effect.#expect_fn();
-                self.expect_no_effect_or_events();
+                let remaining_effects = self.effects().count();
+                let remaining_events = self.events().count();
+                assert!(
+                    remaining_effects + remaining_events == 0,
+                    "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+                );
             }
 
             #[track_caller]
@@ -246,7 +251,12 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
                     .unwrap_or_else(|| panic!(#no_more_msg));
                 let req = effect.#expect_fn();
                 f(&req.operation);
-                self.expect_no_effect_or_events();
+                let remaining_effects = self.effects().count();
+                let remaining_events = self.events().count();
+                assert!(
+                    remaining_effects + remaining_events == 0,
+                    "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+                );
             }
 
             #[track_caller]

--- a/crux_macros/src/effect/macro_impl.rs
+++ b/crux_macros/src/effect/macro_impl.rs
@@ -140,6 +140,7 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
                         None
                     }
                 }
+                #[cfg(test)]
                 #[track_caller]
                 pub fn #expect_fn(self) -> ::crux_core::Request<#operation> {
                     if let #enum_ident::#effect_ident(request) = self {
@@ -265,6 +266,7 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
     });
 
     let test_ext = quote! {
+        #[cfg(test)]
         pub trait #test_ext_trait_ident<Event>
         where
             Event: ::core::marker::Send + 'static,
@@ -276,6 +278,7 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
                 F: ::core::ops::FnOnce(&Event);
         }
 
+        #[cfg(test)]
         impl<Event> #test_ext_trait_ident<Event> for ::crux_core::Command<#enum_ident, Event>
         where
             Event: ::core::marker::Send + 'static,

--- a/crux_macros/src/effect/tests.rs
+++ b/crux_macros/src/effect/tests.rs
@@ -72,7 +72,7 @@ fn single_with_typegen() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -82,7 +82,7 @@ fn single_with_typegen() {
             }
         }
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -104,7 +104,7 @@ fn single_with_typegen() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -266,7 +266,7 @@ fn single_with_new_name() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let MyEffect::Render(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let MyEffect::Render(request) = self {
@@ -276,7 +276,7 @@ fn single_with_new_name() {
             }
         }
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     pub trait MyEffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -298,7 +298,7 @@ fn single_with_new_name() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     impl<Event> MyEffectTestExt<Event> for ::crux_core::Command<MyEffect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -466,7 +466,7 @@ fn single_with_facet_typegen() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -476,7 +476,7 @@ fn single_with_facet_typegen() {
             }
         }
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -498,7 +498,7 @@ fn single_with_facet_typegen() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -683,7 +683,7 @@ fn single_facet_typegen_with_new_name() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let MyEffect::Render(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let MyEffect::Render(request) = self {
@@ -693,7 +693,7 @@ fn single_facet_typegen_with_new_name() {
             }
         }
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     pub trait MyEffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -715,7 +715,7 @@ fn single_facet_typegen_with_new_name() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     impl<Event> MyEffectTestExt<Event> for ::crux_core::Command<MyEffect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -878,7 +878,7 @@ fn single_without_typegen() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -888,7 +888,7 @@ fn single_without_typegen() {
             }
         }
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -910,7 +910,7 @@ fn single_without_typegen() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1076,7 +1076,7 @@ fn multiple_with_typegen() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -1093,7 +1093,7 @@ fn multiple_with_typegen() {
         pub fn into_http(self) -> Option<::crux_core::Request<HttpRequest>> {
             if let Effect::Http(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_http(self) -> ::crux_core::Request<HttpRequest> {
             if let Effect::Http(request) = self {
@@ -1103,7 +1103,7 @@ fn multiple_with_typegen() {
             }
         }
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1138,7 +1138,7 @@ fn multiple_with_typegen() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1403,7 +1403,7 @@ fn multiple_with_facet_typegen() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -1420,7 +1420,7 @@ fn multiple_with_facet_typegen() {
         pub fn into_http(self) -> Option<::crux_core::Request<HttpRequest>> {
             if let Effect::Http(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_http(self) -> ::crux_core::Request<HttpRequest> {
             if let Effect::Http(request) = self {
@@ -1430,7 +1430,7 @@ fn multiple_with_facet_typegen() {
             }
         }
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1465,7 +1465,7 @@ fn multiple_with_facet_typegen() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1725,7 +1725,7 @@ fn multiple_without_typegen() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -1742,7 +1742,7 @@ fn multiple_without_typegen() {
         pub fn into_http(self) -> Option<::crux_core::Request<HttpRequest>> {
             if let Effect::Http(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_http(self) -> ::crux_core::Request<HttpRequest> {
             if let Effect::Http(request) = self {
@@ -1752,7 +1752,7 @@ fn multiple_without_typegen() {
             }
         }
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1787,7 +1787,7 @@ fn multiple_without_typegen() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -2003,7 +2003,7 @@ fn single_without_typegen_with_attributes() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -2013,7 +2013,7 @@ fn single_without_typegen_with_attributes() {
             }
         }
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -2035,7 +2035,7 @@ fn single_without_typegen_with_attributes() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -2193,7 +2193,7 @@ fn facet_typegen_with_namespace_attribute() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
-        #[cfg(test)]
+        #[doc(hidden)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -2203,7 +2203,7 @@ fn facet_typegen_with_namespace_attribute() {
             }
         }
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -2225,7 +2225,7 @@ fn facet_typegen_with_namespace_attribute() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
-    #[cfg(test)]
+    #[doc(hidden)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,

--- a/crux_macros/src/effect/tests.rs
+++ b/crux_macros/src/effect/tests.rs
@@ -72,6 +72,7 @@ fn single_with_typegen() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -81,6 +82,7 @@ fn single_with_typegen() {
             }
         }
     }
+    #[cfg(test)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -102,6 +104,7 @@ fn single_with_typegen() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
+    #[cfg(test)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -253,6 +256,7 @@ fn single_with_new_name() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let MyEffect::Render(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let MyEffect::Render(request) = self {
@@ -262,6 +266,7 @@ fn single_with_new_name() {
             }
         }
     }
+    #[cfg(test)]
     pub trait MyEffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -283,6 +288,7 @@ fn single_with_new_name() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
+    #[cfg(test)]
     impl<Event> MyEffectTestExt<Event> for ::crux_core::Command<MyEffect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -440,6 +446,7 @@ fn single_with_facet_typegen() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -449,6 +456,7 @@ fn single_with_facet_typegen() {
             }
         }
     }
+    #[cfg(test)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -470,6 +478,7 @@ fn single_with_facet_typegen() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
+    #[cfg(test)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -644,6 +653,7 @@ fn single_facet_typegen_with_new_name() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let MyEffect::Render(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let MyEffect::Render(request) = self {
@@ -653,6 +663,7 @@ fn single_facet_typegen_with_new_name() {
             }
         }
     }
+    #[cfg(test)]
     pub trait MyEffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -674,6 +685,7 @@ fn single_facet_typegen_with_new_name() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
+    #[cfg(test)]
     impl<Event> MyEffectTestExt<Event> for ::crux_core::Command<MyEffect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -826,6 +838,7 @@ fn single_without_typegen() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -835,6 +848,7 @@ fn single_without_typegen() {
             }
         }
     }
+    #[cfg(test)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -856,6 +870,7 @@ fn single_without_typegen() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
+    #[cfg(test)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1011,6 +1026,7 @@ fn multiple_with_typegen() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -1027,6 +1043,7 @@ fn multiple_with_typegen() {
         pub fn into_http(self) -> Option<::crux_core::Request<HttpRequest>> {
             if let Effect::Http(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_http(self) -> ::crux_core::Request<HttpRequest> {
             if let Effect::Http(request) = self {
@@ -1036,6 +1053,7 @@ fn multiple_with_typegen() {
             }
         }
     }
+    #[cfg(test)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1070,6 +1088,7 @@ fn multiple_with_typegen() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
+    #[cfg(test)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1314,6 +1333,7 @@ fn multiple_with_facet_typegen() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -1330,6 +1350,7 @@ fn multiple_with_facet_typegen() {
         pub fn into_http(self) -> Option<::crux_core::Request<HttpRequest>> {
             if let Effect::Http(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_http(self) -> ::crux_core::Request<HttpRequest> {
             if let Effect::Http(request) = self {
@@ -1339,6 +1360,7 @@ fn multiple_with_facet_typegen() {
             }
         }
     }
+    #[cfg(test)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1373,6 +1395,7 @@ fn multiple_with_facet_typegen() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
+    #[cfg(test)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1612,6 +1635,7 @@ fn multiple_without_typegen() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -1628,6 +1652,7 @@ fn multiple_without_typegen() {
         pub fn into_http(self) -> Option<::crux_core::Request<HttpRequest>> {
             if let Effect::Http(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_http(self) -> ::crux_core::Request<HttpRequest> {
             if let Effect::Http(request) = self {
@@ -1637,6 +1662,7 @@ fn multiple_without_typegen() {
             }
         }
     }
+    #[cfg(test)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1671,6 +1697,7 @@ fn multiple_without_typegen() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
+    #[cfg(test)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1866,6 +1893,7 @@ fn single_without_typegen_with_attributes() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -1875,6 +1903,7 @@ fn single_without_typegen_with_attributes() {
             }
         }
     }
+    #[cfg(test)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -1896,6 +1925,7 @@ fn single_without_typegen_with_attributes() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
+    #[cfg(test)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -2043,6 +2073,7 @@ fn facet_typegen_with_namespace_attribute() {
         pub fn into_render(self) -> Option<::crux_core::Request<RenderOperation>> {
             if let Effect::Render(request) = self { Some(request) } else { None }
         }
+        #[cfg(test)]
         #[track_caller]
         pub fn expect_render(self) -> ::crux_core::Request<RenderOperation> {
             if let Effect::Render(request) = self {
@@ -2052,6 +2083,7 @@ fn facet_typegen_with_namespace_attribute() {
             }
         }
     }
+    #[cfg(test)]
     pub trait EffectTestExt<Event>
     where
         Event: ::core::marker::Send + 'static,
@@ -2073,6 +2105,7 @@ fn facet_typegen_with_namespace_attribute() {
         where
             F: ::core::ops::FnOnce(&Event);
     }
+    #[cfg(test)]
     impl<Event> EffectTestExt<Event> for ::crux_core::Command<Effect, Event>
     where
         Event: ::core::marker::Send + 'static,

--- a/crux_macros/src/effect/tests.rs
+++ b/crux_macros/src/effect/tests.rs
@@ -144,7 +144,12 @@ fn single_with_typegen() {
                     panic!("expected Render effect but no more effects remain")
                 });
             let _ = effect.expect_render();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_render_with<F>(&mut self, f: F)
@@ -159,7 +164,12 @@ fn single_with_typegen() {
                 });
             let req = effect.expect_render();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_render<F>(&mut self, f: F) -> &mut Self
@@ -328,7 +338,12 @@ fn single_with_new_name() {
                     panic!("expected Render effect but no more effects remain")
                 });
             let _ = effect.expect_render();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_render_with<F>(&mut self, f: F)
@@ -343,7 +358,12 @@ fn single_with_new_name() {
                 });
             let req = effect.expect_render();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_render<F>(&mut self, f: F) -> &mut Self
@@ -518,7 +538,12 @@ fn single_with_facet_typegen() {
                     panic!("expected Render effect but no more effects remain")
                 });
             let _ = effect.expect_render();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_render_with<F>(&mut self, f: F)
@@ -533,7 +558,12 @@ fn single_with_facet_typegen() {
                 });
             let req = effect.expect_render();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_render<F>(&mut self, f: F) -> &mut Self
@@ -725,7 +755,12 @@ fn single_facet_typegen_with_new_name() {
                     panic!("expected Render effect but no more effects remain")
                 });
             let _ = effect.expect_render();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_render_with<F>(&mut self, f: F)
@@ -740,7 +775,12 @@ fn single_facet_typegen_with_new_name() {
                 });
             let req = effect.expect_render();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_render<F>(&mut self, f: F) -> &mut Self
@@ -910,7 +950,12 @@ fn single_without_typegen() {
                     panic!("expected Render effect but no more effects remain")
                 });
             let _ = effect.expect_render();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_render_with<F>(&mut self, f: F)
@@ -925,7 +970,12 @@ fn single_without_typegen() {
                 });
             let req = effect.expect_render();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_render<F>(&mut self, f: F) -> &mut Self
@@ -1128,7 +1178,12 @@ fn multiple_with_typegen() {
                     panic!("expected Render effect but no more effects remain")
                 });
             let _ = effect.expect_render();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_render_with<F>(&mut self, f: F)
@@ -1143,7 +1198,12 @@ fn multiple_with_typegen() {
                 });
             let req = effect.expect_render();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_render<F>(&mut self, f: F) -> &mut Self
@@ -1198,7 +1258,12 @@ fn multiple_with_typegen() {
                     panic!("expected Http effect but no more effects remain")
                 });
             let _ = effect.expect_http();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_http_with<F>(&mut self, f: F)
@@ -1213,7 +1278,12 @@ fn multiple_with_typegen() {
                 });
             let req = effect.expect_http();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_http<F>(&mut self, f: F) -> &mut Self
@@ -1435,7 +1505,12 @@ fn multiple_with_facet_typegen() {
                     panic!("expected Render effect but no more effects remain")
                 });
             let _ = effect.expect_render();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_render_with<F>(&mut self, f: F)
@@ -1450,7 +1525,12 @@ fn multiple_with_facet_typegen() {
                 });
             let req = effect.expect_render();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_render<F>(&mut self, f: F) -> &mut Self
@@ -1505,7 +1585,12 @@ fn multiple_with_facet_typegen() {
                     panic!("expected Http effect but no more effects remain")
                 });
             let _ = effect.expect_http();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_http_with<F>(&mut self, f: F)
@@ -1520,7 +1605,12 @@ fn multiple_with_facet_typegen() {
                 });
             let req = effect.expect_http();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_http<F>(&mut self, f: F) -> &mut Self
@@ -1737,7 +1827,12 @@ fn multiple_without_typegen() {
                     panic!("expected Render effect but no more effects remain")
                 });
             let _ = effect.expect_render();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_render_with<F>(&mut self, f: F)
@@ -1752,7 +1847,12 @@ fn multiple_without_typegen() {
                 });
             let req = effect.expect_render();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_render<F>(&mut self, f: F) -> &mut Self
@@ -1807,7 +1907,12 @@ fn multiple_without_typegen() {
                     panic!("expected Http effect but no more effects remain")
                 });
             let _ = effect.expect_http();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_http_with<F>(&mut self, f: F)
@@ -1822,7 +1927,12 @@ fn multiple_without_typegen() {
                 });
             let req = effect.expect_http();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_http<F>(&mut self, f: F) -> &mut Self
@@ -1965,7 +2075,12 @@ fn single_without_typegen_with_attributes() {
                     panic!("expected Render effect but no more effects remain")
                 });
             let _ = effect.expect_render();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_render_with<F>(&mut self, f: F)
@@ -1980,7 +2095,12 @@ fn single_without_typegen_with_attributes() {
                 });
             let req = effect.expect_render();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_render<F>(&mut self, f: F) -> &mut Self
@@ -2145,7 +2265,12 @@ fn facet_typegen_with_namespace_attribute() {
                     panic!("expected Render effect but no more effects remain")
                 });
             let _ = effect.expect_render();
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn expect_only_render_with<F>(&mut self, f: F)
@@ -2160,7 +2285,12 @@ fn facet_typegen_with_namespace_attribute() {
                 });
             let req = effect.expect_render();
             f(&req.operation);
-            self.expect_no_effect_or_events();
+            let remaining_effects = self.effects().count();
+            let remaining_events = self.events().count();
+            assert!(
+                remaining_effects + remaining_events == 0,
+                "expected command to be done, found {remaining_effects} effects and {remaining_events} events",
+            );
         }
         #[track_caller]
         fn resolve_render<F>(&mut self, f: F) -> &mut Self

--- a/crux_time/Cargo.toml
+++ b/crux_time/Cargo.toml
@@ -20,6 +20,9 @@ thiserror.workspace = true
 
 [dev-dependencies]
 serde_json = "1.0.149"
+crux_core = { version = "0.17.0", path = "../crux_core", features = [
+    "testing",
+] }
 
 [features]
 facet_typegen = ["crux_core/facet_typegen"]

--- a/examples/counter-http/shared/Cargo.toml
+++ b/examples/counter-http/shared/Cargo.toml
@@ -51,6 +51,7 @@ workspace = true
 
 [dev-dependencies]
 insta = { version = "1.46.3", features = ["yaml"] }
+crux_core = { workspace = true, features = ["testing"] }
 
 # wasm
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/examples/counter-middleware/shared/Cargo.toml
+++ b/examples/counter-middleware/shared/Cargo.toml
@@ -20,12 +20,12 @@ uniffi = ["dep:uniffi", "dep:rand", "dep:getrandom"]
 wasm_bindgen = ["dep:wasm-bindgen", "getrandom/wasm_js", "dep:js-sys"]
 wit_bindgen = ["dep:wit-bindgen", "facet_typegen"]
 codegen = [
-  "crux_core/cli",
-  "dep:clap",
-  "dep:log",
-  "dep:pretty_env_logger",
-  "uniffi",
-  "facet_typegen",
+    "crux_core/cli",
+    "dep:clap",
+    "dep:log",
+    "dep:pretty_env_logger",
+    "uniffi",
+    "facet_typegen",
 ]
 facet_typegen = ["crux_core/facet_typegen"]
 
@@ -56,6 +56,7 @@ workspace = true
 
 [dev-dependencies]
 insta = { version = "1.46.3", features = ["yaml"] }
+crux_core = { workspace = true, features = ["testing"] }
 
 # wasm
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/examples/counter/shared/Cargo.toml
+++ b/examples/counter/shared/Cargo.toml
@@ -53,3 +53,6 @@ log = { version = "0.4.29", optional = true }
 pretty_env_logger = { version = "0.5.0", optional = true }
 uniffi = { version = "=0.29.4", optional = true }
 wasm-bindgen = { version = "0.2.114", optional = true }
+
+[dev-dependencies]
+crux_core = { workspace = true, features = ["testing"] }

--- a/examples/counter/shared/tests/example.rs
+++ b/examples/counter/shared/tests/example.rs
@@ -1,0 +1,15 @@
+use crux_core::App as _;
+use shared::*;
+
+#[test]
+fn increments_count() {
+    let app = Counter;
+    let mut model = Model::default();
+
+    app.update(Event::Increment, &mut model)
+        .expect_only_render();
+
+    let actual_view = app.view(&model).count;
+    let expected_view = "Count is: 1";
+    assert_eq!(actual_view, expected_view);
+}

--- a/examples/notes/shared/Cargo.toml
+++ b/examples/notes/shared/Cargo.toml
@@ -46,3 +46,6 @@ wasm-bindgen = { version = "0.2.114", optional = true }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+crux_core = { workspace = true, features = ["testing"] }

--- a/examples/weather/shared/Cargo.toml
+++ b/examples/weather/shared/Cargo.toml
@@ -47,6 +47,7 @@ wasm-bindgen = { version = "0.2.114", optional = true }
 
 [dev-dependencies]
 assert_let_bind = "0.1"
+crux_core = { workspace = true, features = ["testing"] }
 insta = { version = "1.46.3", features = ["yaml"] }
 rstest = "0.25"
 


### PR DESCRIPTION
## Make macro-generated test helpers available to integration tests

### Motivation

The previous commit on this branch gated the `#[effect]`-generated test helpers behind `#[cfg(test)]`. This works for unit tests defined inside the same crate (in `src/`), but **silently breaks for integration tests** defined in a crate's `tests/` directory.

The reason is a subtlety of how Rust compiles integration tests: a file in `tests/` is compiled as a *separate crate* that depends on the library under test. When the library is compiled for that integration-test binary, `cfg(test)` is **not** set for the library — only for the test crate itself. So any items the macro emitted under `#[cfg(test)]` simply don't exist when an integration test tries to use them, producing confusing "method not found" or "trait not in scope" errors with no obvious fix.

### What changed

#### `crux_macros` — `#[cfg(test)]` replaced with `#[doc(hidden)]`

Two groups of macro-generated items that were previously gated with `#[cfg(test)]` are now annotated with `#[doc(hidden)]` instead:

- **`Effect::expect_*()`** — the per-variant panicking assertion methods on the enum itself (e.g. `Effect::expect_render(self)`). These are used internally by the `EffectTestExt` impl, and occasionally called directly in tests.
- **`EffectTestExt` trait + `impl`** — the fluent `Command`-level helpers (`cmd.expect_render()`, `cmd.resolve_http(…)`, `cmd.then_event(…)`, `cmd.expect_only_render()`, etc.).

`#[doc(hidden)]` achieves the right balance:

- Items are **always compiled**, so integration tests (and any other downstream test crate) can use them without any feature flag or build-script workaround.
- Items are **excluded from rustdoc** output, so they don't clutter the public API docs.
- Items are **deprioritised by IDEs** in autocomplete, so they don't get in the way of normal development.
- The **compile-time and binary-size cost is negligible** — the trait and its blanket impl introduce no vtables, and the generic methods are only monomorphised when actually called. A production build that never calls these helpers pays nothing for them.

The non-panicking `is_*()` and `into_*()` filter methods on the enum remain fully public and unconditional — they are general-purpose utilities appropriate for production effect-dispatch code.

#### Example integration test added

`examples/counter/shared/tests/example.rs` is a minimal integration test that exercises the `EffectTestExt` helpers from outside the `shared` crate, demonstrating the pattern that was previously broken:

```rust
use crux_core::App as _;
use shared::*;

#[test]
fn increments_count() {
    let app = Counter;
    let mut model = Model::default();

    app.update(Event::Increment, &mut model)
        .expect_only_render();

    let actual_view = app.view(&model).count;
    let expected_view = "Count is: 1";
    assert_eq!(actual_view, expected_view);
}
```

#### `crux_core` — `testing` module is now opt-in

`pub mod testing` (which contains `AppTester`, `Update`, `assert_effect!`, and the `Command::expect_*` family of methods) is now gated with:

```rust
#[cfg(any(test, feature = "testing"))]
pub mod testing;
```

A `testing = []` feature has been added to `crux_core/Cargo.toml`.

This cannot use `#[cfg(test)]` alone because `cfg(test)` does not propagate across crate boundaries — when `crux_core` is compiled as a dependency for another crate's tests, it is compiled as a plain library without `cfg(test)` set. Crates that call `Command::expect_one_effect()`, `AppTester`, `assert_effect!`, etc. directly in their test code must opt in by adding to their `[dev-dependencies]`:

```toml
crux_core = { version = "…", features = ["testing"] }
```

Cargo unifies `[dependencies]` and `[dev-dependencies]` feature sets only during test builds, so the `testing` feature is never active in production compilations of those crates.

The one doc test in `command/mod.rs` that used `expect_one_effect()` / `expect_one_event()` has been updated to use `effects().next().expect(…)` / `events().next().expect(…)` — more instructive in documentation and free of any feature dependency.

#### Crates updated to opt in

| Crate | Reason |
|---|---|
| `crux_core` (self) | Own integration tests in `tests/` compile `crux_core` as a dependency |
| `crux_http` | `tests/command_with_tester.rs` uses `AppTester` and `Update::expect_one_effect()` |
| `crux_kv` | `src/tests.rs` (`#[cfg(test)]`) uses `Command::expect_one_effect()` etc. |
| `crux_time` | `tests/time_test.rs` uses `Command::expect_one_effect()` etc. |
| `examples/counter/shared` | Integration test in `tests/` uses `EffectTestExt` and `crux_core::testing` |
| `examples/counter-http/shared` | `#[cfg(test)] mod tests` uses `Command::expect_one_effect()`, `expect_one_event()` |
| `examples/counter-middleware/shared` | Same |
| `examples/notes/shared` | `#[cfg(test)]` modules use `assert_effect!` |
| `examples/weather/shared` | `#[cfg(test)]` modules use `Command::expect_event()` |

Crates that only use `#[effect]` and test exclusively through the generated `EffectTestExt` fluent API (without importing anything from `crux_core::testing` directly) do **not** need the opt-in.

### Snapshot tests

All 10 generated-output snapshots in `crux_macros/src/effect/tests.rs` have been updated to reflect the `#[doc(hidden)]` annotations in place of `#[cfg(test)]`.