### PR TITLE
Fix Apple build for Xcode 26 explicit module builds

### DIFF
--- a/examples/counter/apple/Justfile
+++ b/examples/counter/apple/Justfile
@@ -53,7 +53,9 @@ package: install-targets
     for slice in ios-arm64 ios-arm64_x86_64-simulator macos-arm64_x86_64; do \
         target="../apple/generated/Shared/Shared.xcframework/$slice/Headers"; \
         if [ -d "$target" ]; then \
-            printf 'module SharedFFI {\n    header "shared/shared.h"\n    export *\n}\n' > "$target/module.modulemap"; \
+            cp "$target/shared/shared.h" "$target/shared.h"; \
+            rm -f "$target/shared/module.modulemap"; \
+            printf 'module SharedFFI {\n    header "shared.h"\n    export *\n}\n' > "$target/module.modulemap"; \
         fi \
     done
 

--- a/examples/counter/apple/Justfile
+++ b/examples/counter/apple/Justfile
@@ -49,6 +49,13 @@ package: install-targets
     @echo '{{ style("command") }}package:{{ NORMAL }}'
     rm -rf ../apple/generated/Shared
     boltffi pack apple
+    @echo '  Patching xcframework module maps for Xcode 26 explicit module build compatibility'
+    for slice in ios-arm64 ios-arm64_x86_64-simulator macos-arm64_x86_64; do \
+        target="../apple/generated/Shared/Shared.xcframework/$slice/Headers"; \
+        if [ -d "$target" ]; then \
+            printf 'module SharedFFI {\n    header "shared/shared.h"\n    export *\n}\n' > "$target/module.modulemap"; \
+        fi \
+    done
 
 # rebuilds the Xcode project from project.yml
 generate-project:

--- a/examples/counter/apple/project.yml
+++ b/examples/counter/apple/project.yml
@@ -36,6 +36,10 @@ targets:
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
         UILaunchScreen: {}
+    settings:
+      # Xcode 26 enables explicit module builds by default; disable until
+      # boltffi's namespaced xcframework header layout is supported.
+      SWIFT_ENABLE_EXPLICIT_MODULES: NO
 
   CounterApp-macOS:
     templates: [app]
@@ -48,3 +52,6 @@ targets:
     settings:
       OTHER_LDFLAGS: [-w]
       ENABLE_USER_SCRIPT_SANDBOXING: NO
+      # Xcode 26 enables explicit module builds by default; disable until
+      # boltffi's namespaced xcframework header layout is supported.
+      SWIFT_ENABLE_EXPLICIT_MODULES: NO


### PR DESCRIPTION
**Fix Apple build for Xcode 26 explicit module builds**

## Problem

Xcode 26 enables **Explicit Module Builds** by default. In this mode the Swift compiler scans for Clang module maps at the declared `HeadersPath` of each xcframework binary target — it does not recurse into subdirectories.

`boltffi pack apple` namespaces xcframework headers into a `shared/` subdirectory to avoid collisions between multiple frameworks, so the generated layout is:

```
Shared.xcframework/<slice>/Headers/shared/module.modulemap   ← nested
Shared.xcframework/<slice>/Headers/shared/shared.h
```

The explicit module scanner only searches `Headers/` and never finds `module.modulemap`, causing:

```
error: unable to resolve module dependency: 'SharedFFI'
import SharedFFI
       ^
```

## Fix

Two changes:

**`Justfile`** — adds a post-processing step after `boltffi pack apple` that writes a root-level `module.modulemap` into each xcframework slice's `Headers/` directory:

```
module SharedFFI {
    header "shared/shared.h"
    export *
}
```

This is immediately visible to the explicit module scanner while still resolving the header via its namespaced path. The patch runs automatically as part of `just package`, `just generate`, and `just build`, so it survives rebuilds.

**`project.yml`** — adds `SWIFT_ENABLE_EXPLICIT_MODULES: NO` to both `CounterApp-iOS` and `CounterApp-macOS` targets as a belt-and-braces guard for the main project targets (the Justfile patch is what fixes the SPM package targets, which don't inherit this setting).

## Notes

- This is a workaround for a mismatch between boltffi's xcframework header layout and Xcode 26's stricter module scanning. The proper long-term fix is upstream in boltffi's `namespace_xcframework_slice_headers` logic — either placing the `module.modulemap` at the `Headers/` root, or updating the `HeadersPath` in `Info.plist` to point at the `shared/` subdirectory directly.
- No changes to Rust code, generated Swift bindings, or runtime behaviour.