### PR TITLE
chore(release): crux_core 0.18 and associated crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crux_cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ascent",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "crux_core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -709,7 +709,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "assert_fs",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "crux_kv"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "crux_core",
  "crux_http",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "crux_platform"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "crux_core",
  "facet 0.44.5",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "crux_time"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "crux_core",
@@ -2038,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3247,9 +3247,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3547,9 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3560,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3570,9 +3570,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3583,9 +3583,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3626,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crux_cli/CHANGELOG.md
+++ b/crux_cli/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/redbadger/crux/compare/crux_cli-v0.2.0...crux_cli-v0.3.0) - 2026-05-07
+
 ### ⚙️ Miscellaneous Tasks
 
-- Update to `facet_generate` 0.16 and `facet` 0.44. No changes to the `crux bindgen` CLI surface.
+- No changes to the `crux bindgen` CLI surface.
+- Updated internal codegen test fixtures to reflect restructured examples.
 - Align with `crux_core` 0.18.0.
+- Dependency updates.
 
 ## [0.2.0](https://github.com/redbadger/crux/compare/crux_cli-v0.1.1...crux_cli-v0.2.0) - 2026-03-20
 

--- a/crux_cli/Cargo.toml
+++ b/crux_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crux_cli"
-version = "0.2.0"
+version = "0.3.0"
 description = "Command line tool for crux_core"
 authors.workspace = true
 edition.workspace = true

--- a/crux_core/CHANGELOG.md
+++ b/crux_core/CHANGELOG.md
@@ -6,31 +6,53 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+
+## [0.18.0](https://github.com/redbadger/crux/compare/crux_core-v0.17.0...crux_core-v0.18.0) - 2026-05-07
 
 ### 🚀 Features
 
-**This is a breaking release.**
+- **Fluent effect test assertions**: The `#[effect]` macro (from `crux_macros`) now generates a
+  `<Effect>TestExt` trait on `Command<Effect, Event>` with fluent, chainable assertion and
+  resolution methods per effect variant:
+  - `expect_<effect>(&mut self) -> &mut Self` — assert the next effect is of this type and chain
+  - `expect_<effect>_with(&mut self, |op| ...) -> &mut Self` — assert and inspect the operation
+  - `expect_only_<effect>(&mut self)` — assert this is the only remaining effect or event
+  - `expect_only_<effect>_with(&mut self, |op| ...)` — assert, inspect, and assert done
+  - `resolve_<effect>(&mut self, |op| output) -> &mut Self` — assert, resolve, and chain
+  - `then_event(&mut self, |ev| ...) -> &mut Self` — assert and inspect the next event
 
-#### Major Breaking Changes:
+  These helpers are compiled in only when the `testing` feature is enabled on `crux_core`.
 
-- **`facet_generate` 0.16 / `facet` 0.44**: Runtime installation is now automatic. Remove
-  `.add_runtimes()` from any `Config::builder(...)` chain in your `codegen.rs` — it is no longer
-  available. No other call-site changes are needed; `typegen.swift(&config)`,
-  `typegen.kotlin(&config)`, `typegen.typescript(&config)`, and `typegen.csharp(&config)` work the
-  same as before.
-- **`typegen_extensions/` is no longer read from disk**: Template files for the `serde` typegen
-  backend are now embedded into the library at compile time, so type generation works in
-  sandboxed builds (e.g. Bazel) where the source tree may not exist on the host running `codegen`.
-  If you placed a `typegen_extensions/` directory next to your `build.rs` to override templates,
-  that override no longer takes effect — fork or contribute upstream instead. If you didn't
-  customize templates, no action is required.
+- **C# typegen on `facet_generate` backend**: `CodeGenerator::csharp(&Config)` is now available
+  on the `facet_generate` typegen backend, producing an MSBuild project targeting `net10.0` with
+  a `CommunityToolkit.Mvvm` base reference and a Bincode serialization runtime.
 
-#### New Features:
+### ⚠️ Breaking Changes
 
