### PR TITLE
chore: port TypeScript shells to discriminated union types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,7 @@ dependencies = [
  "derive_builder",
  "encoding_rs",
  "facet 0.44.5",
- "facet-generate-attrs",
+ "facet-generate-attrs 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-test",
  "futures-util",
  "http",
@@ -516,7 +516,7 @@ dependencies = [
  "crux_http",
  "darling 0.23.0",
  "facet 0.44.5",
- "facet-generate-attrs",
+ "facet-generate-attrs 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.5.0",
  "insta",
  "prettyplease",
@@ -786,6 +786,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-generate-attrs"
+version = "0.17.0"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+dependencies = [
+ "facet 0.44.5",
+]
+
+[[package]]
 name = "facet-macro-parse"
 version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,12 +872,11 @@ dependencies = [
 [[package]]
 name = "facet_generate"
 version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab57b923bae6e204f5e47643054a9c5ad9c3bd9aadec66df741790de8a859f"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
 dependencies = [
  "derive_builder",
  "facet 0.44.5",
- "facet-generate-attrs",
+ "facet-generate-attrs 0.17.0 (git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions)",
  "heck 0.5.0",
  "include_dir 0.7.4",
  "indent",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,7 @@ dependencies = [
  "derive_builder",
  "encoding_rs",
  "facet 0.44.5",
- "facet-generate-attrs 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "facet-generate-attrs",
  "futures-test",
  "futures-util",
  "http",
@@ -516,7 +516,7 @@ dependencies = [
  "crux_http",
  "darling 0.23.0",
  "facet 0.44.5",
- "facet-generate-attrs 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "facet-generate-attrs",
  "heck 0.5.0",
  "insta",
  "prettyplease",
@@ -786,14 +786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "facet-generate-attrs"
-version = "0.17.0"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
-dependencies = [
- "facet 0.44.5",
-]
-
-[[package]]
 name = "facet-macro-parse"
 version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -871,12 +863,13 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.2"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c7ecce0761dfa28c527bb006a4391336618bd5088c16c8a61ae9bf1f6c0d2f"
 dependencies = [
  "derive_builder",
  "facet 0.44.5",
- "facet-generate-attrs 0.17.0 (git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions)",
+ "facet-generate-attrs",
  "heck 0.5.0",
  "include_dir 0.7.4",
  "indent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,10 @@ keywords = ["cross-platform-ui", "crux", "crux_core", "ffi", "wasm"]
 [workspace.dependencies]
 anyhow = "1.0"
 facet = "=0.44"
-# facet_generate = "0.17"
-facet_generate = { git = "https://github.com/redbadger/facet-generate", branch = "feat/typescript-discriminated-unions" }
+facet_generate = "0.18"
 facet-generate-attrs = "0.17"
+# facet_generate = { path = "../facet-generate/crates/facet_generate" }
+# facet-generate-attrs = { path = "../facet-generate/crates/facet-generate-attrs" }
 serde = "1.0"
 thiserror = "2.0"
 uniffi = "=0.29.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,9 @@ keywords = ["cross-platform-ui", "crux", "crux_core", "ffi", "wasm"]
 [workspace.dependencies]
 anyhow = "1.0"
 facet = "=0.44"
-facet_generate = "0.17"
+# facet_generate = "0.17"
+facet_generate = { git = "https://github.com/redbadger/facet-generate", branch = "feat/typescript-discriminated-unions" }
 facet-generate-attrs = "0.17"
-# facet_generate = { path = "../facet-generate/crates/facet_generate" }
-# facet-generate-attrs = { path = "../facet-generate/crates/facet-generate-attrs" }
 serde = "1.0"
 thiserror = "2.0"
 uniffi = "=0.29.4"

--- a/Justfile
+++ b/Justfile
@@ -1,19 +1,31 @@
 # Crates published in order (dependencies before dependents)
 publish_packages := "crux_macros crux_core crux_http crux_kv crux_time"
 
-default: ci
+# Recipes here cover the root workspace only, so they stay fast enough for a
+# tight edit loop. The examples need every platform toolchain (Xcode, Android
+# SDK, .NET, trunk, dioxus, GTK) and are opt-in via the `*-examples` recipes —
+# in real CI they fan out across separate runners, one shell per job.
+
+default: dev
+
+# Local development loop — fix, check, build, and test the root workspace
+dev: fix check build test
 
 # Build the root workspace
 build:
     @echo '{{ style("command") }}build:{{ NORMAL }}'
     cargo build --all-features
 
-# Check formatting, types, and linting in the root workspace and all examples
+# Check formatting, types, and linting in the root workspace
 check:
     @echo '{{ style("command") }}check:{{ NORMAL }}'
     cargo fmt --all --check
     cargo check --all-features
     cargo clippy --all-targets -- --no-deps -Dclippy::pedantic -Dclippy::nursery -Dwarnings
+
+# Check formatting and lint in all examples (heavy — needs every platform toolchain)
+check-examples:
+    @echo '{{ style("command") }}check-examples:{{ NORMAL }}'
     just examples/check
 
 # Clean build artefacts in the root workspace and all examples
@@ -22,10 +34,14 @@ clean:
     cargo clean
     just examples/clean
 
-# Fix formatting in the root workspace and all examples
+# Fix formatting in the root workspace
 fix:
     @echo '{{ style("command") }}fix:{{ NORMAL }}'
     cargo fmt --all
+
+# Fix formatting in all examples (heavy — needs every platform toolchain)
+fix-examples:
+    @echo '{{ style("command") }}fix-examples:{{ NORMAL }}'
     just examples/fix
 
 # Run tests locally (with cargo-insta snapshot review)
@@ -33,12 +49,25 @@ test:
     @echo '{{ style("command") }}test:{{ NORMAL }}'
     cargo insta test --review --test-runner nextest --all-features --lib
 
-# Run CI workflow — check, build, and test the root workspace, then all examples
+# Mirror the `build` CI workflow — root workspace only, no examples
 ci: check build
     @echo '{{ style("command") }}test:{{ NORMAL }}'
     cargo nextest run --all-features
     cargo test --doc --all-features
+    @echo '{{ style("command") }}test (crux_http with http-types compat feature):{{ NORMAL }}'
+    cargo nextest run -p crux_http --features crux_http/http-types
+    cargo test --doc -p crux_http --features crux_http/http-types
+    @echo '{{ style("command") }}check (crux_http for wasm32-unknown-unknown):{{ NORMAL }}'
+    cargo check -p crux_http --target wasm32-unknown-unknown
+
+# Mirror the `examples` CI workflow — every example x shell, serially (very heavy)
+ci-examples:
+    @echo '{{ style("command") }}ci-examples:{{ NORMAL }}'
+    # CI spreads this across many runners, each with only its platform's toolchain
     just examples/ci
+
+# Everything CI runs — root workspace and all examples
+ci-all: ci ci-examples
 
 # Run doc tests
 test-doc:

--- a/docs/src/part-2/shell/react.md
+++ b/docs/src/part-2/shell/react.md
@@ -50,7 +50,7 @@ Then components fire events with:
 
 ```typescript
 const dispatch = useDispatch();
-dispatch(new EventVariantActive(new ActiveEventVariantResetApiKey()));
+dispatch(eventActive(activeEventResetApiKey()));
 ```
 
 Both directions cross the FFI as bincode. `dispatch` is just a JS callback wrapping the serialise-and-call-update flow; `setView` is a React state setter the `Core` invokes after deserialising the response to `Effect::Render`.

--- a/examples/counter-http/Cargo.lock
+++ b/examples/counter-http/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
  "derive_builder",
  "encoding_rs",
  "facet",
- "facet-generate-attrs 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "facet-generate-attrs",
  "futures-util",
  "http",
  "mime",
@@ -983,14 +983,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "facet-generate-attrs"
-version = "0.17.0"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
-dependencies = [
- "facet",
-]
-
-[[package]]
 name = "facet-macro-parse"
 version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,12 +1029,13 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.2"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c7ecce0761dfa28c527bb006a4391336618bd5088c16c8a61ae9bf1f6c0d2f"
 dependencies = [
  "derive_builder",
  "facet",
- "facet-generate-attrs 0.17.0 (git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions)",
+ "facet-generate-attrs",
  "heck",
  "include_dir",
  "indent",

--- a/examples/counter-http/Cargo.lock
+++ b/examples/counter-http/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
  "derive_builder",
  "encoding_rs",
  "facet",
- "facet-generate-attrs",
+ "facet-generate-attrs 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util",
  "http",
  "mime",
@@ -983,6 +983,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-generate-attrs"
+version = "0.17.0"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+dependencies = [
+ "facet",
+]
+
+[[package]]
 name = "facet-macro-parse"
 version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1030,12 +1038,11 @@ dependencies = [
 [[package]]
 name = "facet_generate"
 version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab57b923bae6e204f5e47643054a9c5ad9c3bd9aadec66df741790de8a859f"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
 dependencies = [
  "derive_builder",
  "facet",
- "facet-generate-attrs",
+ "facet-generate-attrs 0.17.0 (git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions)",
  "heck",
  "include_dir",
  "indent",

--- a/examples/counter-http/web-nextjs/src/app/core.ts
+++ b/examples/counter-http/web-nextjs/src/app/core.ts
@@ -42,14 +42,16 @@ export class Core {
         this.callback(deserializeView(this.core.view()));
       },
       Http: (e): void => {
-        void http.request(e.value).then(response =>
-          this.respond(id, s => serializeHttpResult(response, s))
-        );
+        void http
+          .request(e.value)
+          .then((response) =>
+            this.respond(id, (s) => serializeHttpResult(response, s)),
+          );
       },
       ServerSentEvents: (e): void => {
         void (async () => {
           for await (const response of sse.request(e.value)) {
-            this.respond(id, s => serializeSseResponse(response, s));
+            this.respond(id, (s) => serializeSseResponse(response, s));
           }
         })();
       },

--- a/examples/counter-http/web-nextjs/src/app/core.ts
+++ b/examples/counter-http/web-nextjs/src/app/core.ts
@@ -1,20 +1,19 @@
 import type { Dispatch, SetStateAction } from "react";
 
 import { CoreFFI } from "shared";
-import type { Effect, Event, RenderOperation } from "shared_types/app";
+import type { Effect, Event } from "shared_types/app";
 import {
-  EffectVariantHttp,
-  EffectVariantRender,
-  EffectVariantServerSentEvents,
+  matchEffect,
+  serializeEvent,
+  serializeHttpResult,
+  serializeSseResponse,
   Request,
   ViewModel,
 } from "shared_types/app";
 import { BincodeDeserializer, BincodeSerializer } from "shared_types/bincode";
+import type { Serializer } from "shared_types/serde";
 import * as http from "./http";
 import * as sse from "./sse";
-
-// union of all Operation types, only render is needed here
-type Response = RenderOperation;
 
 export class Core {
   core: CoreFFI;
@@ -27,7 +26,7 @@ export class Core {
 
   update(event: Event) {
     const serializer = new BincodeSerializer();
-    event.serialize(serializer);
+    serializeEvent(event, serializer);
 
     const effects = this.core.update(serializer.getBytes());
 
@@ -37,33 +36,29 @@ export class Core {
     }
   }
 
-  async resolve(id: number, effect: Effect) {
-    switch (effect.constructor) {
-      case EffectVariantRender: {
+  resolve(id: number, effect: Effect) {
+    matchEffect(effect, {
+      Render: (): void => {
         this.callback(deserializeView(this.core.view()));
-        break;
-      }
-      case EffectVariantHttp: {
-        const request = (effect as EffectVariantHttp).value;
-        const response = await http.request(request);
-        this.respond(id, response);
-        break;
-      }
-      case EffectVariantServerSentEvents: {
-        const request = (effect as EffectVariantServerSentEvents).value;
-        (async () => {
-          for await (const response of sse.request(request)) {
-            this.respond(id, response);
+      },
+      Http: (e): void => {
+        void http.request(e.value).then(response =>
+          this.respond(id, s => serializeHttpResult(response, s))
+        );
+      },
+      ServerSentEvents: (e): void => {
+        void (async () => {
+          for await (const response of sse.request(e.value)) {
+            this.respond(id, s => serializeSseResponse(response, s));
           }
         })();
-        break;
-      }
-    }
+      },
+    });
   }
 
-  respond(id: number, response: Response) {
+  respond(id: number, serialize: (s: Serializer) => void) {
     const serializer = new BincodeSerializer();
-    response.serialize(serializer);
+    serialize(serializer);
 
     const effects = this.core.resolve(id, serializer.getBytes());
 

--- a/examples/counter-http/web-nextjs/src/app/http.ts
+++ b/examples/counter-http/web-nextjs/src/app/http.ts
@@ -1,9 +1,5 @@
 import type { HttpRequest, HttpResult } from "shared_types/app";
-import {
-  HttpResponse,
-  HttpHeader,
-  httpResultOk,
-} from "shared_types/app";
+import { HttpResponse, HttpHeader, httpResultOk } from "shared_types/app";
 
 export async function request({
   url,

--- a/examples/counter-http/web-nextjs/src/app/http.ts
+++ b/examples/counter-http/web-nextjs/src/app/http.ts
@@ -2,7 +2,7 @@ import type { HttpRequest, HttpResult } from "shared_types/app";
 import {
   HttpResponse,
   HttpHeader,
-  HttpResultVariantOk,
+  httpResultOk,
 } from "shared_types/app";
 
 export async function request({
@@ -24,7 +24,7 @@ export async function request({
 
   const body = await response.arrayBuffer();
 
-  return new HttpResultVariantOk(
+  return httpResultOk(
     new HttpResponse(response.status, responseHeaders, new Uint8Array(body)),
   );
 }

--- a/examples/counter-http/web-nextjs/src/app/page.tsx
+++ b/examples/counter-http/web-nextjs/src/app/page.tsx
@@ -13,8 +13,9 @@ import {
 
 import { Core } from "./core";
 
-const wasmInitialized = (sharedWasm as unknown as { initialized: Promise<void> })
-  .initialized;
+const wasmInitialized = (
+  sharedWasm as unknown as { initialized: Promise<void> }
+).initialized;
 
 const Home: NextPage = () => {
   const [view, setView] = useState(new ViewModel("", true));
@@ -35,7 +36,7 @@ const Home: NextPage = () => {
         });
       }
     },
-     
+
     /*once*/ [],
   );
 

--- a/examples/counter-http/web-nextjs/src/app/page.tsx
+++ b/examples/counter-http/web-nextjs/src/app/page.tsx
@@ -6,9 +6,9 @@ import { useEffect, useRef, useState } from "react";
 import * as sharedWasm from "shared";
 import {
   ViewModel,
-  EventVariantStartWatch,
-  EventVariantDecrement,
-  EventVariantIncrement,
+  eventStartWatch,
+  eventDecrement,
+  eventIncrement,
 } from "shared_types/app";
 
 import { Core } from "./core";
@@ -31,7 +31,7 @@ const Home: NextPage = () => {
             core.current = new Core(setView);
           }
           // Initial events
-          core.current?.update(new EventVariantStartWatch());
+          core.current?.update(eventStartWatch());
         });
       }
     },
@@ -50,13 +50,13 @@ const Home: NextPage = () => {
         <div className="buttons section is-centered">
           <button
             className="button is-primary is-warning"
-            onClick={() => core.current?.update(new EventVariantDecrement())}
+            onClick={() => core.current?.update(eventDecrement())}
           >
             {"Decrement"}
           </button>
           <button
             className="button is-primary is-danger"
-            onClick={() => core.current?.update(new EventVariantIncrement())}
+            onClick={() => core.current?.update(eventIncrement())}
           >
             {"Increment"}
           </button>

--- a/examples/counter-http/web-nextjs/src/app/sse.ts
+++ b/examples/counter-http/web-nextjs/src/app/sse.ts
@@ -1,8 +1,5 @@
 import type { SseRequest } from "shared_types/app";
-import {
-  sseResponseDone,
-  sseResponseChunk,
-} from "shared_types/app";
+import { sseResponseDone, sseResponseChunk } from "shared_types/app";
 
 export async function* request({ url }: SseRequest) {
   const request = new Request(url);
@@ -16,9 +13,7 @@ export async function* request({ url }: SseRequest) {
   try {
     while (true) {
       const { done, value } = await reader.read();
-      yield done
-        ? sseResponseDone()
-        : sseResponseChunk(Array.from(value));
+      yield done ? sseResponseDone() : sseResponseChunk(Array.from(value));
       if (done) {
         break;
       }

--- a/examples/counter-http/web-nextjs/src/app/sse.ts
+++ b/examples/counter-http/web-nextjs/src/app/sse.ts
@@ -1,7 +1,7 @@
 import type { SseRequest } from "shared_types/app";
 import {
-  SseResponseVariantDone,
-  SseResponseVariantChunk,
+  sseResponseDone,
+  sseResponseChunk,
 } from "shared_types/app";
 
 export async function* request({ url }: SseRequest) {
@@ -17,8 +17,8 @@ export async function* request({ url }: SseRequest) {
     while (true) {
       const { done, value } = await reader.read();
       yield done
-        ? new SseResponseVariantDone()
-        : new SseResponseVariantChunk(Array.from(value));
+        ? sseResponseDone()
+        : sseResponseChunk(Array.from(value));
       if (done) {
         break;
       }

--- a/examples/counter-middleware/Cargo.lock
+++ b/examples/counter-middleware/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
  "derive_builder",
  "encoding_rs",
  "facet",
- "facet-generate-attrs",
+ "facet-generate-attrs 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util",
  "http",
  "mime",
@@ -893,6 +893,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-generate-attrs"
+version = "0.17.0"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+dependencies = [
+ "facet",
+]
+
+[[package]]
 name = "facet-macro-parse"
 version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,12 +948,11 @@ dependencies = [
 [[package]]
 name = "facet_generate"
 version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab57b923bae6e204f5e47643054a9c5ad9c3bd9aadec66df741790de8a859f"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
 dependencies = [
  "derive_builder",
  "facet",
- "facet-generate-attrs",
+ "facet-generate-attrs 0.17.0 (git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions)",
  "heck",
  "include_dir",
  "indent",

--- a/examples/counter-middleware/Cargo.lock
+++ b/examples/counter-middleware/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
  "derive_builder",
  "encoding_rs",
  "facet",
- "facet-generate-attrs 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "facet-generate-attrs",
  "futures-util",
  "http",
  "mime",
@@ -893,14 +893,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "facet-generate-attrs"
-version = "0.17.0"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
-dependencies = [
- "facet",
-]
-
-[[package]]
 name = "facet-macro-parse"
 version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,12 +939,13 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.2"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c7ecce0761dfa28c527bb006a4391336618bd5088c16c8a61ae9bf1f6c0d2f"
 dependencies = [
  "derive_builder",
  "facet",
- "facet-generate-attrs 0.17.0 (git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions)",
+ "facet-generate-attrs",
  "heck",
  "include_dir",
  "indent",

--- a/examples/counter-middleware/web-nextjs/src/app/core.ts
+++ b/examples/counter-middleware/web-nextjs/src/app/core.ts
@@ -54,12 +54,14 @@ export class Core {
         this.callback(deserializeView(this.core.view()));
       },
       Http: (e): void => {
-        void http.request(e.value).then(r => this.respond(id, s => serializeHttpResult(r, s)));
+        void http
+          .request(e.value)
+          .then((r) => this.respond(id, (s) => serializeHttpResult(r, s)));
       },
       ServerSentEvents: (e): void => {
         void (async () => {
           for await (const r of sse.request(e.value)) {
-            this.respond(id, s => serializeSseResponse(r, s));
+            this.respond(id, (s) => serializeSseResponse(r, s));
           }
         })();
       },
@@ -67,7 +69,7 @@ export class Core {
         const min = Number(e.value.field0);
         const max = Number(e.value.field1);
         const result = Math.floor(Math.random() * (max - min)) + min;
-        this.respond(id, s => new RandomNumber(BigInt(result)).serialize(s));
+        this.respond(id, (s) => new RandomNumber(BigInt(result)).serialize(s));
       },
     });
   }

--- a/examples/counter-middleware/web-nextjs/src/app/core.ts
+++ b/examples/counter-middleware/web-nextjs/src/app/core.ts
@@ -1,22 +1,20 @@
 import type { Dispatch, SetStateAction } from "react";
 
 import { CoreFFI } from "shared";
-import type { Effect, Event, RenderOperation } from "shared_types/app";
+import type { Effect, Event } from "shared_types/app";
 import {
-  EffectVariantHttp,
-  EffectVariantRandom,
-  EffectVariantRender,
-  EffectVariantServerSentEvents,
   RandomNumber,
   Request,
   ViewModel,
+  matchEffect,
+  serializeEvent,
+  serializeHttpResult,
+  serializeSseResponse,
 } from "shared_types/app";
 import { BincodeDeserializer, BincodeSerializer } from "shared_types/bincode";
+import type { Serializer } from "shared_types/serde";
 import * as http from "./http";
 import * as sse from "./sse";
-
-// union of all Operation types, only render is needed here
-type Response = RenderOperation;
 
 export class Core {
   core: CoreFFI;
@@ -40,7 +38,7 @@ export class Core {
 
   update(event: Event) {
     const serializer = new BincodeSerializer();
-    event.serialize(serializer);
+    serializeEvent(event, serializer);
 
     const effects = this.core.update(serializer.getBytes());
 
@@ -50,41 +48,33 @@ export class Core {
     }
   }
 
-  async resolve(id: number, effect: Effect) {
-    switch (effect.constructor) {
-      case EffectVariantRender: {
+  resolve(id: number, effect: Effect) {
+    matchEffect(effect, {
+      Render: (): void => {
         this.callback(deserializeView(this.core.view()));
-        break;
-      }
-      case EffectVariantHttp: {
-        const request = (effect as EffectVariantHttp).value;
-        const response = await http.request(request);
-        this.respond(id, response);
-        break;
-      }
-      case EffectVariantServerSentEvents: {
-        const request = (effect as EffectVariantServerSentEvents).value;
-        (async () => {
-          for await (const response of sse.request(request)) {
-            this.respond(id, response);
+      },
+      Http: (e): void => {
+        void http.request(e.value).then(r => this.respond(id, s => serializeHttpResult(r, s)));
+      },
+      ServerSentEvents: (e): void => {
+        void (async () => {
+          for await (const r of sse.request(e.value)) {
+            this.respond(id, s => serializeSseResponse(r, s));
           }
         })();
-        break;
-      }
-      case EffectVariantRandom: {
-        const request = (effect as EffectVariantRandom).value;
-        const min = Number(request.field0);
-        const max = Number(request.field1);
+      },
+      Random: (e): void => {
+        const min = Number(e.value.field0);
+        const max = Number(e.value.field1);
         const result = Math.floor(Math.random() * (max - min)) + min;
-        this.respond(id, new RandomNumber(BigInt(result)));
-        break;
-      }
-    }
+        this.respond(id, s => new RandomNumber(BigInt(result)).serialize(s));
+      },
+    });
   }
 
-  respond(id: number, response: Response) {
+  respond(id: number, serialize: (s: Serializer) => void) {
     const serializer = new BincodeSerializer();
-    response.serialize(serializer);
+    serialize(serializer);
 
     const effects = this.core.resolve(id, serializer.getBytes());
 

--- a/examples/counter-middleware/web-nextjs/src/app/http.ts
+++ b/examples/counter-middleware/web-nextjs/src/app/http.ts
@@ -1,9 +1,5 @@
 import type { HttpRequest, HttpResult } from "shared_types/app";
-import {
-  HttpResponse,
-  HttpHeader,
-  httpResultOk,
-} from "shared_types/app";
+import { HttpResponse, HttpHeader, httpResultOk } from "shared_types/app";
 
 export async function request({
   url,

--- a/examples/counter-middleware/web-nextjs/src/app/http.ts
+++ b/examples/counter-middleware/web-nextjs/src/app/http.ts
@@ -2,7 +2,7 @@ import type { HttpRequest, HttpResult } from "shared_types/app";
 import {
   HttpResponse,
   HttpHeader,
-  HttpResultVariantOk,
+  httpResultOk,
 } from "shared_types/app";
 
 export async function request({
@@ -24,7 +24,7 @@ export async function request({
 
   const body = await response.arrayBuffer();
 
-  return new HttpResultVariantOk(
+  return httpResultOk(
     new HttpResponse(response.status, responseHeaders, new Uint8Array(body)),
   );
 }

--- a/examples/counter-middleware/web-nextjs/src/app/page.tsx
+++ b/examples/counter-middleware/web-nextjs/src/app/page.tsx
@@ -14,8 +14,9 @@ import {
 
 import { Core } from "./core";
 
-const wasmInitialized = (sharedWasm as unknown as { initialized: Promise<void> })
-  .initialized;
+const wasmInitialized = (
+  sharedWasm as unknown as { initialized: Promise<void> }
+).initialized;
 
 const Home: NextPage = () => {
   const [view, setView] = useState(new ViewModel("", true));
@@ -36,7 +37,7 @@ const Home: NextPage = () => {
         });
       }
     },
-     
+
     /*once*/ [],
   );
 

--- a/examples/counter-middleware/web-nextjs/src/app/page.tsx
+++ b/examples/counter-middleware/web-nextjs/src/app/page.tsx
@@ -6,10 +6,10 @@ import { useEffect, useRef, useState } from "react";
 import * as sharedWasm from "shared";
 import {
   ViewModel,
-  EventVariantStartWatch,
-  EventVariantDecrement,
-  EventVariantIncrement,
-  EventVariantRandom,
+  eventStartWatch,
+  eventDecrement,
+  eventIncrement,
+  eventRandom,
 } from "shared_types/app";
 
 import { Core } from "./core";
@@ -32,7 +32,7 @@ const Home: NextPage = () => {
             core.current = new Core(setView);
           }
           // Initial events
-          core.current?.update(new EventVariantStartWatch());
+          core.current?.update(eventStartWatch());
         });
       }
     },
@@ -51,19 +51,19 @@ const Home: NextPage = () => {
         <div className="buttons section is-centered">
           <button
             className="button is-primary is-warning"
-            onClick={() => core.current?.update(new EventVariantDecrement())}
+            onClick={() => core.current?.update(eventDecrement())}
           >
             {"Decrement"}
           </button>
           <button
             className="button is-primary is-danger"
-            onClick={() => core.current?.update(new EventVariantIncrement())}
+            onClick={() => core.current?.update(eventIncrement())}
           >
             {"Increment"}
           </button>
           <button
             className="button is-primary is-link"
-            onClick={() => core.current?.update(new EventVariantRandom())}
+            onClick={() => core.current?.update(eventRandom())}
           >
             {"I'm feeling lucky"}
           </button>

--- a/examples/counter-middleware/web-nextjs/src/app/sse.ts
+++ b/examples/counter-middleware/web-nextjs/src/app/sse.ts
@@ -16,9 +16,7 @@ export async function* request({ url }: SseRequest) {
   try {
     while (true) {
       const { done, value } = await reader.read();
-      yield done
-        ? sseResponseDone()
-        : sseResponseChunk(Array.from(value));
+      yield done ? sseResponseDone() : sseResponseChunk(Array.from(value));
       if (done) {
         break;
       }

--- a/examples/counter-middleware/web-nextjs/src/app/sse.ts
+++ b/examples/counter-middleware/web-nextjs/src/app/sse.ts
@@ -1,7 +1,7 @@
 import {
   SseRequest,
-  SseResponseVariantDone,
-  SseResponseVariantChunk,
+  sseResponseDone,
+  sseResponseChunk,
 } from "shared_types/app";
 
 export async function* request({ url }: SseRequest) {
@@ -17,8 +17,8 @@ export async function* request({ url }: SseRequest) {
     while (true) {
       const { done, value } = await reader.read();
       yield done
-        ? new SseResponseVariantDone()
-        : new SseResponseVariantChunk(Array.from(value));
+        ? sseResponseDone()
+        : sseResponseChunk(Array.from(value));
       if (done) {
         break;
       }

--- a/examples/counter-routing/Cargo.lock
+++ b/examples/counter-routing/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
  "derive_builder",
  "encoding_rs",
  "facet",
- "facet-generate-attrs",
+ "facet-generate-attrs 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util",
  "http",
  "mime",
@@ -893,6 +893,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-generate-attrs"
+version = "0.17.0"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+dependencies = [
+ "facet",
+]
+
+[[package]]
 name = "facet-macro-parse"
 version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,12 +948,11 @@ dependencies = [
 [[package]]
 name = "facet_generate"
 version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab57b923bae6e204f5e47643054a9c5ad9c3bd9aadec66df741790de8a859f"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
 dependencies = [
  "derive_builder",
  "facet",
- "facet-generate-attrs",
+ "facet-generate-attrs 0.17.0 (git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions)",
  "heck",
  "include_dir",
  "indent",

--- a/examples/counter-routing/Cargo.lock
+++ b/examples/counter-routing/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
  "derive_builder",
  "encoding_rs",
  "facet",
- "facet-generate-attrs 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "facet-generate-attrs",
  "futures-util",
  "http",
  "mime",
@@ -893,14 +893,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "facet-generate-attrs"
-version = "0.17.0"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
-dependencies = [
- "facet",
-]
-
-[[package]]
 name = "facet-macro-parse"
 version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,12 +939,13 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.2"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c7ecce0761dfa28c527bb006a4391336618bd5088c16c8a61ae9bf1f6c0d2f"
 dependencies = [
  "derive_builder",
  "facet",
- "facet-generate-attrs 0.17.0 (git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions)",
+ "facet-generate-attrs",
  "heck",
  "include_dir",
  "indent",

--- a/examples/counter-routing/web-nextjs/src/app/core.ts
+++ b/examples/counter-routing/web-nextjs/src/app/core.ts
@@ -1,22 +1,18 @@
 import type { Dispatch, SetStateAction } from "react";
 
 import { CoreFFI } from "shared";
-import type { Effect, Event, RenderOperation } from "shared_types/app";
+import type { Effect, Event } from "shared_types/app";
 import {
-  EffectVariantHttp,
-  EffectVariantRandom,
-  EffectVariantRender,
-  EffectVariantServerSentEvents,
   RandomNumber,
   Request,
   ViewModel,
+  matchEffect,
+  serializeEvent,
 } from "shared_types/app";
 import { BincodeDeserializer, BincodeSerializer } from "shared_types/bincode";
+import type { Serializer } from "shared_types/serde";
 import * as http from "./http";
 import * as sse from "./sse";
-
-// union of all Operation types, only render is needed here
-type Response = RenderOperation;
 
 export class Core {
   core: CoreFFI;
@@ -40,7 +36,7 @@ export class Core {
 
   update(event: Event) {
     const serializer = new BincodeSerializer();
-    event.serialize(serializer);
+    serializeEvent(event, serializer);
     const effects = this.core.update(serializer.getBytes());
     const requests = deserializeRequests(new Uint8Array(effects));
     for (const { id, effect } of requests) {
@@ -48,41 +44,36 @@ export class Core {
     }
   }
 
-  async resolve(id: number, effect: Effect) {
-    switch (effect.constructor) {
-      case EffectVariantRender: {
+  resolve(id: number, effect: Effect): void {
+    matchEffect<void>(effect, {
+      Render: (_e) => {
         this.callback(deserializeView(new Uint8Array(this.core.view())));
-        break;
-      }
-      case EffectVariantHttp: {
-        const request = (effect as EffectVariantHttp).value;
-        const response = await http.request(request);
-        this.respond(id, response);
-        break;
-      }
-      case EffectVariantServerSentEvents: {
-        const request = (effect as EffectVariantServerSentEvents).value;
+      },
+      Http: (e) => {
         (async () => {
-          for await (const response of sse.request(request)) {
-            this.respond(id, response);
+          const response = await http.request(e.value);
+          this.respond(id, (s) => http.serializeResult(response, s));
+        })();
+      },
+      ServerSentEvents: (e) => {
+        (async () => {
+          for await (const response of sse.request(e.value)) {
+            this.respond(id, (s) => sse.serializeResponse(response, s));
           }
         })();
-        break;
-      }
-      case EffectVariantRandom: {
-        const request = (effect as EffectVariantRandom).value;
-        const min = Number(request.field0);
-        const max = Number(request.field1);
+      },
+      Random: (e) => {
+        const min = Number(e.value.field0);
+        const max = Number(e.value.field1);
         const result = Math.floor(Math.random() * (max - min)) + min;
-        this.respond(id, new RandomNumber(BigInt(result)));
-        break;
-      }
-    }
+        this.respond(id, (s) => new RandomNumber(BigInt(result)).serialize(s));
+      },
+    });
   }
 
-  respond(id: number, response: Response) {
+  respond(id: number, serialize: (s: Serializer) => void) {
     const serializer = new BincodeSerializer();
-    response.serialize(serializer);
+    serialize(serializer);
     const effects = this.core.resolve(id, serializer.getBytes());
     const requests = deserializeRequests(new Uint8Array(effects));
     for (const { id, effect } of requests) {

--- a/examples/counter-routing/web-nextjs/src/app/core.ts
+++ b/examples/counter-routing/web-nextjs/src/app/core.ts
@@ -8,6 +8,8 @@ import {
   ViewModel,
   matchEffect,
   serializeEvent,
+  serializeHttpResult,
+  serializeSseResponse,
 } from "shared_types/app";
 import { BincodeDeserializer, BincodeSerializer } from "shared_types/bincode";
 import type { Serializer } from "shared_types/serde";
@@ -45,24 +47,23 @@ export class Core {
   }
 
   resolve(id: number, effect: Effect): void {
-    matchEffect<void>(effect, {
-      Render: (_e) => {
+    matchEffect(effect, {
+      Render: (): void => {
         this.callback(deserializeView(new Uint8Array(this.core.view())));
       },
-      Http: (e) => {
-        (async () => {
-          const response = await http.request(e.value);
-          this.respond(id, (s) => http.serializeResult(response, s));
-        })();
+      Http: (e): void => {
+        void http
+          .request(e.value)
+          .then((r) => this.respond(id, (s) => serializeHttpResult(r, s)));
       },
-      ServerSentEvents: (e) => {
-        (async () => {
-          for await (const response of sse.request(e.value)) {
-            this.respond(id, (s) => sse.serializeResponse(response, s));
+      ServerSentEvents: (e): void => {
+        void (async () => {
+          for await (const r of sse.request(e.value)) {
+            this.respond(id, (s) => serializeSseResponse(r, s));
           }
         })();
       },
-      Random: (e) => {
+      Random: (e): void => {
         const min = Number(e.value.field0);
         const max = Number(e.value.field1);
         const result = Math.floor(Math.random() * (max - min)) + min;

--- a/examples/counter-routing/web-nextjs/src/app/http.ts
+++ b/examples/counter-routing/web-nextjs/src/app/http.ts
@@ -1,11 +1,5 @@
 import type { HttpRequest, HttpResult } from "shared_types/app";
-import {
-  HttpResponse,
-  HttpHeader,
-  httpResultOk,
-  serializeHttpResult,
-} from "shared_types/app";
-import type { Serializer } from "shared_types/serde";
+import { HttpResponse, HttpHeader, httpResultOk } from "shared_types/app";
 
 export async function request({
   url,
@@ -29,11 +23,4 @@ export async function request({
   return httpResultOk(
     new HttpResponse(response.status, responseHeaders, new Uint8Array(body)),
   );
-}
-
-export function serializeResult(
-  result: HttpResult,
-  serializer: Serializer,
-): void {
-  serializeHttpResult(result, serializer);
 }

--- a/examples/counter-routing/web-nextjs/src/app/http.ts
+++ b/examples/counter-routing/web-nextjs/src/app/http.ts
@@ -2,8 +2,10 @@ import type { HttpRequest, HttpResult } from "shared_types/app";
 import {
   HttpResponse,
   HttpHeader,
-  HttpResultVariantOk,
+  httpResultOk,
+  serializeHttpResult,
 } from "shared_types/app";
+import type { Serializer } from "shared_types/serde";
 
 export async function request({
   url,
@@ -24,7 +26,11 @@ export async function request({
 
   const body = await response.arrayBuffer();
 
-  return new HttpResultVariantOk(
+  return httpResultOk(
     new HttpResponse(response.status, responseHeaders, new Uint8Array(body)),
   );
+}
+
+export function serializeResult(result: HttpResult, serializer: Serializer): void {
+  serializeHttpResult(result, serializer);
 }

--- a/examples/counter-routing/web-nextjs/src/app/http.ts
+++ b/examples/counter-routing/web-nextjs/src/app/http.ts
@@ -31,6 +31,9 @@ export async function request({
   );
 }
 
-export function serializeResult(result: HttpResult, serializer: Serializer): void {
+export function serializeResult(
+  result: HttpResult,
+  serializer: Serializer,
+): void {
   serializeHttpResult(result, serializer);
 }

--- a/examples/counter-routing/web-nextjs/src/app/page.tsx
+++ b/examples/counter-routing/web-nextjs/src/app/page.tsx
@@ -6,10 +6,10 @@ import { useEffect, useRef, useState } from "react";
 import * as sharedWasm from "shared";
 import {
   ViewModel,
-  EventVariantStartWatch,
-  EventVariantDecrement,
-  EventVariantIncrement,
-  EventVariantRandom,
+  eventStartWatch,
+  eventDecrement,
+  eventIncrement,
+  eventRandom,
 } from "shared_types/app";
 
 import { Core } from "./core";
@@ -33,7 +33,7 @@ const Home: NextPage = () => {
             core.current = new Core(setView);
           }
           // Initial events
-          core.current?.update(new EventVariantStartWatch());
+          core.current?.update(eventStartWatch());
         });
       }
     },
@@ -51,19 +51,19 @@ const Home: NextPage = () => {
         <div className="buttons section is-centered">
           <button
             className="button is-primary is-warning"
-            onClick={() => core.current?.update(new EventVariantDecrement())}
+            onClick={() => core.current?.update(eventDecrement())}
           >
             {"Decrement"}
           </button>
           <button
             className="button is-primary is-danger"
-            onClick={() => core.current?.update(new EventVariantIncrement())}
+            onClick={() => core.current?.update(eventIncrement())}
           >
             {"Increment"}
           </button>
           <button
             className="button is-primary is-link"
-            onClick={() => core.current?.update(new EventVariantRandom())}
+            onClick={() => core.current?.update(eventRandom())}
           >
             {"I'm feeling lucky"}
           </button>

--- a/examples/counter-routing/web-nextjs/src/app/sse.ts
+++ b/examples/counter-routing/web-nextjs/src/app/sse.ts
@@ -7,7 +7,9 @@ import {
 } from "shared_types/app";
 import type { Serializer } from "shared_types/serde";
 
-export async function* request({ url }: SseRequest): AsyncGenerator<SseResponse> {
+export async function* request({
+  url,
+}: SseRequest): AsyncGenerator<SseResponse> {
   const request = new Request(url);
 
   const response = await fetch(request);
@@ -19,9 +21,7 @@ export async function* request({ url }: SseRequest): AsyncGenerator<SseResponse>
   try {
     while (true) {
       const { done, value } = await reader.read();
-      yield done
-        ? sseResponseDone()
-        : sseResponseChunk(Array.from(value));
+      yield done ? sseResponseDone() : sseResponseChunk(Array.from(value));
       if (done) {
         break;
       }
@@ -31,6 +31,9 @@ export async function* request({ url }: SseRequest): AsyncGenerator<SseResponse>
   }
 }
 
-export function serializeResponse(response: SseResponse, serializer: Serializer): void {
+export function serializeResponse(
+  response: SseResponse,
+  serializer: Serializer,
+): void {
   serializeSseResponse(response, serializer);
 }

--- a/examples/counter-routing/web-nextjs/src/app/sse.ts
+++ b/examples/counter-routing/web-nextjs/src/app/sse.ts
@@ -1,10 +1,13 @@
+import type { SseResponse } from "shared_types/app";
 import {
   SseRequest,
-  SseResponseVariantDone,
-  SseResponseVariantChunk,
+  sseResponseDone,
+  sseResponseChunk,
+  serializeSseResponse,
 } from "shared_types/app";
+import type { Serializer } from "shared_types/serde";
 
-export async function* request({ url }: SseRequest) {
+export async function* request({ url }: SseRequest): AsyncGenerator<SseResponse> {
   const request = new Request(url);
 
   const response = await fetch(request);
@@ -17,8 +20,8 @@ export async function* request({ url }: SseRequest) {
     while (true) {
       const { done, value } = await reader.read();
       yield done
-        ? new SseResponseVariantDone()
-        : new SseResponseVariantChunk(Array.from(value));
+        ? sseResponseDone()
+        : sseResponseChunk(Array.from(value));
       if (done) {
         break;
       }
@@ -26,4 +29,8 @@ export async function* request({ url }: SseRequest) {
   } finally {
     reader.releaseLock();
   }
+}
+
+export function serializeResponse(response: SseResponse, serializer: Serializer): void {
+  serializeSseResponse(response, serializer);
 }

--- a/examples/counter-routing/web-nextjs/src/app/sse.ts
+++ b/examples/counter-routing/web-nextjs/src/app/sse.ts
@@ -3,9 +3,7 @@ import {
   SseRequest,
   sseResponseDone,
   sseResponseChunk,
-  serializeSseResponse,
 } from "shared_types/app";
-import type { Serializer } from "shared_types/serde";
 
 export async function* request({
   url,
@@ -29,11 +27,4 @@ export async function* request({
   } finally {
     reader.releaseLock();
   }
-}
-
-export function serializeResponse(
-  response: SseResponse,
-  serializer: Serializer,
-): void {
-  serializeSseResponse(response, serializer);
 }

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -2181,7 +2181,8 @@ dependencies = [
 [[package]]
 name = "facet-generate-attrs"
 version = "0.17.0"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b430b495d59ffcf07dabe103a796d8d3ba809d12bb25a5960b605883835b3de"
 dependencies = [
  "facet",
 ]
@@ -2233,8 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.2"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c7ecce0761dfa28c527bb006a4391336618bd5088c16c8a61ae9bf1f6c0d2f"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -2181,8 +2181,7 @@ dependencies = [
 [[package]]
 name = "facet-generate-attrs"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b430b495d59ffcf07dabe103a796d8d3ba809d12bb25a5960b605883835b3de"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
 dependencies = [
  "facet",
 ]
@@ -2235,8 +2234,7 @@ dependencies = [
 [[package]]
 name = "facet_generate"
 version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab57b923bae6e204f5e47643054a9c5ad9c3bd9aadec66df741790de8a859f"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/counter/web-nextjs/src/app/core.ts
+++ b/examples/counter/web-nextjs/src/app/core.ts
@@ -2,11 +2,17 @@ import type { Dispatch, SetStateAction } from "react";
 import { CoreFFI } from "shared";
 import * as sharedWasm from "shared";
 import type { Effect, Event } from "shared_types/app";
-import { EffectVariantRender, Request, ViewModel } from "shared_types/app";
+import {
+  serializeEvent,
+  matchEffect,
+  Request,
+  ViewModel,
+} from "shared_types/app";
 import { BincodeDeserializer, BincodeSerializer } from "shared_types/bincode";
 
-const wasmInitialized = (sharedWasm as unknown as { initialized: Promise<void> })
-  .initialized;
+const wasmInitialized = (
+  sharedWasm as unknown as { initialized: Promise<void> }
+).initialized;
 
 export class Core {
   core: CoreFFI | null = null;
@@ -52,7 +58,7 @@ export class Core {
       throw new Error("Core not initialized. Call initialize() first.");
     }
     const serializer = new BincodeSerializer();
-    event.serialize(serializer);
+    serializeEvent(event, serializer);
 
     const effects = this.core.update(serializer.getBytes());
 
@@ -63,12 +69,9 @@ export class Core {
   }
 
   private processEffect(effect: Effect) {
-    switch (effect.constructor) {
-      case EffectVariantRender: {
-        this.setState(this.view());
-        break;
-      }
-    }
+    matchEffect(effect, {
+      Render: () => this.setState(this.view()),
+    });
   }
 }
 

--- a/examples/counter/web-nextjs/src/app/page.tsx
+++ b/examples/counter/web-nextjs/src/app/page.tsx
@@ -5,9 +5,9 @@ import { useEffect, useRef, useState } from "react";
 
 import {
   ViewModel,
-  EventVariantReset,
-  EventVariantIncrement,
-  EventVariantDecrement,
+  eventReset,
+  eventIncrement,
+  eventDecrement,
 } from "shared_types/app";
 
 import { Core } from "./core";
@@ -27,19 +27,19 @@ const Home: NextPage = () => {
         <div className="buttons section is-centered">
           <button
             className="button is-primary is-danger"
-            onClick={() => core.current.update(new EventVariantReset())}
+            onClick={() => core.current.update(eventReset())}
           >
             {"Reset"}
           </button>
           <button
             className="button is-primary is-success"
-            onClick={() => core.current.update(new EventVariantIncrement())}
+            onClick={() => core.current.update(eventIncrement())}
           >
             {"Increment"}
           </button>
           <button
             className="button is-primary is-warning"
-            onClick={() => core.current.update(new EventVariantDecrement())}
+            onClick={() => core.current.update(eventDecrement())}
           >
             {"Decrement"}
           </button>

--- a/examples/counter/web-react-router/app/core.ts
+++ b/examples/counter/web-react-router/app/core.ts
@@ -2,11 +2,17 @@ import type { Dispatch, SetStateAction } from "react";
 import { CoreFFI } from "shared";
 import * as sharedWasm from "shared";
 import type { Effect, Event } from "shared_types/app";
-import { EffectVariantRender, Request, ViewModel } from "shared_types/app";
+import {
+  serializeEvent,
+  matchEffect,
+  Request,
+  ViewModel,
+} from "shared_types/app";
 import { BincodeDeserializer, BincodeSerializer } from "shared_types/bincode";
 
-const wasmInitialized = (sharedWasm as unknown as { initialized: Promise<void> })
-  .initialized;
+const wasmInitialized = (
+  sharedWasm as unknown as { initialized: Promise<void> }
+).initialized;
 
 export class Core {
   core: CoreFFI | null = null;
@@ -52,7 +58,7 @@ export class Core {
       throw new Error("Core not initialized. Call initialize() first.");
     }
     const serializer = new BincodeSerializer();
-    event.serialize(serializer);
+    serializeEvent(event, serializer);
 
     const effects = this.core.update(serializer.getBytes());
 
@@ -63,12 +69,9 @@ export class Core {
   }
 
   private processEffect(effect: Effect) {
-    switch (effect.constructor) {
-      case EffectVariantRender: {
-        this.setState(this.view());
-        break;
-      }
-    }
+    matchEffect(effect, {
+      Render: () => this.setState(this.view()),
+    });
   }
 }
 

--- a/examples/counter/web-react-router/app/routes/_index.tsx
+++ b/examples/counter/web-react-router/app/routes/_index.tsx
@@ -2,9 +2,9 @@ import { useEffect, useRef, useState } from "react";
 
 import {
   ViewModel,
-  EventVariantReset,
-  EventVariantIncrement,
-  EventVariantDecrement,
+  eventReset,
+  eventIncrement,
+  eventDecrement,
 } from "shared_types/app";
 import { Core } from "../core";
 
@@ -30,19 +30,19 @@ export default function Index() {
         <div className="buttons section is-centered">
           <button
             className="button is-primary is-danger"
-            onClick={() => core.current.update(new EventVariantReset())}
+            onClick={() => core.current.update(eventReset())}
           >
             {"Reset"}
           </button>
           <button
             className="button is-primary is-success"
-            onClick={() => core.current.update(new EventVariantIncrement())}
+            onClick={() => core.current.update(eventIncrement())}
           >
             {"Increment"}
           </button>
           <button
             className="button is-primary is-warning"
-            onClick={() => core.current.update(new EventVariantDecrement())}
+            onClick={() => core.current.update(eventDecrement())}
           >
             {"Decrement"}
           </button>

--- a/examples/notes/Cargo.lock
+++ b/examples/notes/Cargo.lock
@@ -524,7 +524,8 @@ dependencies = [
 [[package]]
 name = "facet-generate-attrs"
 version = "0.17.0"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b430b495d59ffcf07dabe103a796d8d3ba809d12bb25a5960b605883835b3de"
 dependencies = [
  "facet",
 ]
@@ -576,8 +577,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.2"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c7ecce0761dfa28c527bb006a4391336618bd5088c16c8a61ae9bf1f6c0d2f"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/notes/Cargo.lock
+++ b/examples/notes/Cargo.lock
@@ -524,8 +524,7 @@ dependencies = [
 [[package]]
 name = "facet-generate-attrs"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b430b495d59ffcf07dabe103a796d8d3ba809d12bb25a5960b605883835b3de"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
 dependencies = [
  "facet",
 ]
@@ -578,8 +577,7 @@ dependencies = [
 [[package]]
 name = "facet_generate"
 version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab57b923bae6e204f5e47643054a9c5ad9c3bd9aadec66df741790de8a859f"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/notes/web-nextjs/src/app/core.ts
+++ b/examples/notes/web-nextjs/src/app/core.ts
@@ -2,34 +2,27 @@ import { CoreFFI } from "shared";
 import type {
   Effect,
   Event,
-  KeyValueResult,
-  Message,
-  TimeResponse,
 } from "shared_types/app";
 import {
-  EffectVariantRender,
   ViewModel,
   Request,
-  EffectVariantKeyValue,
-  EffectVariantPubSub,
-  EffectVariantTime,
-  PubSubOperationVariantPublish,
-  PubSubOperationVariantSubscribe,
-  KeyValueOperationVariantGet,
-  KeyValueOperationVariantSet,
-  KeyValueResultVariantOk,
-  KeyValueResponseVariantGet,
-  KeyValueResponseVariantSet,
-  ValueVariantNone,
-  ValueVariantBytes,
-  TimeRequestVariantNotifyAfter,
-  TimeResponseVariantDurationElapsed,
-  TimeRequestVariantClear,
+  matchEffect,
+  matchPubSubOperation,
+  matchTimeRequest,
+  matchKeyValueOperation,
+  timeResponseDurationElapsed,
+  keyValueResultOk,
+  keyValueResponseGet,
+  keyValueResponseSet,
+  valueNone,
+  valueBytes,
+  serializeEvent,
+  serializeKeyValueResult,
+  serializeTimeResponse,
 } from "shared_types/app";
 import { BincodeSerializer, BincodeDeserializer } from "shared_types/bincode";
+import type { Serializer } from "shared_types/serde";
 import { Dispatch, RefObject, SetStateAction } from "react";
-
-type Response = Message | TimeResponse | KeyValueResult;
 
 export type Timers = {
   [key: number]: number;
@@ -80,7 +73,7 @@ export class Core {
     console.log("event", event);
 
     const serializer = new BincodeSerializer();
-    event.serialize(serializer);
+    serializeEvent(event, serializer);
 
     const effects = this.core.update(serializer.getBytes());
 
@@ -93,127 +86,95 @@ export class Core {
   private processEffect(id: number, effect: Effect) {
     console.log("effect", effect);
 
-    switch (effect.constructor) {
-      case EffectVariantRender: {
+    matchEffect(effect, {
+      Render: () => {
         this.setState(this.view());
-        break;
-      }
+      },
 
-      case EffectVariantPubSub: {
-        const pubSubOp = (effect as EffectVariantPubSub).value;
-
-        switch (pubSubOp.constructor) {
-          case PubSubOperationVariantPublish:
-            let publish = pubSubOp as PubSubOperationVariantPublish;
-            let message: SyncMessage = {
+      PubSub: ({ value: pubSubOp }) => {
+        matchPubSubOperation(pubSubOp, {
+          Publish: (op) => {
+            const message: SyncMessage = {
               kind: "change",
-              data: publish.value,
+              data: op.value,
             };
-
             this.channel.current.postMessage(message);
-
-            break;
-          case PubSubOperationVariantSubscribe:
+          },
+          Subscribe: () => {
             this.subscriptionId.current = id;
+          },
+        });
+      },
 
-            break;
-        }
-        break;
-      }
+      Time: ({ value: timerOp }) => {
+        matchTimeRequest(timerOp, {
+          Now: () => {},
+          NotifyAt: () => {},
+          NotifyAfter: (op) => {
+            const { id: startId, duration } = op;
+            const milliseconds = Number(duration.nanos) / 1e6;
 
-      case EffectVariantTime: {
-        const timerOp = (effect as EffectVariantTime).value;
-
-        switch (timerOp.constructor) {
-          case TimeRequestVariantNotifyAfter: {
-            let { id: startId, duration } =
-              timerOp as TimeRequestVariantNotifyAfter;
-            let milliseconds = Number(duration.nanos) / 1e6;
-
-            let handle = window.setTimeout(() => {
+            const handle = window.setTimeout(() => {
               // Drop the timer
               this.setTimers((ts) => {
-                let { [Number(startId)]: _, ...rest } = ts;
-
+                const { [Number(startId.value)]: _, ...rest } = ts;
                 return rest;
               });
 
-              this.respond(id, new TimeResponseVariantDurationElapsed(startId));
+              this.respond(id, (s) =>
+                serializeTimeResponse(timeResponseDurationElapsed(startId), s),
+              );
             }, milliseconds);
-            this.setTimers((ts) => ({ [Number(startId)]: handle, ...ts }));
-
-            break;
-          }
-
-          case TimeRequestVariantClear: {
-            let { id: cancelId } = timerOp as TimeRequestVariantClear;
-
+            this.setTimers((ts) => ({ [Number(startId.value)]: handle, ...ts }));
+          },
+          Clear: (op) => {
+            const cancelId = op.id;
             this.setTimers((ts) => {
-              let { [Number(cancelId.value)]: handle, ...rest } = ts;
+              const { [Number(cancelId.value)]: handle, ...rest } = ts;
               window.clearTimeout(handle);
-
               return rest;
             });
-          }
-        }
-        break;
-      }
+          },
+        });
+      },
 
-      case EffectVariantKeyValue: {
-        const request = (effect as EffectVariantKeyValue).value;
-        switch (request.constructor) {
-          case KeyValueOperationVariantGet: {
-            const { key: readKey } = request as KeyValueOperationVariantGet;
-
+      KeyValue: ({ value: request }) => {
+        matchKeyValueOperation(request, {
+          Get: (op) => {
+            const readKey = op.key;
             const data = window.localStorage.getItem(readKey);
             const bytes: number[] = data == null ? [] : JSON.parse(data);
             const value =
-              bytes.length === 0
-                ? new ValueVariantNone()
-                : new ValueVariantBytes(bytes);
+              bytes.length === 0 ? valueNone() : valueBytes(bytes);
 
             console.log(`Loaded document (${bytes.length} bytes)`);
-            this.respond(
-              id,
-              new KeyValueResultVariantOk(
-                new KeyValueResponseVariantGet(value),
-              ),
-            );
-
-            break;
-          }
-
-          case KeyValueOperationVariantSet: {
-            const { key: writeKey, value: writeValue } =
-              request as KeyValueOperationVariantSet;
-
+            const result = keyValueResultOk(keyValueResponseGet(value));
+            this.respond(id, (s) => serializeKeyValueResult(result, s));
+          },
+          Set: (op) => {
+            const { key: writeKey, value: writeValue } = op;
             console.log(`Saving document (${writeValue.length} bytes)`);
             window.localStorage.setItem(
               writeKey,
               JSON.stringify(Array.from(writeValue)),
             );
-
-            this.respond(
-              id,
-              new KeyValueResultVariantOk(
-                new KeyValueResponseVariantSet(new ValueVariantNone()),
-              ),
-            );
-
-            break;
-          }
-        }
-        break;
-      }
-    }
+            const result = keyValueResultOk(keyValueResponseSet(valueNone()));
+            this.respond(id, (s) => serializeKeyValueResult(result, s));
+          },
+          Delete: () => {},
+          Exists: () => {},
+          ListKeys: () => {},
+        });
+      },
+    });
   }
 
-  respond(id: number, response: Response) {
+  respond(id: number, serialize: (s: Serializer) => void) {
     if (!this.core) {
       throw new Error("Core not initialized. Call initialize() first.");
     }
     const serializer = new BincodeSerializer();
-    response.serialize(serializer);
+    serialize(serializer);
 
     const effects = this.core.resolve(id, serializer.getBytes());
     const requests = deserializeRequests(effects);

--- a/examples/notes/web-nextjs/src/app/core.ts
+++ b/examples/notes/web-nextjs/src/app/core.ts
@@ -1,61 +1,11 @@
+// Must come first: patches `WebAssembly.instantiate` so automerge can reach
+// `crypto.getRandomValues` through boltffi's stubbed wasm-bindgen imports.
+// See the module for the full explanation — importing it before `shared`
+// is what guarantees the patch is installed before the WASM module loads.
+import "./wasm-getrandom";
+
 import { CoreFFI } from "shared";
 import type { Effect, Event } from "shared_types/app";
-
-// WORKAROUND: automerge uses `features = ["wasm"]` in its Cargo.toml, which
-// enables the `getrandom/js` feature. That compiles a wasm-bindgen import
-// (`__wbg_getRandomValues_8aa3112c6615eef6`) into the WASM binary so that
-// automerge can call `crypto.getRandomValues` to generate random actor IDs.
-//
-// boltffi deliberately stubs ALL `__wbindgen_placeholder__` imports as
-// "Unimplemented" — it replaces wasm-bindgen interop entirely and doesn't
-// provide browser API bindings. There is currently no way to inject custom
-// `__wbindgen_placeholder__` implementations through the `instantiateBoltFFI`
-// API, so we intercept `WebAssembly.instantiate` to replace the stub with the
-// real `crypto.getRandomValues` before the module is loaded.
-//
-// The function name encodes a hash of its wasm-bindgen signature, so it could
-// change if the `getrandom` version changes — grep for the new name in the
-// WASM binary's imports if this breaks after a dependency update:
-//   node -e "const fs=require('fs'); WebAssembly.compile(fs.readFileSync('generated/pkg/shared_bg.wasm')).then(m=>console.log(WebAssembly.Module.imports(m).map(i=>i.module+'::'+i.name).join('\n')))"
-//
-// The proper fix is either:
-//   a) Remove `features = ["wasm"]` from the `automerge` dependency in
-//      shared/Cargo.toml and configure `getrandom` with `features = ["custom"]`
-//      plus a boltffi-compatible random implementation, or
-//   b) Ask boltffi to natively provide `crypto.getRandomValues` for the
-//      `__wbindgen_placeholder__` namespace (feature request to boltffi).
-if (typeof WebAssembly !== "undefined" && typeof crypto !== "undefined") {
-  const _origInstantiate = WebAssembly.instantiate.bind(WebAssembly);
-  let _memory: WebAssembly.Memory | null = null;
-
-  (WebAssembly as any).instantiate = (
-    source: BufferSource | WebAssembly.Module,
-    importObject?: WebAssembly.Imports,
-  ) => {
-    if (importObject?.["__wbindgen_placeholder__"]) {
-      const stubs = importObject["__wbindgen_placeholder__"] as object;
-      importObject["__wbindgen_placeholder__"] = new Proxy(stubs, {
-        get(target, prop) {
-          if (prop === "__wbg_getRandomValues_8aa3112c6615eef6") {
-            return (ptr: number, len: number) => {
-              crypto.getRandomValues(new Uint8Array(_memory!.buffer, ptr, len));
-            };
-          }
-          return Reflect.get(target, prop);
-        },
-      }) as WebAssembly.ModuleImports;
-    }
-    return (
-      _origInstantiate(
-        source as any,
-        importObject,
-      ) as Promise<WebAssembly.WebAssemblyInstantiatedSource>
-    ).then((result) => {
-      _memory = result.instance.exports["memory"] as WebAssembly.Memory;
-      return result;
-    });
-  };
-}
 import {
   ViewModel,
   Request,
@@ -161,8 +111,8 @@ export class Core {
 
       Time: ({ value: timerOp }) => {
         matchTimeRequest(timerOp, {
-          Now: () => {},
-          NotifyAt: () => {},
+          Now: () => unsupported("Time::Now"),
+          NotifyAt: () => unsupported("Time::NotifyAt"),
           NotifyAfter: (op) => {
             const { id: startId, duration } = op;
             const milliseconds = Number(duration.nanos) / 1e6;
@@ -216,9 +166,9 @@ export class Core {
             const result = keyValueResultOk(keyValueResponseSet(valueNone()));
             this.respond(id, (s) => serializeKeyValueResult(result, s));
           },
-          Delete: () => {},
-          Exists: () => {},
-          ListKeys: () => {},
+          Delete: () => unsupported("KeyValue::Delete"),
+          Exists: () => unsupported("KeyValue::Exists"),
+          ListKeys: () => unsupported("KeyValue::ListKeys"),
         });
       },
     });
@@ -238,6 +188,14 @@ export class Core {
       this.processEffect(id, effect);
     }
   }
+}
+
+// The notes app never issues these operations, but the generated `match`
+// helpers are exhaustive so every variant needs an arm. Throwing beats a silent
+// no-op: an unanswered request leaves the core's command waiting forever, so a
+// future change to the app would hang rather than fail here.
+function unsupported(operation: string): never {
+  throw new Error(`the notes shell does not implement ${operation}`);
 }
 
 function deserializeRequests(bytes: Uint8Array | number[]): Request[] {

--- a/examples/notes/web-nextjs/src/app/core.ts
+++ b/examples/notes/web-nextjs/src/app/core.ts
@@ -3,6 +3,59 @@ import type {
   Effect,
   Event,
 } from "shared_types/app";
+
+// WORKAROUND: automerge uses `features = ["wasm"]` in its Cargo.toml, which
+// enables the `getrandom/js` feature. That compiles a wasm-bindgen import
+// (`__wbg_getRandomValues_8aa3112c6615eef6`) into the WASM binary so that
+// automerge can call `crypto.getRandomValues` to generate random actor IDs.
+//
+// boltffi deliberately stubs ALL `__wbindgen_placeholder__` imports as
+// "Unimplemented" — it replaces wasm-bindgen interop entirely and doesn't
+// provide browser API bindings. There is currently no way to inject custom
+// `__wbindgen_placeholder__` implementations through the `instantiateBoltFFI`
+// API, so we intercept `WebAssembly.instantiate` to replace the stub with the
+// real `crypto.getRandomValues` before the module is loaded.
+//
+// The function name encodes a hash of its wasm-bindgen signature, so it could
+// change if the `getrandom` version changes — grep for the new name in the
+// WASM binary's imports if this breaks after a dependency update:
+//   node -e "const fs=require('fs'); WebAssembly.compile(fs.readFileSync('generated/pkg/shared_bg.wasm')).then(m=>console.log(WebAssembly.Module.imports(m).map(i=>i.module+'::'+i.name).join('\n')))"
+//
+// The proper fix is either:
+//   a) Remove `features = ["wasm"]` from the `automerge` dependency in
+//      shared/Cargo.toml and configure `getrandom` with `features = ["custom"]`
+//      plus a boltffi-compatible random implementation, or
+//   b) Ask boltffi to natively provide `crypto.getRandomValues` for the
+//      `__wbindgen_placeholder__` namespace (feature request to boltffi).
+if (typeof WebAssembly !== "undefined" && typeof crypto !== "undefined") {
+  const _origInstantiate = WebAssembly.instantiate.bind(WebAssembly);
+  let _memory: WebAssembly.Memory | null = null;
+
+  (WebAssembly as any).instantiate = (
+    source: BufferSource | WebAssembly.Module,
+    importObject?: WebAssembly.Imports,
+  ) => {
+    if (importObject?.["__wbindgen_placeholder__"]) {
+      const stubs = importObject["__wbindgen_placeholder__"] as object;
+      importObject["__wbindgen_placeholder__"] = new Proxy(stubs, {
+        get(target, prop) {
+          if (prop === "__wbg_getRandomValues_8aa3112c6615eef6") {
+            return (ptr: number, len: number) => {
+              crypto.getRandomValues(new Uint8Array(_memory!.buffer, ptr, len));
+            };
+          }
+          return Reflect.get(target, prop);
+        },
+      }) as WebAssembly.ModuleImports;
+    }
+    return (
+      _origInstantiate(source as any, importObject) as Promise<WebAssembly.WebAssemblyInstantiatedSource>
+    ).then((result) => {
+      _memory = result.instance.exports["memory"] as WebAssembly.Memory;
+      return result;
+    });
+  };
+}
 import {
   ViewModel,
   Request,

--- a/examples/notes/web-nextjs/src/app/core.ts
+++ b/examples/notes/web-nextjs/src/app/core.ts
@@ -1,8 +1,5 @@
 import { CoreFFI } from "shared";
-import type {
-  Effect,
-  Event,
-} from "shared_types/app";
+import type { Effect, Event } from "shared_types/app";
 
 // WORKAROUND: automerge uses `features = ["wasm"]` in its Cargo.toml, which
 // enables the `getrandom/js` feature. That compiles a wasm-bindgen import
@@ -49,7 +46,10 @@ if (typeof WebAssembly !== "undefined" && typeof crypto !== "undefined") {
       }) as WebAssembly.ModuleImports;
     }
     return (
-      _origInstantiate(source as any, importObject) as Promise<WebAssembly.WebAssemblyInstantiatedSource>
+      _origInstantiate(
+        source as any,
+        importObject,
+      ) as Promise<WebAssembly.WebAssemblyInstantiatedSource>
     ).then((result) => {
       _memory = result.instance.exports["memory"] as WebAssembly.Memory;
       return result;
@@ -178,7 +178,10 @@ export class Core {
                 serializeTimeResponse(timeResponseDurationElapsed(startId), s),
               );
             }, milliseconds);
-            this.setTimers((ts) => ({ [Number(startId.value)]: handle, ...ts }));
+            this.setTimers((ts) => ({
+              [Number(startId.value)]: handle,
+              ...ts,
+            }));
           },
           Clear: (op) => {
             const cancelId = op.id;
@@ -197,8 +200,7 @@ export class Core {
             const readKey = op.key;
             const data = window.localStorage.getItem(readKey);
             const bytes: number[] = data == null ? [] : JSON.parse(data);
-            const value =
-              bytes.length === 0 ? valueNone() : valueBytes(bytes);
+            const value = bytes.length === 0 ? valueNone() : valueBytes(bytes);
 
             console.log(`Loaded document (${bytes.length} bytes)`);
             const result = keyValueResultOk(keyValueResponseGet(value));

--- a/examples/notes/web-nextjs/src/app/page.tsx
+++ b/examples/notes/web-nextjs/src/app/page.tsx
@@ -14,14 +14,14 @@ import * as sharedWasm from "shared";
 import { SyncMessage, Timers, Core } from "./core";
 import {
   TextCursor,
-  TextCursorVariantPosition,
-  TextCursorVariantSelection,
+  matchTextCursor,
+  textCursorPosition,
   ViewModel,
   Message,
-  EventVariantOpen,
-  EventVariantReplace,
-  EventVariantMoveCursor,
-  EventVariantSelect,
+  eventOpen,
+  eventReplace,
+  eventMoveCursor,
+  eventSelect,
 } from "shared_types/app";
 
 const LOG_EDITS = false;
@@ -35,33 +35,15 @@ type Selection = {
 };
 
 function cursorToSelection(cursor: TextCursor): Selection {
-  var start = 0;
-  var end = 0;
-
-  switch (cursor.constructor) {
-    case TextCursorVariantPosition:
-      let cursorP = cursor as TextCursorVariantPosition;
-
-      start = Number(cursorP.value);
-      end = Number(cursorP.value);
-      break;
-    case TextCursorVariantSelection:
-      let cursorS = cursor as TextCursorVariantSelection;
-
-      start = Number(cursorS.value.start);
-      end = Number(cursorS.value.end);
-      break;
-  }
-
-  return {
-    start,
-    end,
-  };
+  return matchTextCursor(cursor, {
+    Position: (c) => ({ start: Number(c.value), end: Number(c.value) }),
+    Selection: (c) => ({ start: Number(c.value.start), end: Number(c.value.end) }),
+  });
 }
 
 const Home: NextPage = () => {
   const [view, setView] = useState<ViewModel>(
-    new ViewModel("", new TextCursorVariantPosition(BigInt(0))),
+    new ViewModel("", textCursorPosition(BigInt(0))),
   );
 
   const [_, setTimers] = useState<Timers>({});
@@ -85,7 +67,8 @@ const Home: NextPage = () => {
       if (subscriptionId.current == null) return;
 
       // Pass data into the core
-      core.current.respond(subscriptionId.current, new Message(message.data));
+      const data = message.data;
+      core.current.respond(subscriptionId.current, (s) => new Message(data).serialize(s));
     }
   };
 
@@ -108,7 +91,7 @@ const Home: NextPage = () => {
             channel.current.onmessage = onMessage;
 
             // Open the document
-            core.current.update(new EventVariantOpen());
+            core.current.update(eventOpen());
 
             // Ask all peers to reset
             let message: SyncMessage = {
@@ -136,7 +119,7 @@ const Home: NextPage = () => {
     log(`onChange ${start} ${end} "${text}"`);
 
     core.current.update(
-      new EventVariantReplace(BigInt(start), BigInt(end), text),
+      eventReplace(BigInt(start), BigInt(end), text),
     );
   };
 
@@ -145,8 +128,8 @@ const Home: NextPage = () => {
 
     let event =
       start == end
-        ? new EventVariantMoveCursor(BigInt(end))
-        : new EventVariantSelect(BigInt(start), BigInt(end));
+        ? eventMoveCursor(BigInt(end))
+        : eventSelect(BigInt(start), BigInt(end));
 
     core.current.update(event);
   };

--- a/examples/notes/web-nextjs/src/app/page.tsx
+++ b/examples/notes/web-nextjs/src/app/page.tsx
@@ -26,8 +26,9 @@ import {
 
 const LOG_EDITS = false;
 
-const wasmInitialized = (sharedWasm as unknown as { initialized: Promise<void> })
-  .initialized;
+const wasmInitialized = (
+  sharedWasm as unknown as { initialized: Promise<void> }
+).initialized;
 
 type Selection = {
   start: number;
@@ -37,7 +38,10 @@ type Selection = {
 function cursorToSelection(cursor: TextCursor): Selection {
   return matchTextCursor(cursor, {
     Position: (c) => ({ start: Number(c.value), end: Number(c.value) }),
-    Selection: (c) => ({ start: Number(c.value.start), end: Number(c.value.end) }),
+    Selection: (c) => ({
+      start: Number(c.value.start),
+      end: Number(c.value.end),
+    }),
   });
 }
 
@@ -68,7 +72,9 @@ const Home: NextPage = () => {
 
       // Pass data into the core
       const data = message.data;
-      core.current.respond(subscriptionId.current, (s) => new Message(data).serialize(s));
+      core.current.respond(subscriptionId.current, (s) =>
+        new Message(data).serialize(s),
+      );
     }
   };
 
@@ -118,9 +124,7 @@ const Home: NextPage = () => {
   const onChange = ({ start, end, text }: ChangeEvent): void => {
     log(`onChange ${start} ${end} "${text}"`);
 
-    core.current.update(
-      eventReplace(BigInt(start), BigInt(end), text),
-    );
+    core.current.update(eventReplace(BigInt(start), BigInt(end), text));
   };
 
   const onSelect = ({ start, end }: SelectEvent): void => {

--- a/examples/notes/web-nextjs/src/app/wasm-getrandom.ts
+++ b/examples/notes/web-nextjs/src/app/wasm-getrandom.ts
@@ -1,0 +1,73 @@
+// WORKAROUND: automerge uses `features = ["wasm"]` in its Cargo.toml, which
+// enables the `getrandom/js` feature. That compiles a wasm-bindgen import
+// (`__wbg_getRandomValues_<hash>`) into the WASM binary so that automerge can
+// call `crypto.getRandomValues` to generate random actor IDs.
+//
+// boltffi deliberately stubs ALL `__wbindgen_placeholder__` imports as
+// "Unimplemented" — it replaces wasm-bindgen interop entirely and doesn't
+// provide browser API bindings. There is currently no way to inject custom
+// `__wbindgen_placeholder__` implementations through the `instantiateBoltFFI`
+// API, so we intercept `WebAssembly.instantiate` to replace the stub with the
+// real `crypto.getRandomValues` before the module is loaded.
+//
+// This lives in its own module, imported for its side effect *before* `shared`,
+// because ES module imports are hoisted and evaluated in source order: patching
+// inline in a module that also imports `shared` would install the patch only
+// after `shared` had already been evaluated.
+//
+// Only `WebAssembly.instantiate` is patched, which is what boltffi's loader
+// calls. If that ever changes to `instantiateStreaming`, the stub returns to
+// throwing "Unimplemented" as soon as automerge needs randomness.
+//
+// The import name ends in a hash of its wasm-bindgen signature, which changes
+// whenever `getrandom` is bumped (0.4.2 and 0.4.3 differ), so we match on the
+// `__wbg_getRandomValues_` prefix rather than pinning one hash — pinning meant
+// a lockfile refresh silently reverted the stub to throwing. To see the
+// current imports:
+//   node -e "const fs=require('fs'); WebAssembly.compile(fs.readFileSync('generated/pkg/shared_bg.wasm')).then(m=>console.log(WebAssembly.Module.imports(m).map(i=>i.module+'::'+i.name).join('\n')))"
+//
+// The proper fix is either:
+//   a) Remove `features = ["wasm"]` from the `automerge` dependency in
+//      shared/Cargo.toml and configure `getrandom` with `features = ["custom"]`
+//      plus a boltffi-compatible random implementation, or
+//   b) Ask boltffi to natively provide `crypto.getRandomValues` for the
+//      `__wbindgen_placeholder__` namespace (feature request to boltffi).
+if (typeof WebAssembly !== "undefined" && typeof crypto !== "undefined") {
+  const origInstantiate = WebAssembly.instantiate.bind(WebAssembly);
+
+  // Memory of the most recently instantiated module. `getRandomValues` is only
+  // reachable through that module's own exports, and the shell instantiates a
+  // single WASM module, so this is the one automerge is calling from.
+  let memory: WebAssembly.Memory | null = null;
+
+  (WebAssembly as any).instantiate = (
+    source: BufferSource | WebAssembly.Module,
+    importObject?: WebAssembly.Imports,
+  ) => {
+    if (importObject?.["__wbindgen_placeholder__"]) {
+      const stubs = importObject["__wbindgen_placeholder__"] as object;
+      importObject["__wbindgen_placeholder__"] = new Proxy(stubs, {
+        get(target, prop) {
+          if (
+            typeof prop === "string" &&
+            prop.startsWith("__wbg_getRandomValues_")
+          ) {
+            return (ptr: number, len: number) => {
+              crypto.getRandomValues(new Uint8Array(memory!.buffer, ptr, len));
+            };
+          }
+          return Reflect.get(target, prop);
+        },
+      }) as WebAssembly.ModuleImports;
+    }
+    return (
+      origInstantiate(
+        source as any,
+        importObject,
+      ) as Promise<WebAssembly.WebAssemblyInstantiatedSource>
+    ).then((result) => {
+      memory = result.instance.exports["memory"] as WebAssembly.Memory;
+      return result;
+    });
+  };
+}

--- a/examples/weather/Cargo.lock
+++ b/examples/weather/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
  "derive_builder",
  "encoding_rs",
  "facet",
- "facet-generate-attrs",
+ "facet-generate-attrs 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util",
  "http",
  "mime",
@@ -862,6 +862,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet-generate-attrs"
+version = "0.17.0"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+dependencies = [
+ "facet",
+]
+
+[[package]]
 name = "facet-macro-parse"
 version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,12 +917,11 @@ dependencies = [
 [[package]]
 name = "facet_generate"
 version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab57b923bae6e204f5e47643054a9c5ad9c3bd9aadec66df741790de8a859f"
+source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
 dependencies = [
  "derive_builder",
  "facet",
- "facet-generate-attrs",
+ "facet-generate-attrs 0.17.0 (git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions)",
  "heck",
  "include_dir",
  "indent",

--- a/examples/weather/Cargo.lock
+++ b/examples/weather/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
  "derive_builder",
  "encoding_rs",
  "facet",
- "facet-generate-attrs 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "facet-generate-attrs",
  "futures-util",
  "http",
  "mime",
@@ -862,14 +862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "facet-generate-attrs"
-version = "0.17.0"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
-dependencies = [
- "facet",
-]
-
-[[package]]
 name = "facet-macro-parse"
 version = "0.44.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,12 +908,13 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.17.2"
-source = "git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions#f557b2f8944ee7f96b8a0c9ed5688e4a0b67438d"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c7ecce0761dfa28c527bb006a4391336618bd5088c16c8a61ae9bf1f6c0d2f"
 dependencies = [
  "derive_builder",
  "facet",
- "facet-generate-attrs 0.17.0 (git+https://github.com/redbadger/facet-generate?branch=feat%2Ftypescript-discriminated-unions)",
+ "facet-generate-attrs",
  "heck",
  "include_dir",
  "indent",

--- a/examples/weather/web-nextjs/src/app/components/AddFavoriteView.tsx
+++ b/examples/weather/web-nextjs/src/app/components/AddFavoriteView.tsx
@@ -3,13 +3,13 @@ import { ArrowLeft, MagnifyingGlass, MapPinLine } from "@phosphor-icons/react";
 
 import type { AddFavoriteViewModel, AddFavoriteEvent } from "shared_types/app";
 import {
-  EventVariantActive,
-  ActiveEventVariantFavorites,
-  FavoritesScreenEventVariantWorkflow,
-  FavoritesWorkflowEventVariantAdd,
-  AddFavoriteEventVariantSearch,
-  AddFavoriteEventVariantSubmit,
-  AddFavoriteEventVariantCancel,
+  eventActive,
+  activeEventFavorites,
+  favoritesScreenEventWorkflow,
+  favoritesWorkflowEventAdd,
+  addFavoriteEventSearch,
+  addFavoriteEventSubmit,
+  addFavoriteEventCancel,
 } from "shared_types/app";
 
 import { useDispatch } from "../../lib/core/provider";
@@ -17,11 +17,9 @@ import { Button, Card, SectionTitle, StatusMessage, TextField } from "./common";
 import { SearchResultItem } from "./SearchResultItem";
 
 function addFavEvent(inner: AddFavoriteEvent) {
-  return new EventVariantActive(
-    new ActiveEventVariantFavorites(
-      new FavoritesScreenEventVariantWorkflow(
-        new FavoritesWorkflowEventVariantAdd(inner),
-      ),
+  return eventActive(
+    activeEventFavorites(
+      favoritesScreenEventWorkflow(favoritesWorkflowEventAdd(inner)),
     ),
   );
 }
@@ -42,7 +40,7 @@ export function AddFavoriteView({ model }: { model: AddFavoriteViewModel }) {
             onInput={(val) => {
               setSearchText(val);
               if (val) {
-                dispatch(addFavEvent(new AddFavoriteEventVariantSearch(val)));
+                dispatch(addFavEvent(addFavoriteEventSearch(val)));
               }
             }}
           />
@@ -57,9 +55,7 @@ export function AddFavoriteView({ model }: { model: AddFavoriteViewModel }) {
                   key={i}
                   result={result}
                   onAdd={() =>
-                    dispatch(
-                      addFavEvent(new AddFavoriteEventVariantSubmit(result)),
-                    )
+                    dispatch(addFavEvent(addFavoriteEventSubmit(result)))
                   }
                 />
               ))}
@@ -71,9 +67,7 @@ export function AddFavoriteView({ model }: { model: AddFavoriteViewModel }) {
           label="Cancel"
           icon={ArrowLeft}
           variant="secondary"
-          onClick={() =>
-            dispatch(addFavEvent(new AddFavoriteEventVariantCancel()))
-          }
+          onClick={() => dispatch(addFavEvent(addFavoriteEventCancel()))}
         />
       </div>
     </>

--- a/examples/weather/web-nextjs/src/app/components/FavoriteWeatherCard.tsx
+++ b/examples/weather/web-nextjs/src/app/components/FavoriteWeatherCard.tsx
@@ -22,7 +22,9 @@ export function FavoriteWeatherCard({
               {v.value.main.temp.toFixed(1)}&deg;
             </span>
             {v.value.weather?.[0] ? (
-              <span className="capitalize">{v.value.weather[0].description}</span>
+              <span className="capitalize">
+                {v.value.weather[0].description}
+              </span>
             ) : null}
             <span className="flex items-center gap-1">
               <Drop size={14} />

--- a/examples/weather/web-nextjs/src/app/components/FavoriteWeatherCard.tsx
+++ b/examples/weather/web-nextjs/src/app/components/FavoriteWeatherCard.tsx
@@ -1,11 +1,7 @@
 import { Drop, Warning } from "@phosphor-icons/react";
 
 import type { FavoriteWeatherViewModel } from "shared_types/app";
-import {
-  FavoriteWeatherStateViewModelVariantFetching,
-  FavoriteWeatherStateViewModelVariantFetched,
-  FavoriteWeatherStateViewModelVariantFailed,
-} from "shared_types/app";
+import { matchFavoriteWeatherStateViewModel } from "shared_types/app";
 
 export function FavoriteWeatherCard({
   fav,
@@ -16,29 +12,31 @@ export function FavoriteWeatherCard({
   return (
     <div className="bg-slate-50 rounded-xl px-4 py-3 flex items-center justify-between gap-4">
       <span className="font-semibold text-slate-900">{fav.name}</span>
-      {w instanceof FavoriteWeatherStateViewModelVariantFetching && (
-        <span className="text-sm text-slate-500">Loading...</span>
-      )}
-      {w instanceof FavoriteWeatherStateViewModelVariantFetched && (
-        <div className="flex items-center gap-3 text-sm text-slate-600">
-          <span className="text-2xl font-bold text-slate-900">
-            {w.value.main.temp.toFixed(1)}&deg;
+      {matchFavoriteWeatherStateViewModel(w, {
+        Fetching: () => (
+          <span className="text-sm text-slate-500">Loading...</span>
+        ),
+        Fetched: (v) => (
+          <div className="flex items-center gap-3 text-sm text-slate-600">
+            <span className="text-2xl font-bold text-slate-900">
+              {v.value.main.temp.toFixed(1)}&deg;
+            </span>
+            {v.value.weather?.[0] ? (
+              <span className="capitalize">{v.value.weather[0].description}</span>
+            ) : null}
+            <span className="flex items-center gap-1">
+              <Drop size={14} />
+              {Number(v.value.main.humidity)}%
+            </span>
+          </div>
+        ),
+        Failed: () => (
+          <span className="text-red-500 text-sm flex items-center gap-1">
+            <Warning size={14} />
+            Failed
           </span>
-          {w.value.weather?.[0] ? (
-            <span className="capitalize">{w.value.weather[0].description}</span>
-          ) : null}
-          <span className="flex items-center gap-1">
-            <Drop size={14} />
-            {Number(w.value.main.humidity)}%
-          </span>
-        </div>
-      )}
-      {w instanceof FavoriteWeatherStateViewModelVariantFailed && (
-        <span className="text-red-500 text-sm flex items-center gap-1">
-          <Warning size={14} />
-          Failed
-        </span>
-      )}
+        ),
+      })}
     </div>
   );
 }

--- a/examples/weather/web-nextjs/src/app/components/FavoritesView.tsx
+++ b/examples/weather/web-nextjs/src/app/components/FavoritesView.tsx
@@ -9,17 +9,15 @@ import {
 
 import type { FavoritesViewModel, FavoritesScreenEvent } from "shared_types/app";
 import {
-  FavoritesWorkflowViewModelVariantAdd,
-  FavoritesWorkflowViewModelVariantConfirmDelete,
-  EventVariantActive,
-  ActiveEventVariantFavorites,
-  FavoritesScreenEventVariantGoToHome,
-  FavoritesScreenEventVariantRequestAddFavorite,
-  FavoritesScreenEventVariantRequestDelete,
-  FavoritesScreenEventVariantWorkflow,
-  FavoritesWorkflowEventVariantConfirmDelete,
-  ConfirmDeleteEventVariantConfirmed,
-  ConfirmDeleteEventVariantCancelled,
+  eventActive,
+  activeEventFavorites,
+  favoritesScreenEventGoToHome,
+  favoritesScreenEventRequestAddFavorite,
+  favoritesScreenEventRequestDelete,
+  favoritesScreenEventWorkflow,
+  favoritesWorkflowEventConfirmDelete,
+  confirmDeleteEventConfirmed,
+  confirmDeleteEventCancelled,
 } from "shared_types/app";
 
 import { useDispatch } from "../../lib/core/provider";
@@ -34,18 +32,17 @@ import {
 } from "./common";
 
 function favEvent(inner: FavoritesScreenEvent) {
-  return new EventVariantActive(new ActiveEventVariantFavorites(inner));
+  return eventActive(activeEventFavorites(inner));
 }
 
 export function FavoritesView({ model }: { model: FavoritesViewModel }) {
   const dispatch = useDispatch();
 
-  if (model.workflow instanceof FavoritesWorkflowViewModelVariantAdd) {
+  if (model.workflow?.kind === "Add") {
     return <AddFavoriteView model={model.workflow.value} />;
   }
 
-  const isConfirmingDelete =
-    model.workflow instanceof FavoritesWorkflowViewModelVariantConfirmDelete;
+  const isConfirmingDelete = model.workflow?.kind === "ConfirmDelete";
 
   return (
     <>
@@ -70,11 +67,7 @@ export function FavoritesView({ model }: { model: FavoritesViewModel }) {
                   ariaLabel="Delete favourite"
                   onClick={() =>
                     dispatch(
-                      favEvent(
-                        new FavoritesScreenEventVariantRequestDelete(
-                          fav.location,
-                        ),
-                      ),
+                      favEvent(favoritesScreenEventRequestDelete(fav.location)),
                     )
                   }
                 />
@@ -100,9 +93,9 @@ export function FavoritesView({ model }: { model: FavoritesViewModel }) {
                   onClick={() =>
                     dispatch(
                       favEvent(
-                        new FavoritesScreenEventVariantWorkflow(
-                          new FavoritesWorkflowEventVariantConfirmDelete(
-                            new ConfirmDeleteEventVariantCancelled(),
+                        favoritesScreenEventWorkflow(
+                          favoritesWorkflowEventConfirmDelete(
+                            confirmDeleteEventCancelled(),
                           ),
                         ),
                       ),
@@ -116,9 +109,9 @@ export function FavoritesView({ model }: { model: FavoritesViewModel }) {
                   onClick={() =>
                     dispatch(
                       favEvent(
-                        new FavoritesScreenEventVariantWorkflow(
-                          new FavoritesWorkflowEventVariantConfirmDelete(
-                            new ConfirmDeleteEventVariantConfirmed(),
+                        favoritesScreenEventWorkflow(
+                          favoritesWorkflowEventConfirmDelete(
+                            confirmDeleteEventConfirmed(),
                           ),
                         ),
                       ),
@@ -135,17 +128,13 @@ export function FavoritesView({ model }: { model: FavoritesViewModel }) {
           label="Back"
           icon={ArrowLeft}
           variant="secondary"
-          onClick={() =>
-            dispatch(favEvent(new FavoritesScreenEventVariantGoToHome()))
-          }
+          onClick={() => dispatch(favEvent(favoritesScreenEventGoToHome()))}
         />
         <Button
           label="Add Favourite"
           icon={Plus}
           onClick={() =>
-            dispatch(
-              favEvent(new FavoritesScreenEventVariantRequestAddFavorite()),
-            )
+            dispatch(favEvent(favoritesScreenEventRequestAddFavorite()))
           }
         />
       </div>

--- a/examples/weather/web-nextjs/src/app/components/FavoritesView.tsx
+++ b/examples/weather/web-nextjs/src/app/components/FavoritesView.tsx
@@ -7,7 +7,10 @@ import {
   Warning,
 } from "@phosphor-icons/react";
 
-import type { FavoritesViewModel, FavoritesScreenEvent } from "shared_types/app";
+import type {
+  FavoritesViewModel,
+  FavoritesScreenEvent,
+} from "shared_types/app";
 import {
   eventActive,
   activeEventFavorites,

--- a/examples/weather/web-nextjs/src/app/components/HomeView.tsx
+++ b/examples/weather/web-nextjs/src/app/components/HomeView.tsx
@@ -7,16 +7,11 @@ import {
 
 import type { HomeViewModel } from "shared_types/app";
 import {
-  LocalWeatherViewModelVariantCheckingPermission,
-  LocalWeatherViewModelVariantLocationDisabled,
-  LocalWeatherViewModelVariantFetchingLocation,
-  LocalWeatherViewModelVariantFetchingWeather,
-  LocalWeatherViewModelVariantFetched,
-  LocalWeatherViewModelVariantFailed,
-  EventVariantActive,
-  ActiveEventVariantHome,
-  ActiveEventVariantResetApiKey,
-  HomeEventVariantGoToFavorites,
+  matchLocalWeatherViewModel,
+  eventActive,
+  activeEventHome,
+  activeEventResetApiKey,
+  homeEventGoToFavorites,
 } from "shared_types/app";
 
 import { useDispatch } from "../../lib/core/provider";
@@ -38,34 +33,34 @@ export function HomeView({ model }: { model: HomeViewModel }) {
   return (
     <>
       <Card className="mb-4">
-        {lw instanceof LocalWeatherViewModelVariantCheckingPermission && (
-          <StatusMessage
-            icon={MapPinLine}
-            message="Checking location permission..."
-          />
-        )}
-        {lw instanceof LocalWeatherViewModelVariantLocationDisabled && (
-          <StatusMessage
-            icon={MapPinLine}
-            message="Location is disabled. Enable location access to see local weather."
-          />
-        )}
-        {lw instanceof LocalWeatherViewModelVariantFetchingLocation && (
-          <Spinner message="Getting your location..." />
-        )}
-        {lw instanceof LocalWeatherViewModelVariantFetchingWeather && (
-          <Spinner message="Loading weather data..." />
-        )}
-        {lw instanceof LocalWeatherViewModelVariantFetched && (
-          <WeatherDetail data={lw.value} />
-        )}
-        {lw instanceof LocalWeatherViewModelVariantFailed && (
-          <StatusMessage
-            icon={CloudSlash}
-            message="Failed to load weather."
-            tone="error"
-          />
-        )}
+        {matchLocalWeatherViewModel(lw, {
+          CheckingPermission: () => (
+            <StatusMessage
+              icon={MapPinLine}
+              message="Checking location permission..."
+            />
+          ),
+          LocationDisabled: () => (
+            <StatusMessage
+              icon={MapPinLine}
+              message="Location is disabled. Enable location access to see local weather."
+            />
+          ),
+          FetchingLocation: () => (
+            <Spinner message="Getting your location..." />
+          ),
+          FetchingWeather: () => (
+            <Spinner message="Loading weather data..." />
+          ),
+          Fetched: (v) => <WeatherDetail data={v.value} />,
+          Failed: () => (
+            <StatusMessage
+              icon={CloudSlash}
+              message="Failed to load weather."
+              tone="error"
+            />
+          ),
+        })}
       </Card>
       {model.favorites.length > 0 && (
         <Card className="mb-4">
@@ -82,24 +77,14 @@ export function HomeView({ model }: { model: HomeViewModel }) {
           label="Favourites"
           icon={Star}
           onClick={() =>
-            dispatch(
-              new EventVariantActive(
-                new ActiveEventVariantHome(
-                  new HomeEventVariantGoToFavorites(),
-                ),
-              ),
-            )
+            dispatch(eventActive(activeEventHome(homeEventGoToFavorites())))
           }
         />
         <Button
           label="Reset API Key"
           icon={Key}
           variant="secondary"
-          onClick={() =>
-            dispatch(
-              new EventVariantActive(new ActiveEventVariantResetApiKey()),
-            )
-          }
+          onClick={() => dispatch(eventActive(activeEventResetApiKey()))}
         />
       </div>
     </>

--- a/examples/weather/web-nextjs/src/app/components/HomeView.tsx
+++ b/examples/weather/web-nextjs/src/app/components/HomeView.tsx
@@ -1,9 +1,4 @@
-import {
-  CloudSlash,
-  Key,
-  MapPinLine,
-  Star,
-} from "@phosphor-icons/react";
+import { CloudSlash, Key, MapPinLine, Star } from "@phosphor-icons/react";
 
 import type { HomeViewModel } from "shared_types/app";
 import {
@@ -15,13 +10,7 @@ import {
 } from "shared_types/app";
 
 import { useDispatch } from "../../lib/core/provider";
-import {
-  Button,
-  Card,
-  SectionTitle,
-  Spinner,
-  StatusMessage,
-} from "./common";
+import { Button, Card, SectionTitle, Spinner, StatusMessage } from "./common";
 import { FavoriteWeatherCard } from "./FavoriteWeatherCard";
 import { WeatherDetail } from "./WeatherDetail";
 
@@ -49,9 +38,7 @@ export function HomeView({ model }: { model: HomeViewModel }) {
           FetchingLocation: () => (
             <Spinner message="Getting your location..." />
           ),
-          FetchingWeather: () => (
-            <Spinner message="Loading weather data..." />
-          ),
+          FetchingWeather: () => <Spinner message="Loading weather data..." />,
           Fetched: (v) => <WeatherDetail data={v.value} />,
           Failed: () => (
             <StatusMessage

--- a/examples/weather/web-nextjs/src/app/components/OnboardView.tsx
+++ b/examples/weather/web-nextjs/src/app/components/OnboardView.tsx
@@ -8,14 +8,11 @@ import {
 
 import type { OnboardViewModel, OnboardReason } from "shared_types/app";
 import {
-  OnboardReasonVariantWelcome,
-  OnboardReasonVariantUnauthorized,
-  OnboardReasonVariantReset,
-  OnboardStateViewModelVariantInput,
-  OnboardStateViewModelVariantSaving,
-  EventVariantOnboard,
-  OnboardEventVariantApiKey,
-  OnboardEventVariantSubmit,
+  matchOnboardReason,
+  matchOnboardStateViewModel,
+  eventOnboard,
+  onboardEventApiKey,
+  onboardEventSubmit,
 } from "shared_types/app";
 
 import { useDispatch } from "../../lib/core/provider";
@@ -32,46 +29,36 @@ export function OnboardView({ model }: { model: OnboardViewModel }) {
   const dispatch = useDispatch();
   const { icon, reasonText } = reasonCopy(model.reason);
 
-  if (model.state instanceof OnboardStateViewModelVariantInput) {
-    const { api_key, can_submit } = model.state;
-    return (
+  return matchOnboardStateViewModel(model.state, {
+    Input: (s) => (
       <Card>
         <SectionTitle icon={icon} title="Setup" />
         <p className="text-slate-500 text-sm mb-4">{reasonText}</p>
         <div className="mb-4">
           <TextField
-            value={api_key}
+            value={s.api_key}
             placeholder="Paste your API key here"
             icon={Key}
             onInput={(value) =>
-              dispatch(
-                new EventVariantOnboard(new OnboardEventVariantApiKey(value)),
-              )
+              dispatch(eventOnboard(onboardEventApiKey(value)))
             }
           />
         </div>
         <Button
           label="Submit"
           icon={Check}
-          enabled={can_submit}
+          enabled={s.can_submit}
           fullWidth
-          onClick={() =>
-            dispatch(new EventVariantOnboard(new OnboardEventVariantSubmit()))
-          }
+          onClick={() => dispatch(eventOnboard(onboardEventSubmit()))}
         />
       </Card>
-    );
-  }
-
-  if (model.state instanceof OnboardStateViewModelVariantSaving) {
-    return (
+    ),
+    Saving: () => (
       <Card>
         <Spinner message="Saving..." />
       </Card>
-    );
-  }
-
-  return null;
+    ),
+  });
 }
 // ANCHOR_END: onboard_view
 
@@ -79,23 +66,18 @@ function reasonCopy(reason: OnboardReason): {
   icon: PhosphorIcon;
   reasonText: string;
 } {
-  if (reason instanceof OnboardReasonVariantWelcome) {
-    return {
+  return matchOnboardReason(reason, {
+    Welcome: () => ({
       icon: Key,
       reasonText: "Welcome! Enter your OpenWeather API key to get started.",
-    };
-  }
-  if (reason instanceof OnboardReasonVariantUnauthorized) {
-    return {
+    }),
+    Unauthorized: () => ({
       icon: Warning,
       reasonText: "Your API key was rejected. Please enter a valid key.",
-    };
-  }
-  if (reason instanceof OnboardReasonVariantReset) {
-    return {
+    }),
+    Reset: () => ({
       icon: ArrowCounterClockwise,
       reasonText: "Enter a new API key.",
-    };
-  }
-  return { icon: Key, reasonText: "" };
+    }),
+  });
 }

--- a/examples/weather/web-nextjs/src/app/components/OnboardView.tsx
+++ b/examples/weather/web-nextjs/src/app/components/OnboardView.tsx
@@ -16,13 +16,7 @@ import {
 } from "shared_types/app";
 
 import { useDispatch } from "../../lib/core/provider";
-import {
-  Button,
-  Card,
-  SectionTitle,
-  Spinner,
-  TextField,
-} from "./common";
+import { Button, Card, SectionTitle, Spinner, TextField } from "./common";
 
 // ANCHOR: onboard_view
 export function OnboardView({ model }: { model: OnboardViewModel }) {

--- a/examples/weather/web-nextjs/src/app/page.tsx
+++ b/examples/weather/web-nextjs/src/app/page.tsx
@@ -11,14 +11,6 @@ import type {
   OnboardViewModel,
   ViewModel,
 } from "shared_types/app";
-import {
-  ViewModelVariantLoading,
-  ViewModelVariantOnboard,
-  ViewModelVariantActive,
-  ViewModelVariantFailed,
-  ActiveViewModelVariantHome,
-  ActiveViewModelVariantFavorites,
-} from "shared_types/app";
 
 import { CoreProvider, useViewModel } from "../lib/core/provider";
 import {
@@ -31,11 +23,6 @@ import { OnboardView } from "./components/OnboardView";
 import { HomeView } from "./components/HomeView";
 import { FavoritesView } from "./components/FavoritesView";
 
-// Note: The generated types use class hierarchies to represent Rust enums,
-// which requires `instanceof` checks throughout the view code. This will be
-// made more idiomatic (discriminated unions) once
-// https://github.com/redbadger/facet-generate/issues/83 is resolved.
-
 // ANCHOR: app
 const AppShell = () => {
   const view = useViewModel();
@@ -44,13 +31,13 @@ const AppShell = () => {
   // is the coarse equivalent of Leptos's `Memo`: recomputes only when `view`
   // changes, but doesn't diff deeper than reference equality.
   const onboardVm = useMemo(
-    () => (view instanceof ViewModelVariantOnboard ? view.value : null),
+    () => (view.kind === "Onboard" ? view.value : null),
     [view],
   );
   const homeVm = useMemo(() => pickHome(view), [view]);
   const favoritesVm = useMemo(() => pickFavorites(view), [view]);
   const failedMessage = useMemo(
-    () => (view instanceof ViewModelVariantFailed ? view.message : null),
+    () => (view.kind === "Failed" ? view.message : null),
     [view],
   );
 
@@ -61,7 +48,7 @@ const AppShell = () => {
         subtitle="Rust Core, TypeScript Shell (Next.js)"
         icon={CloudSun}
       />
-      {view instanceof ViewModelVariantLoading && (
+      {view.kind === "Loading" && (
         <Card>
           <Spinner message="Loading..." />
         </Card>
@@ -84,16 +71,16 @@ const AppShell = () => {
 // ANCHOR_END: app
 
 function pickHome(view: ViewModel): HomeViewModel | null {
-  if (!(view instanceof ViewModelVariantActive)) return null;
+  if (view.kind !== "Active") return null;
   const active: ActiveViewModel = view.value;
-  if (!(active instanceof ActiveViewModelVariantHome)) return null;
+  if (active.kind !== "Home") return null;
   return active.value;
 }
 
 function pickFavorites(view: ViewModel): FavoritesViewModel | null {
-  if (!(view instanceof ViewModelVariantActive)) return null;
+  if (view.kind !== "Active") return null;
   const active: ActiveViewModel = view.value;
-  if (!(active instanceof ActiveViewModelVariantFavorites)) return null;
+  if (active.kind !== "Favorites") return null;
   return active.value;
 }
 

--- a/examples/weather/web-nextjs/src/lib/core/http.ts
+++ b/examples/weather/web-nextjs/src/lib/core/http.ts
@@ -2,7 +2,7 @@ import type { HttpRequest, HttpResult } from "shared_types/app";
 import {
   HttpResponse,
   HttpHeader,
-  HttpResultVariantOk,
+  httpResultOk,
 } from "shared_types/app";
 
 export async function request({
@@ -25,7 +25,7 @@ export async function request({
 
   const body = await response.arrayBuffer();
 
-  return new HttpResultVariantOk(
+  return httpResultOk(
     new HttpResponse(response.status, responseHeaders, new Uint8Array(body)),
   );
 }

--- a/examples/weather/web-nextjs/src/lib/core/http.ts
+++ b/examples/weather/web-nextjs/src/lib/core/http.ts
@@ -1,9 +1,5 @@
 import type { HttpRequest, HttpResult } from "shared_types/app";
-import {
-  HttpResponse,
-  HttpHeader,
-  httpResultOk,
-} from "shared_types/app";
+import { HttpResponse, HttpHeader, httpResultOk } from "shared_types/app";
 
 export async function request({
   url,

--- a/examples/weather/web-nextjs/src/lib/core/index.ts
+++ b/examples/weather/web-nextjs/src/lib/core/index.ts
@@ -1,26 +1,25 @@
 import type { Dispatch, SetStateAction } from "react";
 
 import { CoreFFI } from "shared";
-import type { Effect, Event, RenderOperation } from "shared_types/app";
+import type { Effect, Event, ViewModel } from "shared_types/app";
 import {
-  EffectVariantHttp,
-  EffectVariantKeyValue,
-  EffectVariantLocation,
-  EffectVariantRender,
-  EffectVariantSecret,
-  EffectVariantTime,
   Request,
-  ViewModel,
+  matchEffect,
+  serializeEvent,
+  serializeHttpResult,
+  serializeKeyValueResult,
+  serializeLocationResult,
+  serializeSecretResponse,
+  serializeTimeResponse,
+  deserializeViewModel,
 } from "shared_types/app";
+import type { Serializer } from "shared_types/serde";
 import { BincodeDeserializer, BincodeSerializer } from "shared_types/bincode";
 import * as http from "./http";
 import * as kv from "./kv";
 import * as location from "./location";
 import * as secret from "./secret";
 import * as time from "./time";
-
-// union of all Operation types, only render is needed here
-type Response = RenderOperation;
 
 // ANCHOR: core_base
 export class Core {
@@ -34,7 +33,7 @@ export class Core {
 
   update(event: Event) {
     const serializer = new BincodeSerializer();
-    event.serialize(serializer);
+    serializeEvent(event, serializer);
 
     const effects = this.core.update(serializer.getBytes());
 
@@ -45,51 +44,44 @@ export class Core {
   }
   // ANCHOR_END: core_base
 
-  async resolve(id: number, effect: Effect) {
-    switch (effect.constructor) {
-      case EffectVariantRender: {
+  resolve(id: number, effect: Effect) {
+    matchEffect(effect, {
+      Render: (): void => {
         this.callback(deserializeView(this.core.view()));
-        break;
-      }
+      },
       // ANCHOR: http
-      case EffectVariantHttp: {
-        const request = (effect as EffectVariantHttp).value;
-        const response = await http.request(request);
-        this.respond(id, response);
-        break;
-      }
+      Http: (e): void => {
+        void http.request(e.value).then((r) =>
+          this.respond(id, (s) => serializeHttpResult(r, s)),
+        );
+      },
       // ANCHOR_END: http
-      case EffectVariantKeyValue: {
-        const request = (effect as EffectVariantKeyValue).value;
-        const response = await kv.handle(request);
-        this.respond(id, response);
-        break;
-      }
-      case EffectVariantLocation: {
-        const request = (effect as EffectVariantLocation).value;
-        const response = await location.handle(request);
-        this.respond(id, response);
-        break;
-      }
-      case EffectVariantSecret: {
-        const request = (effect as EffectVariantSecret).value;
-        const response = secret.handle(request);
-        this.respond(id, response);
-        break;
-      }
-      case EffectVariantTime: {
-        const request = (effect as EffectVariantTime).value;
-        const response = await time.handle(request);
-        this.respond(id, response);
-        break;
-      }
-    }
+      KeyValue: (e): void => {
+        void kv.handle(e.value).then((r) =>
+          this.respond(id, (s) => serializeKeyValueResult(r, s)),
+        );
+      },
+      Location: (e): void => {
+        void location.handle(e.value).then((r) =>
+          this.respond(id, (s) => serializeLocationResult(r, s)),
+        );
+      },
+      Secret: (e): void => {
+        const r = secret.handle(e.value);
+        this.respond(id, (s) => serializeSecretResponse(r, s));
+      },
+      Time: (e): void => {
+        void time.handle(e.value).then((r) =>
+          this.respond(id, (s) => serializeTimeResponse(r, s)),
+        );
+      },
+    });
   }
 
   // ANCHOR: respond
-  respond(id: number, response: Response) {
+  respond(id: number, serialize: (s: Serializer) => void) {
     const serializer = new BincodeSerializer();
-    response.serialize(serializer);
+    serialize(serializer);
 
     const effects = this.core.resolve(id, serializer.getBytes());
 
@@ -113,7 +105,7 @@ function deserializeRequests(bytes: Uint8Array | number[]) {
 }
 
 function deserializeView(bytes: Uint8Array | number[]) {
-  return ViewModel.deserialize(new BincodeDeserializer(asBytes(bytes)));
+  return deserializeViewModel(new BincodeDeserializer(asBytes(bytes)));
 }
 
 function asBytes(bytes: Uint8Array | number[]): Uint8Array {

--- a/examples/weather/web-nextjs/src/lib/core/index.ts
+++ b/examples/weather/web-nextjs/src/lib/core/index.ts
@@ -51,29 +51,29 @@ export class Core {
       },
       // ANCHOR: http
       Http: (e): void => {
-        void http.request(e.value).then((r) =>
-          this.respond(id, (s) => serializeHttpResult(r, s)),
-        );
+        void http
+          .request(e.value)
+          .then((r) => this.respond(id, (s) => serializeHttpResult(r, s)));
       },
       // ANCHOR_END: http
       KeyValue: (e): void => {
-        void kv.handle(e.value).then((r) =>
-          this.respond(id, (s) => serializeKeyValueResult(r, s)),
-        );
+        void kv
+          .handle(e.value)
+          .then((r) => this.respond(id, (s) => serializeKeyValueResult(r, s)));
       },
       Location: (e): void => {
-        void location.handle(e.value).then((r) =>
-          this.respond(id, (s) => serializeLocationResult(r, s)),
-        );
+        void location
+          .handle(e.value)
+          .then((r) => this.respond(id, (s) => serializeLocationResult(r, s)));
       },
       Secret: (e): void => {
         const r = secret.handle(e.value);
         this.respond(id, (s) => serializeSecretResponse(r, s));
       },
       Time: (e): void => {
-        void time.handle(e.value).then((r) =>
-          this.respond(id, (s) => serializeTimeResponse(r, s)),
-        );
+        void time
+          .handle(e.value)
+          .then((r) => this.respond(id, (s) => serializeTimeResponse(r, s)));
       },
     });
   }

--- a/examples/weather/web-nextjs/src/lib/core/kv.ts
+++ b/examples/weather/web-nextjs/src/lib/core/kv.ts
@@ -1,36 +1,32 @@
 import type { KeyValueOperation, KeyValueResult } from "shared_types/app";
 import {
-  KeyValueOperationVariantGet,
-  KeyValueOperationVariantSet,
-  KeyValueOperationVariantDelete,
-  KeyValueOperationVariantExists,
-  KeyValueOperationVariantListKeys,
-  KeyValueResultVariantOk,
-  KeyValueResponseVariantGet,
-  KeyValueResponseVariantSet,
-  KeyValueResponseVariantDelete,
-  KeyValueResponseVariantExists,
-  KeyValueResponseVariantListKeys,
-  ValueVariantBytes,
+  matchKeyValueOperation,
+  keyValueResultOk,
+  keyValueResponseGet,
+  keyValueResponseSet,
+  keyValueResponseDelete,
+  keyValueResponseExists,
+  keyValueResponseListKeys,
+  valueBytes,
 } from "shared_types/app";
 
 export async function handle(
   operation: KeyValueOperation,
 ): Promise<KeyValueResult> {
-  switch (operation.constructor) {
-    case KeyValueOperationVariantGet: {
-      const key = (operation as KeyValueOperationVariantGet).key;
+  return matchKeyValueOperation(operation, {
+    Get: (op) => {
+      const key = op.key;
       console.debug("kv get:", key);
       const stored = localStorage.getItem(key);
       const bytes = stored
         ? Array.from(new TextEncoder().encode(stored))
         : [];
-      return new KeyValueResultVariantOk(
-        new KeyValueResponseVariantGet(new ValueVariantBytes(bytes)),
+      return Promise.resolve(
+        keyValueResultOk(keyValueResponseGet(valueBytes(bytes))),
       );
-    }
-    case KeyValueOperationVariantSet: {
-      const { key, value } = operation as KeyValueOperationVariantSet;
+    },
+    Set: (op) => {
+      const { key, value } = op;
       console.debug("kv set:", key);
       const previous = localStorage.getItem(key);
       const prevBytes = previous
@@ -38,32 +34,32 @@ export async function handle(
         : [];
       const valueStr = new TextDecoder().decode(new Uint8Array(value));
       localStorage.setItem(key, valueStr);
-      return new KeyValueResultVariantOk(
-        new KeyValueResponseVariantSet(new ValueVariantBytes(prevBytes)),
+      return Promise.resolve(
+        keyValueResultOk(keyValueResponseSet(valueBytes(prevBytes))),
       );
-    }
-    case KeyValueOperationVariantDelete: {
-      const key = (operation as KeyValueOperationVariantDelete).key;
+    },
+    Delete: (op) => {
+      const key = op.key;
       console.debug("kv delete:", key);
       const previous = localStorage.getItem(key);
       const prevBytes = previous
         ? Array.from(new TextEncoder().encode(previous))
         : [];
       localStorage.removeItem(key);
-      return new KeyValueResultVariantOk(
-        new KeyValueResponseVariantDelete(new ValueVariantBytes(prevBytes)),
+      return Promise.resolve(
+        keyValueResultOk(keyValueResponseDelete(valueBytes(prevBytes))),
       );
-    }
-    case KeyValueOperationVariantExists: {
-      const key = (operation as KeyValueOperationVariantExists).key;
+    },
+    Exists: (op) => {
+      const key = op.key;
       const exists = localStorage.getItem(key) !== null;
       console.debug("kv exists:", key, exists);
-      return new KeyValueResultVariantOk(
-        new KeyValueResponseVariantExists(exists),
+      return Promise.resolve(
+        keyValueResultOk(keyValueResponseExists(exists)),
       );
-    }
-    case KeyValueOperationVariantListKeys: {
-      const { prefix } = operation as KeyValueOperationVariantListKeys;
+    },
+    ListKeys: (op) => {
+      const { prefix } = op;
       console.debug("kv list_keys: prefix=", prefix);
       const keys: string[] = [];
       for (let i = 0; i < localStorage.length; i++) {
@@ -72,11 +68,9 @@ export async function handle(
           keys.push(key);
         }
       }
-      return new KeyValueResultVariantOk(
-        new KeyValueResponseVariantListKeys(keys, BigInt(0)),
+      return Promise.resolve(
+        keyValueResultOk(keyValueResponseListKeys(keys, BigInt(0))),
       );
-    }
-    default:
-      throw new Error(`Unhandled KeyValue operation: ${operation.constructor}`);
-  }
+    },
+  });
 }

--- a/examples/weather/web-nextjs/src/lib/core/kv.ts
+++ b/examples/weather/web-nextjs/src/lib/core/kv.ts
@@ -19,9 +19,7 @@ export async function handle(
       console.debug("kv get:", key);
       const stored = localStorage.getItem(key);
       const bytes = stored ? Array.from(new TextEncoder().encode(stored)) : [];
-      return Promise.resolve(
-        keyValueResultOk(keyValueResponseGet(valueBytes(bytes))),
-      );
+      return keyValueResultOk(keyValueResponseGet(valueBytes(bytes)));
     },
     Set: (op) => {
       const { key, value } = op;
@@ -32,9 +30,7 @@ export async function handle(
         : [];
       const valueStr = new TextDecoder().decode(new Uint8Array(value));
       localStorage.setItem(key, valueStr);
-      return Promise.resolve(
-        keyValueResultOk(keyValueResponseSet(valueBytes(prevBytes))),
-      );
+      return keyValueResultOk(keyValueResponseSet(valueBytes(prevBytes)));
     },
     Delete: (op) => {
       const key = op.key;
@@ -44,15 +40,13 @@ export async function handle(
         ? Array.from(new TextEncoder().encode(previous))
         : [];
       localStorage.removeItem(key);
-      return Promise.resolve(
-        keyValueResultOk(keyValueResponseDelete(valueBytes(prevBytes))),
-      );
+      return keyValueResultOk(keyValueResponseDelete(valueBytes(prevBytes)));
     },
     Exists: (op) => {
       const key = op.key;
       const exists = localStorage.getItem(key) !== null;
       console.debug("kv exists:", key, exists);
-      return Promise.resolve(keyValueResultOk(keyValueResponseExists(exists)));
+      return keyValueResultOk(keyValueResponseExists(exists));
     },
     ListKeys: (op) => {
       const { prefix } = op;
@@ -64,9 +58,7 @@ export async function handle(
           keys.push(key);
         }
       }
-      return Promise.resolve(
-        keyValueResultOk(keyValueResponseListKeys(keys, BigInt(0))),
-      );
+      return keyValueResultOk(keyValueResponseListKeys(keys, BigInt(0)));
     },
   });
 }

--- a/examples/weather/web-nextjs/src/lib/core/kv.ts
+++ b/examples/weather/web-nextjs/src/lib/core/kv.ts
@@ -18,9 +18,7 @@ export async function handle(
       const key = op.key;
       console.debug("kv get:", key);
       const stored = localStorage.getItem(key);
-      const bytes = stored
-        ? Array.from(new TextEncoder().encode(stored))
-        : [];
+      const bytes = stored ? Array.from(new TextEncoder().encode(stored)) : [];
       return Promise.resolve(
         keyValueResultOk(keyValueResponseGet(valueBytes(bytes))),
       );
@@ -54,9 +52,7 @@ export async function handle(
       const key = op.key;
       const exists = localStorage.getItem(key) !== null;
       console.debug("kv exists:", key, exists);
-      return Promise.resolve(
-        keyValueResultOk(keyValueResponseExists(exists)),
-      );
+      return Promise.resolve(keyValueResultOk(keyValueResponseExists(exists)));
     },
     ListKeys: (op) => {
       const { prefix } = op;

--- a/examples/weather/web-nextjs/src/lib/core/location.ts
+++ b/examples/weather/web-nextjs/src/lib/core/location.ts
@@ -28,10 +28,7 @@ export async function handle(
           position.coords.longitude,
         );
         return locationResultLocation(
-          new Location(
-            position.coords.latitude,
-            position.coords.longitude,
-          ),
+          new Location(position.coords.latitude, position.coords.longitude),
         );
       } catch (e) {
         console.warn("geolocation failed:", e);

--- a/examples/weather/web-nextjs/src/lib/core/location.ts
+++ b/examples/weather/web-nextjs/src/lib/core/location.ts
@@ -1,22 +1,21 @@
 import type { LocationOperation, LocationResult } from "shared_types/app";
 import {
-  LocationOperationVariantIsLocationEnabled,
-  LocationResultVariantEnabled,
-  LocationResultVariantLocation,
+  matchLocationOperation,
+  locationResultEnabled,
+  locationResultLocation,
   Location,
 } from "shared_types/app";
 
 export async function handle(
   operation: LocationOperation,
 ): Promise<LocationResult> {
-  switch (operation.constructor) {
-    case LocationOperationVariantIsLocationEnabled: {
+  return matchLocationOperation<Promise<LocationResult>>(operation, {
+    IsLocationEnabled: async () => {
       const enabled = "geolocation" in navigator;
       console.debug("location enabled:", enabled);
-      return new LocationResultVariantEnabled(enabled);
-    }
-    default: {
-      // GetLocation
+      return locationResultEnabled(enabled);
+    },
+    GetLocation: async () => {
       try {
         const position = await new Promise<GeolocationPosition>(
           (resolve, reject) => {
@@ -28,7 +27,7 @@ export async function handle(
           position.coords.latitude,
           position.coords.longitude,
         );
-        return new LocationResultVariantLocation(
+        return locationResultLocation(
           new Location(
             position.coords.latitude,
             position.coords.longitude,
@@ -36,8 +35,8 @@ export async function handle(
         );
       } catch (e) {
         console.warn("geolocation failed:", e);
-        return new LocationResultVariantLocation(null);
+        return locationResultLocation(null);
       }
-    }
-  }
+    },
+  });
 }

--- a/examples/weather/web-nextjs/src/lib/core/provider.tsx
+++ b/examples/weather/web-nextjs/src/lib/core/provider.tsx
@@ -16,8 +16,9 @@ import { eventStart, viewModelLoading } from "shared_types/app";
 
 import { Core } from "./";
 
-const wasmInitialized = (sharedWasm as unknown as { initialized: Promise<void> })
-  .initialized;
+const wasmInitialized = (
+  sharedWasm as unknown as { initialized: Promise<void> }
+).initialized;
 
 // ANCHOR: context
 /**

--- a/examples/weather/web-nextjs/src/lib/core/provider.tsx
+++ b/examples/weather/web-nextjs/src/lib/core/provider.tsx
@@ -12,7 +12,7 @@ import {
 
 import * as sharedWasm from "shared";
 import type { Event, ViewModel } from "shared_types/app";
-import { EventVariantStart, ViewModelVariantLoading } from "shared_types/app";
+import { eventStart, viewModelLoading } from "shared_types/app";
 
 import { Core } from "./";
 
@@ -35,7 +35,7 @@ const DispatchContext = createContext<((event: Event) => void) | null>(null);
  * exposes `dispatch` as a stable callback via context.
  */
 export function CoreProvider({ children }: { children: ReactNode }) {
-  const [view, setView] = useState<ViewModel>(new ViewModelVariantLoading());
+  const [view, setView] = useState<ViewModel>(viewModelLoading());
   const coreRef = useRef<Core | null>(null);
   const initialized = useRef(false);
 
@@ -47,7 +47,7 @@ export function CoreProvider({ children }: { children: ReactNode }) {
       if (!coreRef.current) {
         coreRef.current = new Core(setView);
       }
-      coreRef.current.update(new EventVariantStart());
+      coreRef.current.update(eventStart());
     });
   }, []);
 

--- a/examples/weather/web-nextjs/src/lib/core/secret.ts
+++ b/examples/weather/web-nextjs/src/lib/core/secret.ts
@@ -6,42 +6,38 @@
 
 import type { SecretRequest, SecretResponse } from "shared_types/app";
 import {
-  SecretRequestVariantFetch,
-  SecretRequestVariantStore,
-  SecretRequestVariantDelete,
-  SecretResponseVariantMissing,
-  SecretResponseVariantFetched,
-  SecretResponseVariantStored,
-  SecretResponseVariantDeleted,
+  matchSecretRequest,
+  secretResponseMissing,
+  secretResponseFetched,
+  secretResponseStored,
+  secretResponseDeleted,
 } from "shared_types/app";
 
 export function handle(request: SecretRequest): SecretResponse {
-  if (request instanceof SecretRequestVariantFetch) {
-    const key = request.value;
-    console.debug("secret fetch:", key);
-    const value = localStorage.getItem(key);
-    if (value !== null) {
-      console.debug("secret found:", key);
-      return new SecretResponseVariantFetched(key, value);
-    }
-    console.debug("secret not found:", key);
-    return new SecretResponseVariantMissing(key);
-  }
-
-  if (request instanceof SecretRequestVariantStore) {
-    const key = request.field0;
-    const value = request.field1;
-    console.debug("secret store:", key);
-    localStorage.setItem(key, value);
-    return new SecretResponseVariantStored(key);
-  }
-
-  if (request instanceof SecretRequestVariantDelete) {
-    const key = request.value;
-    console.debug("secret delete:", key);
-    localStorage.removeItem(key);
-    return new SecretResponseVariantDeleted(key);
-  }
-
-  throw new Error(`Unhandled secret operation: ${request.constructor.name}`);
+  return matchSecretRequest(request, {
+    Fetch: (r) => {
+      const key = r.value;
+      console.debug("secret fetch:", key);
+      const value = localStorage.getItem(key);
+      if (value !== null) {
+        console.debug("secret found:", key);
+        return secretResponseFetched(key, value);
+      }
+      console.debug("secret not found:", key);
+      return secretResponseMissing(key);
+    },
+    Store: (r) => {
+      const key = r.field0;
+      const value = r.field1;
+      console.debug("secret store:", key);
+      localStorage.setItem(key, value);
+      return secretResponseStored(key);
+    },
+    Delete: (r) => {
+      const key = r.value;
+      console.debug("secret delete:", key);
+      localStorage.removeItem(key);
+      return secretResponseDeleted(key);
+    },
+  });
 }

--- a/examples/weather/web-nextjs/src/lib/core/time.ts
+++ b/examples/weather/web-nextjs/src/lib/core/time.ts
@@ -1,49 +1,43 @@
 import type { TimeRequest, TimeResponse } from "shared_types/app";
 import {
-  TimeRequestVariantNow,
-  TimeRequestVariantNotifyAfter,
-  TimeRequestVariantNotifyAt,
-  TimeRequestVariantClear,
-  TimeResponseVariantNow,
-  TimeResponseVariantDurationElapsed,
-  TimeResponseVariantInstantArrived,
-  TimeResponseVariantCleared,
+  matchTimeRequest,
+  timeResponseNow,
+  timeResponseDurationElapsed,
+  timeResponseInstantArrived,
+  timeResponseCleared,
   Instant,
 } from "shared_types/app";
 
 export async function handle(request: TimeRequest): Promise<TimeResponse> {
-  if (request instanceof TimeRequestVariantNow) {
-    console.debug("time: now");
-    return new TimeResponseVariantNow(nowInstant());
-  }
-
-  if (request instanceof TimeRequestVariantNotifyAfter) {
-    const millis = Number(request.duration.nanos / BigInt(1_000_000));
-    console.debug(`time: notify_after ${millis}ms (id=${request.id})`);
-    await sleep(millis);
-    console.debug(`time: duration elapsed (id=${request.id})`);
-    return new TimeResponseVariantDurationElapsed(request.id);
-  }
-
-  if (request instanceof TimeRequestVariantNotifyAt) {
-    const targetMs = instantToEpochMs(request.instant);
-    const nowMs = Date.now();
-    console.debug(
-      `time: notify_at target=${targetMs}ms now=${nowMs}ms (id=${request.id})`,
-    );
-    if (targetMs > nowMs) {
-      await sleep(targetMs - nowMs);
-    }
-    console.debug(`time: instant arrived (id=${request.id})`);
-    return new TimeResponseVariantInstantArrived(request.id);
-  }
-
-  if (request instanceof TimeRequestVariantClear) {
-    console.debug(`time: clear (id=${request.id})`);
-    return new TimeResponseVariantCleared(request.id);
-  }
-
-  throw new Error(`Unhandled time operation: ${request.constructor.name}`);
+  return matchTimeRequest<Promise<TimeResponse>>(request, {
+    Now: async () => {
+      console.debug("time: now");
+      return timeResponseNow(nowInstant());
+    },
+    NotifyAfter: async (r) => {
+      const millis = Number(r.duration.nanos / BigInt(1_000_000));
+      console.debug(`time: notify_after ${millis}ms (id=${r.id})`);
+      await sleep(millis);
+      console.debug(`time: duration elapsed (id=${r.id})`);
+      return timeResponseDurationElapsed(r.id);
+    },
+    NotifyAt: async (r) => {
+      const targetMs = instantToEpochMs(r.instant);
+      const nowMs = Date.now();
+      console.debug(
+        `time: notify_at target=${targetMs}ms now=${nowMs}ms (id=${r.id})`,
+      );
+      if (targetMs > nowMs) {
+        await sleep(targetMs - nowMs);
+      }
+      console.debug(`time: instant arrived (id=${r.id})`);
+      return timeResponseInstantArrived(r.id);
+    },
+    Clear: async (r) => {
+      console.debug(`time: clear (id=${r.id})`);
+      return timeResponseCleared(r.id);
+    },
+  });
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

- Ports all TypeScript shells in the `examples/` directory to use the new discriminated union API generated by [`facet-generate` PR #106](https://github.com/redbadger/facet-generate/pull/106), replacing abstract class hierarchies with plain union types and generated `match*` functions
- Replaces `new EventVariantX()` / `new EffectVariantX()` constructor calls with `eventX()` / `effectX()` factory functions throughout
- Replaces `switch (effect.constructor)` and `instanceof` checks with exhaustive `matchEffect(...)` / `matchViewModel(...)` etc. calls
- Replaces `response.serialize(serializer)` calls on enum types with standalone `serializeX(value, serializer)` functions; updates `respond()` to accept a serializer callback `(s: Serializer) => void` instead of a response object
- Adds a shell-side workaround for the notes example, where `automerge`'s `wasm` feature pulls in `getrandom/js`, which requires a `crypto.getRandomValues` wasm-bindgen import that the boltffi runtime stubs as "Unimplemented"

## Examples updated

- `counter/web-nextjs` and `counter/web-react-router`
- `counter-http/web-nextjs`, `counter-middleware/web-nextjs`, `counter-routing/web-nextjs`
- `notes/web-nextjs`
- `weather/web-nextjs` (including all component files)

## Dependency

`facet_generate` now tracks the published **0.18.0** release rather than the `feat/typescript-discriminated-unions` git branch. 0.18.0 still depends on `facet-generate-attrs ^0.17` and `facet =0.44`, so those constraints are unchanged.

## Incidental fixes

Two bugs surfaced while porting and rebasing. Neither is apparent from the refactor itself, so calling them out explicitly:

- **notes timers were keyed on `NaN`.** `TimeRequest::NotifyAfter` used `Number(startId)`, but `TimerId` wraps `value: uint64` and defines no `valueOf`, so every timer landed in the map under `NaN` while `Clear` looked up `Number(cancelId.value)`. `window.clearTimeout` was therefore always called with `undefined`: a cleared timer still fired and sent a spurious `DurationElapsed` back to the core. Now uses `startId.value`, matching what `Clear` already did.
- **the `getRandomValues` workaround had stopped working.** It matched one hardcoded wasm-bindgen signature hash, and rebasing onto `master` moved `getrandom` 0.4.2 → 0.4.3, which changed the import name to `__wbg_getRandomValues_bf16787eede473f5`. The Proxy fell through to boltffi's "Unimplemented" stub, WASM init threw, and the notes shell did not start at all. It now matches on the `__wbg_getRandomValues_` prefix so a lockfile refresh cannot silently break it again. Note this is invisible to `tsc`/eslint/`next build` — it only shows up at runtime.

  The patch also moved into its own module, imported for its side effect before `shared`. It previously sat between `core.ts`'s import statements, which reads as if it runs first but does not: ES imports are hoisted, so it was installed only after `shared` had been evaluated, and worked purely because boltffi instantiates in a later microtask.

## Also in this branch

- Root `Just` recipes are scoped to the workspace, with the examples sweep opt-in via `ci-examples` / `check-examples` / `fix-examples`, plus `ci-all` for both. `just` previously defaulted to `ci`, which ran every example × shell serially and so needed Xcode, the Android SDK, .NET, trunk, dioxus and GTK all present at once — CI itself fans these out one shell per runner. `ci` also gained the two steps the `build` workflow runs but the recipe was missing (the `crux_http` `http-types` compat tests and the `wasm32-unknown-unknown` check), so it can no longer pass locally and fail in CI.
- `counter-routing` had drifted from the other shells — pass-through serialize wrappers, an explicit `matchEffect` type argument, unmarked async IIFEs. The four counter shells now read identically.
- The notes shell throws rather than silently ignoring the `Time` and `KeyValue` operations it never issues. Those arms exist only to satisfy the exhaustive generated matchers, and an unanswered request leaves the core's command waiting forever, so a silent no-op would hang.
- `docs/src/part-2/shell/react.md` had a hand-written snippet (not an `{{#include}}`) still showing the old class-variant constructors.

## Test plan

- [x] `just ci` passes in each updated shell
- [x] Each example runs correctly in the browser
- [x] Root workspace: 218 tests, 94 doc tests, 89 `crux_http` `http-types` tests, clippy pedantic/nursery, `cargo fmt`
- [x] Rust suites pass in all six example workspaces
- [x] All seven web shells regenerate their types against published 0.18.0 and build with TypeScript checking
- [x] notes shell re-verified in a browser after the `getRandomValues` fix: WASM initialises, the persisted note loads, and editing works (which is what exercises automerge's actor-ID randomness)
- [x] `mdbook build` clean; all 32 changed TS/TSX files pass `prettier --check`
