### PR TITLE
use classic `powershell.exe` instead of newer `pwsh.exe`

### DIFF
--- a/examples/counter/windows/Justfile
+++ b/examples/counter/windows/Justfile
@@ -1,4 +1,4 @@
-set windows-shell := ["pwsh.exe", "-NoLogo", "-NoProfile", "-Command"]
+set windows-shell := ["powershell.exe", "-NoLogo", "-NoProfile", "-Command"]
 default: dev
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
@mhedgpeth 
To keep the barriers as low as possible, and because I don't see any need for the newer PowerShell, I would go with the more widely used executable.