### PR TITLE
fix: build for examples with MacOS shells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
+checksum = "831d4a105b7e0abce52910f544ffa2698064b1d4864d381672137f804548a45a"
 dependencies = [
  "derive_builder",
  "facet 0.44.5",

--- a/examples/counter-http/Cargo.lock
+++ b/examples/counter-http/Cargo.lock
@@ -1097,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
+checksum = "831d4a105b7e0abce52910f544ffa2698064b1d4864d381672137f804548a45a"
 dependencies = [
  "derive_builder",
  "facet 0.44.5",

--- a/examples/counter-http/apple/Justfile
+++ b/examples/counter-http/apple/Justfile
@@ -43,12 +43,26 @@ typegen:
             --language swift \
             --output-dir generated
 
-# builds the shared library as a Swift package using BoltFFI
+# builds the shared library as a Swift package using BoltFFI, then fixes the
+# macOS XCFramework slice from a shallow (iOS-style) bundle to the versioned
+# bundle structure that macOS requires. boltffi currently generates shallow
+# bundles for all platforms (see https://github.com/boltffi/boltffi/issues/560).
 [working-directory('../shared')]
 package: install-targets
     @echo '{{ style("command") }}package:{{ NORMAL }}'
     rm -rf ../apple/generated/Shared
     boltffi pack apple
+    FW="../apple/generated/Shared/Shared.xcframework/macos-arm64_x86_64/SharedFFI.framework" ; \
+    mkdir -p "$FW/Versions/A/Resources" ; \
+    mv "$FW/SharedFFI"   "$FW/Versions/A/SharedFFI" ; \
+    mv "$FW/Headers"     "$FW/Versions/A/Headers" ; \
+    mv "$FW/Modules"     "$FW/Versions/A/Modules" ; \
+    mv "$FW/Info.plist"  "$FW/Versions/A/Resources/Info.plist" ; \
+    ln -sf A                          "$FW/Versions/Current" ; \
+    ln -sf Versions/Current/SharedFFI "$FW/SharedFFI" ; \
+    ln -sf Versions/Current/Headers   "$FW/Headers" ; \
+    ln -sf Versions/Current/Modules   "$FW/Modules" ; \
+    ln -sf Versions/Current/Resources "$FW/Resources"
 
 # rebuilds the Xcode project from project.yml
 generate-project:

--- a/examples/counter-middleware/Cargo.lock
+++ b/examples/counter-middleware/Cargo.lock
@@ -1007,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
+checksum = "831d4a105b7e0abce52910f544ffa2698064b1d4864d381672137f804548a45a"
 dependencies = [
  "derive_builder",
  "facet 0.44.5",

--- a/examples/counter-middleware/apple/Justfile
+++ b/examples/counter-middleware/apple/Justfile
@@ -43,12 +43,26 @@ typegen:
             --language swift \
             --output-dir generated
 
-# builds the shared library as a Swift package using BoltFFI
+# builds the shared library as a Swift package using BoltFFI, then fixes the
+# macOS XCFramework slice from a shallow (iOS-style) bundle to the versioned
+# bundle structure that macOS requires. boltffi currently generates shallow
+# bundles for all platforms (see https://github.com/boltffi/boltffi/issues/560).
 [working-directory('../shared')]
 package: install-targets
     @echo '{{ style("command") }}package:{{ NORMAL }}'
     rm -rf ../apple/generated/Shared
     boltffi pack apple
+    FW="../apple/generated/Shared/Shared.xcframework/macos-arm64_x86_64/SharedFFI.framework" ; \
+    mkdir -p "$FW/Versions/A/Resources" ; \
+    mv "$FW/SharedFFI"   "$FW/Versions/A/SharedFFI" ; \
+    mv "$FW/Headers"     "$FW/Versions/A/Headers" ; \
+    mv "$FW/Modules"     "$FW/Versions/A/Modules" ; \
+    mv "$FW/Info.plist"  "$FW/Versions/A/Resources/Info.plist" ; \
+    ln -sf A                          "$FW/Versions/Current" ; \
+    ln -sf Versions/Current/SharedFFI "$FW/SharedFFI" ; \
+    ln -sf Versions/Current/Headers   "$FW/Headers" ; \
+    ln -sf Versions/Current/Modules   "$FW/Modules" ; \
+    ln -sf Versions/Current/Resources "$FW/Resources"
 
 # rebuilds the Xcode project from project.yml
 generate-project:

--- a/examples/counter-routing/Cargo.lock
+++ b/examples/counter-routing/Cargo.lock
@@ -1007,9 +1007,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
+checksum = "831d4a105b7e0abce52910f544ffa2698064b1d4864d381672137f804548a45a"
 dependencies = [
  "derive_builder",
  "facet 0.44.5",

--- a/examples/counter-routing/apple/Justfile
+++ b/examples/counter-routing/apple/Justfile
@@ -43,12 +43,26 @@ typegen:
             --language swift \
             --output-dir generated
 
-# builds the shared library as a Swift package using BoltFFI
+# builds the shared library as a Swift package using BoltFFI, then fixes the
+# macOS XCFramework slice from a shallow (iOS-style) bundle to the versioned
+# bundle structure that macOS requires. boltffi currently generates shallow
+# bundles for all platforms (see https://github.com/boltffi/boltffi/issues/560).
 [working-directory('../shared')]
 package: install-targets
     @echo '{{ style("command") }}package:{{ NORMAL }}'
     rm -rf ../apple/generated/Shared
     boltffi pack apple
+    FW="../apple/generated/Shared/Shared.xcframework/macos-arm64_x86_64/SharedFFI.framework" ; \
+    mkdir -p "$FW/Versions/A/Resources" ; \
+    mv "$FW/SharedFFI"   "$FW/Versions/A/SharedFFI" ; \
+    mv "$FW/Headers"     "$FW/Versions/A/Headers" ; \
+    mv "$FW/Modules"     "$FW/Versions/A/Modules" ; \
+    mv "$FW/Info.plist"  "$FW/Versions/A/Resources/Info.plist" ; \
+    ln -sf A                          "$FW/Versions/Current" ; \
+    ln -sf Versions/Current/SharedFFI "$FW/SharedFFI" ; \
+    ln -sf Versions/Current/Headers   "$FW/Headers" ; \
+    ln -sf Versions/Current/Modules   "$FW/Modules" ; \
+    ln -sf Versions/Current/Resources "$FW/Resources"
 
 # rebuilds the Xcode project from project.yml
 generate-project:

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -2215,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
+checksum = "831d4a105b7e0abce52910f544ffa2698064b1d4864d381672137f804548a45a"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/counter/apple/Justfile
+++ b/examples/counter/apple/Justfile
@@ -43,12 +43,26 @@ typegen:
             --language swift \
             --output-dir generated
 
-# builds the shared library as a Swift package using BoltFFI
+# builds the shared library as a Swift package using BoltFFI, then fixes the
+# macOS XCFramework slice from a shallow (iOS-style) bundle to the versioned
+# bundle structure that macOS requires. boltffi currently generates shallow
+# bundles for all platforms (see https://github.com/boltffi/boltffi/issues/560).
 [working-directory('../shared')]
 package: install-targets
     @echo '{{ style("command") }}package:{{ NORMAL }}'
     rm -rf ../apple/generated/Shared
     boltffi pack apple
+    FW="../apple/generated/Shared/Shared.xcframework/macos-arm64_x86_64/SharedFFI.framework" ; \
+    mkdir -p "$FW/Versions/A/Resources" ; \
+    mv "$FW/SharedFFI"   "$FW/Versions/A/SharedFFI" ; \
+    mv "$FW/Headers"     "$FW/Versions/A/Headers" ; \
+    mv "$FW/Modules"     "$FW/Versions/A/Modules" ; \
+    mv "$FW/Info.plist"  "$FW/Versions/A/Resources/Info.plist" ; \
+    ln -sf A                          "$FW/Versions/Current" ; \
+    ln -sf Versions/Current/SharedFFI "$FW/SharedFFI" ; \
+    ln -sf Versions/Current/Headers   "$FW/Headers" ; \
+    ln -sf Versions/Current/Modules   "$FW/Modules" ; \
+    ln -sf Versions/Current/Resources "$FW/Resources"
 
 # rebuilds the Xcode project from project.yml
 generate-project:

--- a/examples/notes/Cargo.lock
+++ b/examples/notes/Cargo.lock
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
+checksum = "831d4a105b7e0abce52910f544ffa2698064b1d4864d381672137f804548a45a"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/weather/Cargo.lock
+++ b/examples/weather/Cargo.lock
@@ -993,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2735cffb3535a6d1554197eaf509192103c9fd0f66cf01f143c252ef0f78d7"
+checksum = "831d4a105b7e0abce52910f544ffa2698064b1d4864d381672137f804548a45a"
 dependencies = [
  "derive_builder",
  "facet 0.44.5",

--- a/examples/weather/apple/Justfile
+++ b/examples/weather/apple/Justfile
@@ -43,12 +43,26 @@ typegen:
             --language swift \
             --output-dir generated
 
-# builds the shared library as a Swift package using BoltFFI
+# builds the shared library as a Swift package using BoltFFI, then fixes the
+# macOS XCFramework slice from a shallow (iOS-style) bundle to the versioned
+# bundle structure that macOS requires. boltffi currently generates shallow
+# bundles for all platforms (see https://github.com/boltffi/boltffi/issues/560).
 [working-directory('../shared')]
 package: install-targets
     @echo '{{ style("command") }}package:{{ NORMAL }}'
     rm -rf ../apple/generated/Shared
     boltffi pack apple
+    FW="../apple/generated/Shared/Shared.xcframework/macos-arm64_x86_64/SharedFFI.framework" ; \
+    mkdir -p "$FW/Versions/A/Resources" ; \
+    mv "$FW/SharedFFI"   "$FW/Versions/A/SharedFFI" ; \
+    mv "$FW/Headers"     "$FW/Versions/A/Headers" ; \
+    mv "$FW/Modules"     "$FW/Versions/A/Modules" ; \
+    mv "$FW/Info.plist"  "$FW/Versions/A/Resources/Info.plist" ; \
+    ln -sf A                          "$FW/Versions/Current" ; \
+    ln -sf Versions/Current/SharedFFI "$FW/SharedFFI" ; \
+    ln -sf Versions/Current/Headers   "$FW/Headers" ; \
+    ln -sf Versions/Current/Modules   "$FW/Modules" ; \
+    ln -sf Versions/Current/Resources "$FW/Resources"
 
 # rebuilds the Xcode project from project.yml
 generate-project:


### PR DESCRIPTION
Temporary workaround for [this problem](https://github.com/boltffi/boltffi/issues/560) when building MacOS shells in examples 