### PR TITLE
Clarify building instructions for Android

### DIFF
--- a/docs/src/part-1/shell/android/index.md
+++ b/docs/src/part-1/shell/android/index.md
@@ -128,8 +128,8 @@ Android library added above. This includes compiling and linking the Rust
 dynamic library and generating the runtime bindings and the shared types.
 
 - The [Android NDK](https://developer.android.com/ndk)
-- [BoltFFI](https://www.boltffi.dev/) — `boltffi pack android` builds the native
-  libraries, generates the Kotlin bindings, and writes the `jniLibs`
+- [BoltFFI](https://www.boltffi.dev/) builds the native libraries, generates 
+  the Kotlin bindings, and writes the `jniLibs`
 - The `codegen` binary (with the `facet_typegen` feature) generates the Kotlin
   app data types
 
@@ -165,11 +165,25 @@ You will need to set the `ndkVersion` to one you have installed, go to "**Tools,
 When you have edited the Gradle files, don't forget to click "sync now".
 ```
 
-If you now build your project, BoltFFI and the type generator populate the
-`Android/generated` folder. It holds the native libraries (`jniLibs`), the JNI
-glue and Kotlin bindings, and the generated app types. The `sourceSets`
-directive in the shared library Gradle file (above) points both
-`kotlin.srcDirs` and `jniLibs.srcDirs` at this folder.
+As you can see, The `sourceSets` directive in the shared library Gradle 
+file points both `kotlin.srcDirs` and `jniLibs.srcDirs` at the `generated`
+directory. Let's populate it.
+
+First generate the data types using `codegen`:
+
+```sh
+$ # In `/Android`
+$ cargo run --package shared --bin codegen --features codegen,facet_typegen -- --language kotlin --output-dir generated
+```
+
+Then generate the bindings and native libraries using BoltFFI:
+
+```sh
+$ # In `/shared` 
+$ boltffi pack android
+```
+
+Now your `generated` directory should look like this:
 
 ```sh
 $ ls --tree Android/generated
@@ -208,6 +222,12 @@ Android/generated
    │           └── Shared.kt
    └── jni
       └── jni_glue.c
+```
+
+```admonish tip
+`codegen` will generate a `build.gradle.kts` that we won't be using in this setup.
+Any error reported by the IDE in this file can be ignored, and if the file prevents
+buiding it can safely be deleted.
 ```
 
 ## Create some UI and run in the Simulator


### PR DESCRIPTION
When following the Android shell tutorial. I got a bit confused at what to do when reading this line: 

> If you now build your project, BoltFFI and the type generator populate the`Android/generated` folder.

This PR aims to clarify that step by explicitly writing the shell commands to build when they are needed. 

---
PS: Thank you for this tool (framework?), I am only getting started, but it is already really exciting!