-- **C# Typegen on `facet_generate`**: The newer `facet_generate` typegen backend now exposes
-  `CodeGenerator::csharp(&Config)`, producing an `MSBuild` project targeting `net10.0` with a
-  `CommunityToolkit.Mvvm` base reference and a Bincode runtime.
+- **`testing` feature required for cross-crate test helpers**: Testing helpers are now gated
+  behind the `testing` feature flag. If your integration tests (`tests/*.rs`) call `crux_core`
+  test helpers or use the generated `<Effect>TestExt` trait, add `features = ["testing"]` to
+  your `crux_core` dev-dependency:
+  ```toml
+  [dev-dependencies]
+  crux_core = { version = "0.18.0", features = ["testing"] }
+  ```
+
+- **`facet_generate` 0.17 — remove `.add_runtimes()`**: Runtime installation is now handled
+  automatically. Remove `.add_runtimes()` from any `Config::builder(...)` chain in your
+  `codegen.rs`. The `typegen.swift`, `typegen.kotlin`, `typegen.typescript`, and `typegen.csharp`
+  call sites are unchanged.
+
+- **`typegen_extensions/` no longer read from disk**: Templates for the `serde` typegen backend
+  are now embedded in the library at compile time, enabling codegen in sandboxed builds (e.g.
+  Bazel). Any `typegen_extensions/` directory placed next to your `build.rs` to override
+  templates is no longer honored.
+
+### ⚙️ Miscellaneous Tasks
+
+- Updated to `facet_generate` 0.17.
+- Dependency updates.
 
 ## [0.17.0](https://github.com/redbadger/crux/compare/crux_core-v0.16.2...crux_core-v0.17.0) - 2026-03-20
 

--- a/crux_core/Cargo.toml
+++ b/crux_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crux_core"
-version = "0.17.0"
+version = "0.18.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -17,8 +17,8 @@ all-features = true
 anyhow.workspace = true
 bincode = "=1.3"
 crossbeam-channel = "0.5"
-crux_cli = { version = "0.2.0", optional = true, path = "../crux_cli" }
-crux_macros = { version = "0.8.0", path = "../crux_macros", optional = true }
+crux_cli = { version = "0.3.0", optional = true, path = "../crux_cli" }
+crux_macros = { version = "0.9.0", path = "../crux_macros", optional = true }
 facet.workspace = true
 facet_generate = { workspace = true, optional = true }
 futures = "0.3"

