### PR TITLE
feat(http): add `HttpRequestBuilder::body_json`, mirroring the capability

### DIFF
--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `HttpRequestBuilder::body_json`, which sets a JSON body **and**
+  `content-type: application/json`, mirroring what
+  `command::RequestBuilder::body_json` puts on the wire.
+
+  The protocol builders are how a test names the request it expects, but
+  `HttpRequestBuilder::json` sets only the body, where the capability side sets the
+  mime too (via `Body::from_json`). Mirroring a real request therefore failed on
+  the `content-type` header alone unless you knew to add it by hand:
+
+  ```rust
+  // before — passes only with the header spelled out
+  assert_eq!(
+      &request.operation,
+      &HttpRequest::post(URL)
+          .header("content-type", "application/json")
+          .json(&body)
+          .build()
+  );
+
+  // after
+  assert_eq!(&request.operation, &HttpRequest::post(URL).body_json(&body).build());
+  ```
+
+  `json` is unchanged and still sets only the body: these builders construct
+  protocol-layer values, so they must stay able to express a JSON body with no
+  `content-type` (or a malformed one), and changing `json` would silently break
+  tests that already add the header themselves.
+
 ## [0.19.0](https://github.com/redbadger/crux/compare/crux_http-v0.18.0...crux_http-v0.19.0) - 2026-07-06
 
 > **📖 See the [Migrating `crux_http` to native `http` types](https://redbadger.github.io/crux/guide/migrate-crux-http.html)

--- a/crux_http/src/protocol.rs
+++ b/crux_http/src/protocol.rs
@@ -131,11 +131,51 @@ impl HttpRequestBuilder {
 
     /// Sets the body of the request to the JSON representation of the given value.
     ///
+    /// Sets **only** the body. To build the request a capability call produces —
+    /// body *and* `content-type` — use [`body_json`](Self::body_json).
+    ///
     /// # Panics
     /// Panics if the serialization fails.
     pub fn json(&mut self, body: impl serde::Serialize) -> &mut Self {
         self.body = Some(serde_json::to_vec(&body).unwrap());
         self
+    }
+
+    /// Sets the body to the JSON representation of `body` **and** sets
+    /// `content-type: application/json`, mirroring
+    /// [`crate::command::RequestBuilder::body_json`].
+    ///
+    /// This is what you want when asserting on a request an app actually made,
+    /// where spelling the header out by hand is easy to forget:
+    ///
+    /// ```rust
+    /// # use crux_http::protocol::HttpRequest;
+    /// let body = serde_json::json!({ "title": "New Post" });
+    ///
+    /// assert_eq!(
+    ///     HttpRequest::post("https://example.com/posts")
+    ///         .body_json(&body)
+    ///         .build(),
+    ///     HttpRequest::post("https://example.com/posts")
+    ///         .header("content-type", "application/json")
+    ///         .json(&body)
+    ///         .build(),
+    /// );
+    /// ```
+    ///
+    /// [`json`](Self::json) deliberately does not set the header — these builders
+    /// construct protocol-layer values, so they must stay able to express a JSON
+    /// body with no `content-type`, or a malformed one. But because the capability
+    /// side sets the mime (via `Body::from_json`), mirroring a real request with
+    /// `json` alone fails on a header-only difference. Hence this method.
+    ///
+    /// # Panics
+    /// Panics if the serialization fails.
+    pub fn body_json(&mut self, body: impl serde::Serialize) -> &mut Self {
+        self.json(body).header(
+            http::header::CONTENT_TYPE.as_str(),
+            mime::APPLICATION_JSON.as_ref(),
+        )
     }
 
     /// Builds the request.

--- a/crux_http/tests/request_building.rs
+++ b/crux_http/tests/request_building.rs
@@ -1,0 +1,74 @@
+//! What the capability puts on the wire, asserted against the protocol builders.
+//!
+//! These builders are how a test names the request it expects, so the two sides
+//! have to agree exactly — a difference in headers alone is both easy to introduce
+//! and confusing to debug.
+
+mod shared {
+    use crux_core::{macros::effect, render::RenderOperation};
+    use crux_http::protocol::HttpRequest;
+
+    #[effect]
+    pub enum Effect {
+        Http(HttpRequest),
+        Render(RenderOperation),
+    }
+
+    /// The command has to be bound to *some* event; nothing here reads it.
+    pub enum Event {
+        Done(#[expect(dead_code)] crux_http::Result<crux_http::Response<Vec<u8>>>),
+    }
+}
+
+use crux_core::Command;
+use crux_http::{command::Http, protocol::HttpRequest};
+use shared::{Effect, Event};
+
+const URL: &str = "https://example.com/posts";
+
+/// The request a `POST` with a JSON body actually produces.
+fn posted(body: &serde_json::Value) -> HttpRequest {
+    let mut cmd: Command<Effect, Event> = Http::post(URL)
+        .body_json(body)
+        .expect("the body serialises")
+        .build()
+        .then_send(Event::Done);
+
+    cmd.effects()
+        .next()
+        .expect("an HTTP request")
+        .expect_http()
+        .operation
+}
+
+#[test]
+fn body_json_mirrors_the_request_the_capability_builds() {
+    // `HttpRequestBuilder::body_json` exists so an expected value can be written
+    // in one line and still match: the capability's `body_json` sets the mime, so
+    // `json` alone would differ by the `content-type` header and nothing else.
+    let body = serde_json::json!({ "title": "New Post", "body": "Hello!" });
+
+    assert_eq!(
+        posted(&body),
+        HttpRequest::post(URL).body_json(&body).build()
+    );
+}
+
+#[test]
+fn json_sets_only_the_body() {
+    // The protocol builders stay dumb on purpose — they must be able to express a
+    // JSON body with no `content-type` — so `json` is *not* a mirror.
+    let body = serde_json::json!({ "title": "New Post" });
+    let expected = HttpRequest::post(URL).json(&body).build();
+
+    assert!(expected.headers.is_empty());
+    assert_eq!(
+        expected.body,
+        serde_json::to_vec(&body).expect("serialisable")
+    );
+    assert_ne!(
+        posted(&body),
+        expected,
+        "differs by the content-type header"
+    );
+}


### PR DESCRIPTION
## The problem

The protocol builders are how a test names the request it expects. But the two `json` methods are asymmetric:

- `command::RequestBuilder::body_json` goes through `Body::from_json`, which sets `mime::APPLICATION_JSON`, so the real request carries `content-type: application/json`.
- `protocol::HttpRequestBuilder::json` sets only the body bytes.

So the obvious way to write the expected value fails on the `content-type` header and nothing else:

```rust
// what you'd naturally write
assert_eq!(&request.operation, &HttpRequest::post(URL).json(&body).build());

//   left: HttpRequest { method: "POST", url: "…", headers: [HttpHeader { name: "content-type", value: "application/json" }], body: "{…}" }
//  right: HttpRequest { method: "POST", url: "…", body: "{…}" }
```

A header-only diff is a confusing failure, in an API whose main job is to make that assertion easy. It found me while writing request-level assertions across an app's core, and the fix is to know to add the header by hand — which is exactly the kind of thing a builder should absorb.

## The change

`HttpRequestBuilder::body_json` sets the body **and** the `content-type`, mirroring the capability, so the expected value is one line:

```rust
assert_eq!(&request.operation, &HttpRequest::post(URL).body_json(&body).build());
```

Additive and non-breaking. It borrows the capability's name deliberately, so the mirror is easy to find from the app-side call.

## Why `json` is left alone

Changing `json` to set the header would be neater at first glance, and I decided against it:

- These builders construct *protocol-layer* values. `header`'s own docs go out of their way to allow arbitrary and even malformed input, so the builders must stay able to express a JSON body with no `content-type`.
- `header` appends rather than replaces, so any existing test that adds the header by hand would silently end up with two and start failing.

`json`'s docs now point at `body_json` so the distinction is discoverable at the call site.

## Scope

The response side needs no equivalent: response decoding ignores `content-type` entirely — `body_json` is `serde_json::from_slice` over the bytes — so a test-side response without the header is already faithful.

## Testing

- New `crux_http/tests/request_building.rs` asserts the property directly: a `POST` built by the capability equals `HttpRequest::post(URL).body_json(&body).build()`, and that `json` alone does *not* match (differing by the header).
- A doctest on `body_json` showing the two equivalent spellings.
- `cargo nextest run -p crux_http --all-features` — 89 passed. Doctests — 65 passed.
- `cargo fmt --all --check` clean.

## Note on `just check`

`cargo clippy --all-targets -- -Dclippy::pedantic -Dclippy::nursery -Dwarnings` reports 8 errors on `master` under stable 1.97.1, in `compat.rs`, `request.rs` and `response/decode.rs` (`useless_borrows_in_formatting`, `manual_assert_eq`). I confirmed the count is identical with and without this branch, so this PR adds none — but CI will presumably go red on those independently once it picks up the newer stable. Happy to fix them in a separate PR if useful; I left them out to keep this diff to one concern.