### PR TITLE
chore(crux_core): Reduce Command async boilerplate

### DIFF
--- a/crux_core/src/command/builder.rs
+++ b/crux_core/src/command/builder.rs
@@ -6,7 +6,7 @@
 //! of the composition are unclear. If you need to compose streams, use the async
 //! API and tools from the `futures` crate.
 
-use std::{future::Future, pin::pin};
+use std::future::Future;
 
 use futures::{FutureExt, Stream, StreamExt};
 
@@ -42,9 +42,7 @@ where
 
     /// Convert the [`NotificationBuilder`] into a [`Command`] to use in an sync context
     pub fn build(self) -> Command<Effect, Event> {
-        Command::new(|ctx| async move {
-            self.into_future(ctx.clone()).await;
-        })
+        Command::new(move |ctx| self.into_future(ctx))
     }
 }
 
@@ -374,9 +372,9 @@ where
         E: FnOnce(T) -> Event + Send + 'static,
         Task: Future<Output = T> + Send + 'static,
     {
-        Command::new(|ctx| async move {
-            let out = self.into_future(ctx.clone()).await;
-            ctx.send_event(event(out));
+        Command::new(move |ctx| {
+            self.into_future(ctx.clone())
+                .map(move |out| ctx.send_event(event(out)))
         })
     }
 
@@ -390,9 +388,7 @@ where
     /// It might be useful when using a 3rd party capability and you don't
     /// care about the request's response.
     pub fn build(self) -> Command<Effect, Event> {
-        Command::new(|ctx| async move {
-            self.into_future(ctx.clone()).await;
-        })
+        Command::new(move |ctx| self.into_future(ctx).map(|_| ()))
     }
 }
 
@@ -611,12 +607,11 @@ where
     where
         E: Fn(T) -> Event + Send + 'static,
     {
-        Command::new(|ctx| async move {
-            let mut stream = pin!(self.into_stream(ctx.clone()));
-
-            while let Some(out) = stream.next().await {
+        Command::new(move |ctx| {
+            self.into_stream(ctx.clone()).for_each(move |out| {
                 ctx.send_event(event(out));
-            }
+                futures::future::ready(())
+            })
         })
     }
 
@@ -639,10 +634,9 @@ where
     /// It may be useful when using a 3rd party capability and you don't
     /// care about the stream output.
     pub fn build(self) -> Command<Effect, Event> {
-        Command::new(|ctx| async move {
-            let mut stream = pin!(self.into_stream(ctx.clone()));
-
-            while (stream.next().await).is_some() {}
+        Command::new(move |ctx| {
+            self.into_stream(ctx)
+                .for_each(|_| futures::future::ready(()))
         })
     }
 }

--- a/crux_core/src/command/mod.rs
+++ b/crux_core/src/command/mod.rs
@@ -384,7 +384,10 @@ where
     /// the event is not guaranteed to dispatch instantly - another `update` call which is
     /// already scheduled may happen first.
     pub fn event(event: Event) -> Self {
-        Command::new(|ctx| async move { ctx.send_event(event) })
+        Command::new(|ctx| {
+            ctx.send_event(event);
+            futures::future::ready(())
+        })
     }
 
     /// Start a creation of a Command which sends a notification to the shell with a provided
@@ -401,7 +404,10 @@ where
         Op: Operation,
         Effect: From<Request<Op>>,
     {
-        builder::NotificationBuilder::new(|ctx| async move { ctx.notify_shell(operation) })
+        builder::NotificationBuilder::new(|ctx| {
+            ctx.notify_shell(operation);
+            futures::future::ready(())
+        })
     }
 
     /// Start a creation of a Command which sends a one-time request to the shell with a provided
@@ -471,12 +477,12 @@ where
     // Combinators
 
     /// Convert the command into a future to use in an async context
-    pub async fn into_future(self, ctx: CommandContext<Effect, Event>)
+    pub fn into_future(self, ctx: CommandContext<Effect, Event>) -> impl Future<Output = ()>
     where
         Effect: Unpin + Send + 'static,
         Event: Unpin + Send + 'static,
     {
-        self.host(ctx.effects, ctx.events).await;
+        self.host(ctx.effects, ctx.events).map(|_| ())
     }
 
     /// Create a command running self and the other command in sequence
@@ -488,12 +494,11 @@ where
         Effect: Unpin,
         Event: Unpin,
     {
-        Command::new(|ctx| async move {
+        Command::new(|ctx| {
             // first run self until done
-            self.into_future(ctx.clone()).await;
-
-            // then run other until done
-            other.into_future(ctx).await;
+            self.into_future(ctx.clone())
+                // then run other until done
+                .then(|()| other.into_future(ctx))
         })
     }
 
@@ -537,13 +542,13 @@ where
         Effect: Unpin,
         Event: Unpin,
     {
-        Command::new(|ctx| async move {
-            let mapped = self.map(|output| match output {
+        Command::new(move |ctx| {
+            self.map(move |output| match output {
                 CommandOutput::Effect(effect) => CommandOutput::Effect(map(effect)),
                 CommandOutput::Event(event) => CommandOutput::Event(event),
-            });
-
-            mapped.host(ctx.effects, ctx.events).await;
+            })
+            .host(ctx.effects, ctx.events)
+            .map(|_| ())
         })
     }
 
@@ -558,13 +563,13 @@ where
         Effect: Unpin,
         Event: Unpin,
     {
-        Command::new(|ctx| async move {
-            let mapped = self.map(|output| match output {
+        Command::new(move |ctx| {
+            self.map(move |output| match output {
                 CommandOutput::Effect(effect) => CommandOutput::Effect(effect),
                 CommandOutput::Event(event) => CommandOutput::Event(map(event)),
-            });
-
-            mapped.host(ctx.effects, ctx.events).await;
+            })
+            .host(ctx.effects, ctx.events)
+            .map(|_| ())
         })
     }
 

--- a/crux_core/src/command/tests/combinators.rs
+++ b/crux_core/src/command/tests/combinators.rs
@@ -35,6 +35,8 @@ impl From<Request<AnOperation>> for Effect {
 #[derive(Debug, PartialEq)]
 enum Event {
     Completed(AnOperationOutput),
+    First,
+    Second,
 }
 
 #[test]
@@ -739,4 +741,39 @@ fn stream_mapping_and_chaining() {
 
     let Effect::AnEffect(plus_one_request) = effect;
     assert_eq!(plus_one_request.operation, AnOperation::More([3, 4]));
+}
+
+// This test verifies that the order events arrive at the caller always matches
+// the written order of commands in Command::all, regardless of whether they are
+// placed into the internal channel eagerly (Command::event, which calls
+// ctx.send_event synchronously in its closure) or lazily (Command::new with an
+// async block, which only calls ctx.send_event when the future is first polled).
+#[test]
+fn event_ordering_follows_code_order_not_channel_eagerness() {
+    // Case 1: eager (Command::event) is written first in the array.
+    // Even though its event is already in the internal channel before any task
+    // runs, it should still arrive first — matching the written order.
+    let mut cmd: Command<Effect, Event> = Command::all([
+        Command::event(Event::First),
+        Command::new(|ctx| async move {
+            ctx.send_event(Event::Second);
+        }),
+    ]);
+    let events: Vec<_> = cmd.events().collect();
+    assert_eq!(events, vec![Event::First, Event::Second]);
+    assert!(cmd.is_done());
+
+    // Case 2: lazy (async block) is written first.
+    // Even though Command::event's event is eagerly in its internal channel
+    // before Command::all is even called, the lazy command is listed first so
+    // its event should still arrive first.
+    let mut cmd: Command<Effect, Event> = Command::all([
+        Command::new(|ctx| async move {
+            ctx.send_event(Event::First);
+        }),
+        Command::event(Event::Second),
+    ]);
+    let events: Vec<_> = cmd.events().collect();
+    assert_eq!(events, vec![Event::First, Event::Second]);
+    assert!(cmd.is_done());
 }


### PR DESCRIPTION
Hi everyone, 

As I dig in the `crux_core` code I noticed some possible improvements in the `command` building logic, following those [recommandations](https://tweedegolf.nl/en/blog/235/debloat-your-async-rust).

The following improvements were made:

- `Command::build` no longer clones the `CommandContext` and does not create an extra `async` block and the associated state machine
- `Command::then_send` utilizes `futures` crate combinator to avoid an extra `async` block
- `Command::notfiy_shell` and `Command::event` do not create an `async` block and returns a sync block with `futures::ready()`
- `Command::into_future` does not create an extra `async` block and returns the original future with no overhead
- `Command::then`, `Command::map_effect` and `Command::map_event` no longer add extra `async` block and utilize `futures` combinator patterns instead
- `StreamBuilder::then_send` and `StreamBuilder::build` no longer:
  -  `pin!` the stream
  -  clone the `CommandContext`
  - add an extra `async` block 
  
 I do not have benchmarks for these specific changes, but I expect small improvements in binary size, especially for WASM on large projects, and a slight reduction in CPU cycles as we get less async state machines.
 
 On a large project, replacing `async` "pass-through" methods where possible reduced the final bundle wasm optimized bundle size by 10kB. As `Command` are one of the foundation of the crux app, I think any optimization will scale
 
 > I did read `CONTRIBUTING.md` but I'm not sure opening an issue is relevant, as no logic is changed and this does not fix any bug