### PR TITLE
chore: crux versions in docs

### DIFF
--- a/crux_core/src/type_generation/facet.rs
+++ b/crux_core/src/type_generation/facet.rs
@@ -10,7 +10,7 @@
 //!
 //! ```rust,ignore
 //! [build-dependencies]
-//! crux_core = { version = "0.15", features = ["facet_typegen"] }
+//! crux_core = { version = "0.19", features = ["facet_typegen"] }
 //! ```
 //!
 //! * Your `shared_types` library, will have an empty `lib.rs`, since we only use it for generating foreign language type declarations.

--- a/crux_core/src/type_generation/serde.rs
+++ b/crux_core/src/type_generation/serde.rs
@@ -10,7 +10,7 @@
 //!
 //! ```rust,ignore
 //! [build-dependencies]
-//! crux_core = { version = "0.15", features = ["typegen"] }
+//! crux_core = { version = "0.19", features = ["typegen"] }
 //! ```
 //!
 //! * Your `shared_types` library, will have an empty `lib.rs`, since we only use it for generating foreign language type declarations.

--- a/docs/src/part-1/getting_started.md
+++ b/docs/src/part-1/getting_started.md
@@ -57,7 +57,7 @@ rust-version = "1.90"
 
 [workspace.dependencies]
 anyhow = "1.0.102"
-crux_core = "0.17.0"
+crux_core = "0.19"
 serde = "1.0.228"
 ```
 

--- a/examples/counter-http/Cargo.toml
+++ b/examples/counter-http/Cargo.toml
@@ -23,8 +23,6 @@ anyhow = "1.0.102"
 boltffi = "=0.25.2"
 crux_core = { path = "../../crux_core" }
 crux_http = { path = "../../crux_http" }
-# crux_core = "0.18.0"
-# crux_http = "0.17.0"
 serde = "1.0.228"
 
 [profile]

--- a/examples/counter-middleware/Cargo.toml
+++ b/examples/counter-middleware/Cargo.toml
@@ -23,10 +23,8 @@ anyhow = "1.0.102"
 boltffi = "=0.25.2"
 crux_core = { path = "../../crux_core" }
 crux_http = { path = "../../crux_http" }
-# crux_core = "0.18.0"
-# crux_http = "0.17.0"
 serde = "1.0.228"
-js-sys = "0.3.99" # FIXME: bring into crux_core, make conditional
+js-sys = "0.3.99"                        # FIXME: bring into crux_core, make conditional
 
 [profile]
 

--- a/examples/counter-routing/Cargo.toml
+++ b/examples/counter-routing/Cargo.toml
@@ -22,10 +22,8 @@ anyhow = "1.0.102"
 boltffi = "=0.25.2"
 crux_core = { path = "../../crux_core" }
 crux_http = { path = "../../crux_http" }
-# crux_core = "0.17.0"
-# crux_http = "0.16.0"
 serde = "1.0.228"
-js-sys = "0.3.99" # FIXME: bring into crux_core, make conditional
+js-sys = "0.3.99"                        # FIXME: bring into crux_core, make conditional
 
 [profile]
 

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -29,7 +29,6 @@ unsafe_code = "forbid"
 anyhow = "1.0.102"
 boltffi = "=0.25.2"
 crux_core = { path = "../../crux_core" }
-# crux_core = "0.18.0"
 serde = "1.0.228"
 
 [profile]

--- a/examples/notes/Cargo.toml
+++ b/examples/notes/Cargo.toml
@@ -24,9 +24,7 @@ boltffi = "=0.25.2"
 crux_core = { path = "../../crux_core" }
 crux_kv = { path = "../../crux_kv" }
 crux_time = { path = "../../crux_time" }
-# crux_core = "0.18.0"
-# crux_kv = "0.12.0"
-# crux_time = "0.16.0"
+
 serde = "1.0"
 
 [profile.wasm-dev]

--- a/examples/weather/Cargo.toml
+++ b/examples/weather/Cargo.toml
@@ -25,9 +25,7 @@ crux_core = { path = "../../crux_core" }
 crux_http = { path = "../../crux_http" }
 crux_kv = { path = "../../crux_kv" }
 crux_time = { path = "../../crux_time" }
-# crux_core = "0.18.0"
-# crux_http = "0.17.0"
-# crux_kv = "0.12.0"
+
 serde = "1.0.228"
 
 [profile.dev.package]


### PR DESCRIPTION
Updates version of `crux_core` referenced in the getting started guide in the book