--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -8,12 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.17.0](https://github.com/redbadger/crux/compare/crux_http-v0.16.0...crux_http-v0.17.0) - 2026-05-07
+
 ### ⚙️ Miscellaneous Tasks
 
-- Align with `crux_core` 0.18.0 and update to `facet_generate` 0.16 / `facet` 0.44. No public
-  API changes; users who consume only the `crux_http` API (e.g. `Http::get(...)`) need no
-  migration. Users running `crux_core` typegen on `crux_http` types should follow the
-  `crux_core` 0.18.0 migration notes.
+- Align with `crux_core` 0.18.0. No public API changes.
+- Dependency updates.
 
 ## [0.16.0](https://github.com/redbadger/crux/compare/crux_http-v0.15.0...crux_http-v0.16.0) - 2026-03-20
 

--- a/crux_http/Cargo.toml
+++ b/crux_http/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_http"
 description = "HTTP capability for use with crux_core"
-version = "0.16.0"
+version = "0.17.0"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true
@@ -21,7 +21,7 @@ http-compat = ["dep:http"]
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1"
-crux_core = { version = "0.17.0", path = "../crux_core" }
+crux_core = { version = "0.18.0", path = "../crux_core" }
 derive_builder = "0.20"
 encoding_rs = { version = "0.8", optional = true }
 facet.workspace = true
@@ -38,13 +38,13 @@ thiserror.workspace = true
 url = "2.5"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-web-sys = { optional = true, version = "0.3.97", features = ["TextDecoder"] }
+web-sys = { optional = true, version = "0.3.98", features = ["TextDecoder"] }
 
 [dev-dependencies]
 assert_fs = "1.1.3"
 futures-test = "0.3"
 assert_matches = "1.5"
 insta = "1.47.2"
-crux_core = { version = "0.17.0", path = "../crux_core", features = [
+crux_core = { version = "0.18.0", path = "../crux_core", features = [
     "testing",
 ] }

--- a/crux_kv/CHANGELOG.md
+++ b/crux_kv/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/redbadger/crux/compare/crux_kv-v0.11.0...crux_kv-v0.12.0) - 2026-05-07
+
 ### ⚙️ Miscellaneous Tasks
 
 - Align with `crux_core` 0.18.0. No public API changes.

--- a/crux_kv/Cargo.toml
+++ b/crux_kv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crux_kv"
-version = "0.11.0"
+version = "0.12.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -12,14 +12,14 @@ keywords.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-crux_core = { version = "0.17.0", path = "../crux_core" }
+crux_core = { version = "0.18.0", path = "../crux_core" }
 facet.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = "0.11"
 thiserror.workspace = true
 
 [dev-dependencies]
-crux_core = { version = "0.17.0", path = "../crux_core", features = [
+crux_core = { version = "0.18.0", path = "../crux_core", features = [
     "testing",
 ] }
 

--- a/crux_macros/CHANGELOG.md
+++ b/crux_macros/CHANGELOG.md
@@ -8,11 +8,29 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/redbadger/crux/compare/crux_macros-v0.8.0...crux_macros-v0.9.0) - 2026-05-07
+
+### 🚀 Features
+
+- **Fluent effect test assertions**: The `#[effect]` macro now generates an `<Effect>TestExt`
+  trait on `Command<Effect, Event>` with chainable, per-variant assertion and resolution methods:
+  `expect_<effect>`, `expect_<effect>_with`, `expect_only_<effect>`, `expect_only_<effect>_with`,
+  `resolve_<effect>`, and `then_event`. These allow integration tests to be written as a
+  readable chain of assertions and responses. The helpers are compiled in only when the `testing`
+  feature is enabled on `crux_core`.
+
+- **Improved assertion error messages**: Effect and event assertion failures now report how many
+  effects and events remain, making failing tests easier to diagnose.
+
+- **`Requests` type registered for facet typegen**: The generated typegen code now also registers
+  `crux_core::bridge::Requests<EffectFfi>` alongside `Request<EffectFfi>`, ensuring the batch
+  request wrapper type is included in generated bindings.
+
 ### ⚙️ Miscellaneous Tasks
 
-- Update to `facet_generate` 0.16 and `facet` 0.44. No changes to the public derive surface
-  (`#[derive(Effect)]`, `#[effect]`); no migration needed for downstream apps.
+- Updated to `facet_generate` 0.17.
 - Align with `crux_core` 0.18.0.
+- Dependency updates.
 
 ## [0.8.0](https://github.com/redbadger/crux/compare/crux_macros-v0.7.0...crux_macros-v0.8.0) - 2026-03-20
 

--- a/crux_macros/Cargo.toml
+++ b/crux_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crux_macros"
-version = "0.8.0"
+version = "0.9.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/crux_platform/CHANGELOG.md
+++ b/crux_platform/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/redbadger/crux/compare/crux_platform-v0.8.0...crux_platform-v0.9.0) - 2026-05-07
+
 ### ⚙️ Miscellaneous Tasks
 
-- Align with `crux_core` 0.18.0 and update to `facet_generate` 0.16 / `facet` 0.44. No public
-  API changes.
+- Align with `crux_core` 0.18.0. No public API changes.
 
 ## [0.8.0](https://github.com/redbadger/crux/compare/crux_platform-v0.7.0...crux_platform-v0.8.0) - 2026-03-20
 

--- a/crux_platform/Cargo.toml
+++ b/crux_platform/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crux_platform"
 description = "Platform capability for use with crux_core"
-version = "0.8.0"
+version = "0.9.0"
 readme = "README.md"
 authors.workspace = true
 repository.workspace = true
@@ -11,6 +11,6 @@ keywords.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-crux_core = { version = "0.17.0", path = "../crux_core" }
+crux_core = { version = "0.18.0", path = "../crux_core" }
 facet.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crux_time/CHANGELOG.md
+++ b/crux_time/CHANGELOG.md
@@ -8,10 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/redbadger/crux/compare/crux_time-v0.15.0...crux_time-v0.16.0) - 2026-05-07
+
 ### ⚙️ Miscellaneous Tasks
 
-- Align with `crux_core` 0.18.0 and update to `facet_generate` 0.16 / `facet` 0.44. No public
-  API changes.
+- Align with `crux_core` 0.18.0. No public API changes.
+- Dependency updates.
 
 ## [0.15.0](https://github.com/redbadger/crux/compare/crux_time-v0.14.0...crux_time-v0.15.0) - 2026-03-20
 

--- a/crux_time/Cargo.toml
+++ b/crux_time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crux_time"
-version = "0.15.0"
+version = "0.16.0"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -12,7 +12,7 @@ keywords.workspace = true
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"], optional = true }
-crux_core = { version = "0.17.0", path = "../crux_core" }
+crux_core = { version = "0.18.0", path = "../crux_core" }
 facet.workspace = true
 futures = "0.3"
 serde = { workspace = true, features = ["derive"] }
@@ -20,7 +20,7 @@ thiserror.workspace = true
 
 [dev-dependencies]
 serde_json = "1.0.149"
-crux_core = { version = "0.17.0", path = "../crux_core", features = [
+crux_core = { version = "0.18.0", path = "../crux_core", features = [
     "testing",
 ] }
 

--- a/examples/counter-http/Cargo.lock
+++ b/examples/counter-http/Cargo.lock
@@ -813,7 +813,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crux_cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ascent",
@@ -839,7 +839,7 @@ dependencies = [
 
 [[package]]
 name = "crux_core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -858,7 +858,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "darling 0.23.0",
  "heck 0.5.0",
@@ -2226,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4068,9 +4068,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4081,9 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4091,9 +4091,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4101,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4114,9 +4114,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4209,9 +4209,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/examples/counter-http/Cargo.toml
+++ b/examples/counter-http/Cargo.toml
@@ -21,8 +21,8 @@ unsafe_code = "forbid"
 anyhow = "1.0.102"
 crux_core = { path = "../../crux_core" }
 crux_http = { path = "../../crux_http" }
-# crux_core = "0.17.0"
-# crux_http = "0.16.0"
+# crux_core = "0.18.0"
+# crux_http = "0.17.0"
 serde = "1.0.228"
 
 [profile]

--- a/examples/counter-http/shared/Cargo.toml
+++ b/examples/counter-http/shared/Cargo.toml
@@ -44,7 +44,7 @@ clap = { version = "4.6.1", optional = true, features = ["derive"] }
 log = { version = "0.4.29", optional = true }
 pretty_env_logger = { version = "0.5.0", optional = true }
 uniffi = { version = "=0.29.4", optional = true }
-wasm-bindgen = { version = "0.2.120", optional = true }
+wasm-bindgen = { version = "0.2.121", optional = true }
 
 [lints]
 workspace = true

--- a/examples/counter-http/web-leptos/Cargo.toml
+++ b/examples/counter-http/web-leptos/Cargo.toml
@@ -14,10 +14,10 @@ console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 futures-util = "0.3.32"
 gloo-net = { version = "0.7.0", features = ["http"] }
-js-sys = "0.3.97"
+js-sys = "0.3.98"
 log = "0.4.29"
 shared = { path = "../shared" }
-wasm-bindgen = "0.2.120"
+wasm-bindgen = "0.2.121"
 wasm-streams = "0.5.0"
 
 leptos = { version = "0.8.19", features = ["csr"] }

--- a/examples/counter-middleware/Cargo.lock
+++ b/examples/counter-middleware/Cargo.lock
@@ -723,7 +723,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crux_cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ascent",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "crux_core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -791,7 +791,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "darling 0.23.0",
  "heck 0.5.0",
@@ -2128,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3951,9 +3951,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3964,9 +3964,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3974,9 +3974,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3984,9 +3984,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3997,9 +3997,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4126,9 +4126,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/examples/counter-middleware/Cargo.toml
+++ b/examples/counter-middleware/Cargo.toml
@@ -21,10 +21,10 @@ unsafe_code = "deny"
 anyhow = "1.0.102"
 crux_core = { path = "../../crux_core" }
 crux_http = { path = "../../crux_http" }
-# crux_core = "0.17.0"
-# crux_http = "0.16.0"
+# crux_core = "0.18.0"
+# crux_http = "0.17.0"
 serde = "1.0.228"
-js-sys = "0.3.97" # FIXME: bring into crux_core, make conditional
+js-sys = "0.3.98" # FIXME: bring into crux_core, make conditional
 
 [profile]
 

--- a/examples/counter-middleware/shared/Cargo.toml
+++ b/examples/counter-middleware/shared/Cargo.toml
@@ -43,12 +43,12 @@ url = "2.5.8"
 # optional dependencies
 clap = { version = "4.6.1", optional = true, features = ["derive"] }
 getrandom = { version = "=0.3", optional = true, default-features = false }
-js-sys = { version = "0.3.97", optional = true }
+js-sys = { version = "0.3.98", optional = true }
 log = { version = "0.4.29", optional = true }
 pretty_env_logger = { version = "0.5.0", optional = true }
 rand = { version = "0.10", optional = true, features = ["sys_rng"] }
 uniffi = { version = "=0.29.4", optional = true }
-wasm-bindgen = { version = "0.2.120", optional = true }
+wasm-bindgen = { version = "0.2.121", optional = true }
 wit-bindgen = { version = "0.57.1", optional = true }
 
 [lints]

--- a/examples/counter-middleware/web-leptos/Cargo.toml
+++ b/examples/counter-middleware/web-leptos/Cargo.toml
@@ -14,10 +14,10 @@ console_error_panic_hook = "0.1.7"
 console_log = "1.0.0"
 futures-util = "0.3.32"
 gloo-net = { version = "0.7.0", features = ["http"] }
-js-sys = "0.3.97"
+js-sys = "0.3.98"
 log = "0.4.29"
 shared = { path = "../shared" }
-wasm-bindgen = "0.2.120"
+wasm-bindgen = "0.2.121"
 wasm-streams = "0.5.0"
 
 leptos = { version = "0.8.19", features = ["csr"] }

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -1194,7 +1194,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crux_cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ascent",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "crux_core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1239,7 +1239,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "darling 0.23.0",
  "heck 0.5.0",
@@ -2188,18 +2188,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.10"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
+checksum = "7f96a4a12fe60ac746ae295a1a4ecb5bb02debc20856506c8635288065f142de"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -3946,9 +3946,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -7693,9 +7693,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
@@ -8287,9 +8287,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8300,9 +8300,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8310,9 +8310,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8320,9 +8320,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8333,9 +8333,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -8444,9 +8444,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -1,5 +1,12 @@
 [workspace]
-members = ["shared", "tauri/src-tauri", "tui", "web-dioxus", "web-leptos", "web-yew"]
+members = [
+    "shared",
+    "tauri/src-tauri",
+    "tui",
+    "web-dioxus",
+    "web-leptos",
+    "web-yew",
+]
 resolver = "3"
 
 [workspace.package]
@@ -20,7 +27,7 @@ unsafe_code = "forbid"
 [workspace.dependencies]
 anyhow = "1.0.102"
 crux_core = { path = "../../crux_core" }
-# crux_core = "0.17.0"
+# crux_core = "0.18.0"
 serde = "1.0.228"
 
 [profile]

--- a/examples/counter/shared/Cargo.toml
+++ b/examples/counter/shared/Cargo.toml
@@ -52,7 +52,7 @@ clap = { version = "4.6.1", optional = true, features = ["derive"] }
 log = { version = "0.4.29", optional = true }
 pretty_env_logger = { version = "0.5.0", optional = true }
 uniffi = { version = "=0.29.4", optional = true }
-wasm-bindgen = { version = "0.2.120", optional = true }
+wasm-bindgen = { version = "0.2.121", optional = true }
 
 [dev-dependencies]
 crux_core = { workspace = true, features = ["testing"] }

--- a/examples/notes/Cargo.lock
+++ b/examples/notes/Cargo.lock
@@ -467,7 +467,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crux_cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ascent",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "crux_core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "crux_kv"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "darling 0.23.0",
  "heck 0.5.0",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "crux_time"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "crux_core",
  "facet",
@@ -1387,9 +1387,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2461,9 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2474,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2484,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2497,9 +2497,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -2540,9 +2540,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/examples/notes/Cargo.toml
+++ b/examples/notes/Cargo.toml
@@ -22,9 +22,9 @@ anyhow = "1.0"
 crux_core = { path = "../../crux_core" }
 crux_kv = { path = "../../crux_kv" }
 crux_time = { path = "../../crux_time" }
-# crux_core = "0.17.0"
-# crux_kv = "0.11.0"
-# crux_time = "0.15.0"
+# crux_core = "0.18.0"
+# crux_kv = "0.12.0"
+# crux_time = "0.16.0"
 serde = "1.0"
 
 [profile.wasm-dev]

--- a/examples/notes/shared/Cargo.toml
+++ b/examples/notes/shared/Cargo.toml
@@ -42,7 +42,7 @@ clap = { version = "4.6.1", optional = true, features = ["derive"] }
 log = { version = "0.4.29", optional = true }
 pretty_env_logger = { version = "0.5.0", optional = true }
 uniffi = { version = "=0.29.4", optional = true }
-wasm-bindgen = { version = "0.2.120", optional = true }
+wasm-bindgen = { version = "0.2.121", optional = true }
 
 [lints]
 workspace = true

--- a/examples/weather/Cargo.lock
+++ b/examples/weather/Cargo.lock
@@ -686,7 +686,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crux_cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ascent",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "crux_core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "crux_kv"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "crux_core",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "crux_macros"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "darling 0.23.0",
  "heck 0.5.0",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "crux_time"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "crux_core",
  "facet 0.44.5",
@@ -2067,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3894,9 +3894,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3907,9 +3907,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3917,9 +3917,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3927,9 +3927,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3940,9 +3940,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4040,9 +4040,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/examples/weather/Cargo.toml
+++ b/examples/weather/Cargo.toml
@@ -23,9 +23,9 @@ crux_core = { path = "../../crux_core" }
 crux_http = { path = "../../crux_http" }
 crux_kv = { path = "../../crux_kv" }
 crux_time = { path = "../../crux_time" }
-# crux_core = "0.17.0"
-# crux_http = "0.16.0"
-# crux_kv = "0.11.0"
+# crux_core = "0.18.0"
+# crux_http = "0.17.0"
+# crux_kv = "0.12.0"
 serde = "1.0.228"
 
 [profile.dev.package]

--- a/examples/weather/shared/Cargo.toml
+++ b/examples/weather/shared/Cargo.toml
@@ -43,7 +43,7 @@ serde = { workspace = true, features = ["derive"] }
 tracing = "0.1"
 serde_json = "1.0"
 uniffi = { version = "=0.29.4", optional = true }
-wasm-bindgen = { version = "0.2.120", optional = true }
+wasm-bindgen = { version = "0.2.121", optional = true }
 
 [dev-dependencies]
 assert_let_bind = "0.1"

--- a/examples/weather/web-leptos/Cargo.toml
+++ b/examples/weather/web-leptos/Cargo.toml
@@ -17,12 +17,12 @@ crux_time.workspace = true
 futures-util = "0.3.32"
 gloo-net = { version = "0.7.0", features = ["http"] }
 gloo-timers = { version = "0.4", features = ["futures"] }
-js-sys = "0.3.97"
+js-sys = "0.3.98"
 log = "0.4.29"
 shared = { path = "../shared" }
-wasm-bindgen = "0.2.120"
-wasm-bindgen-futures = "0.4.70"
-web-sys = { version = "0.3.97", features = ["Geolocation", "Navigator", "Position", "Coordinates", "Storage", "Window"] }
+wasm-bindgen = "0.2.121"
+wasm-bindgen-futures = "0.4.71"
+web-sys = { version = "0.3.98", features = ["Geolocation", "Navigator", "Position", "Coordinates", "Storage", "Window"] }
 
 leptos = { version = "0.8.19", features = ["csr"] }
 phosphor-leptos = "0.8.0"

--- a/examples_support/api_server/Cargo.toml
+++ b/examples_support/api_server/Cargo.toml
@@ -12,6 +12,6 @@ rand = "0.10"
 serde = "1.0.228"
 serde_json = "1.0.149"
 tokio = { version = "1.52.2", features = ["full"] }
-tower-http = { version = "0.6.9", features = ["cors"] }
+tower-http = { version = "0.6.10", features = ["cors"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }


### PR DESCRIPTION
release prep for `crux_core` v0.18.0