### PR TITLE
fix: satisfy clippy pedantic/nursery on newer stable, refresh example lockfiles

### DIFF
--- a/crux_core/tests/json_bridge.rs
+++ b/crux_core/tests/json_bridge.rs
@@ -82,22 +82,19 @@ mod tests {
         };
 
         let Value::Number(id) = &request["id"] else {
-            panic!("Expected id to be a number, got: {:?}", &request["id"])
+            panic!("Expected id to be a number, got: {:?}", request["id"])
         };
         assert_eq!(id.as_u64().unwrap(), 0);
 
         let Value::Object(effect) = &request["effect"] else {
             panic!(
                 "Expected effect to be an object, got: {:?}",
-                &request["effect"]
+                request["effect"]
             )
         };
 
         let Value::Null = &effect["Render"] else {
-            panic!(
-                "Expected effect to be a 'Render' variant, got: {:?}",
-                &effect
-            )
+            panic!("Expected effect to be a 'Render' variant, got: {effect:?}")
         };
     }
 

--- a/crux_http/src/compat.rs
+++ b/crux_http/src/compat.rs
@@ -104,8 +104,8 @@ mod tests {
         let cookie_values: Vec<String> = ht
             .header("cookie")
             .into_iter()
-            .flat_map(|vals| vals.iter())
-            .map(|v| v.to_string())
+            .flat_map(http_types::headers::HeaderValues::iter)
+            .map(ToString::to_string)
             .collect();
 
         assert_eq!(cookie_values.len(), 2, "both cookie values must survive");
@@ -124,7 +124,10 @@ mod tests {
 
         let req: Request = ht.into();
 
-        let values: Vec<&HeaderValue> = req.header_all("set-cookie").into_iter().collect();
-        assert_eq!(values.len(), 2, "both set-cookie values must survive");
+        assert_eq!(
+            req.header_all("set-cookie").into_iter().count(),
+            2,
+            "both set-cookie values must survive"
+        );
     }
 }

--- a/crux_http/src/request.rs
+++ b/crux_http/src/request.rs
@@ -500,7 +500,7 @@ mod tests {
     #[test]
     fn new_request_has_empty_body() {
         let req = get("https://example.com");
-        assert!(req.is_empty() == Some(true));
+        assert_eq!(req.is_empty(), Some(true));
         assert_eq!(req.len(), Some(0));
     }
 
@@ -529,7 +529,7 @@ mod tests {
         req.set_body("world");
         let body = req.take_body();
         assert_eq!(body.into_bytes(), b"world");
-        assert!(req.is_empty() == Some(true));
+        assert_eq!(req.is_empty(), Some(true));
     }
 
     #[test]

--- a/crux_http/src/response/decode.rs
+++ b/crux_http/src/response/decode.rs
@@ -29,7 +29,7 @@ impl fmt::Debug for DecodeError {
 
 impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "could not decode body as {}", &self.encoding)
+        write!(f, "could not decode body as {}", self.encoding)
     }
 }
 

--- a/crux_http/tests/command_with_shell.rs
+++ b/crux_http/tests/command_with_shell.rs
@@ -72,7 +72,7 @@ mod shared {
                     "Status: {}, Body: {}, Json Body: {}",
                     model.status,
                     String::from_utf8_lossy(&model.body),
-                    &model.json_body
+                    model.json_body
                 ),
             }
         }

--- a/examples/counter-middleware/Cargo.lock
+++ b/examples/counter-middleware/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/counter-routing/Cargo.lock
+++ b/examples/counter-routing/Cargo.lock
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/weather/Cargo.lock
+++ b/examples/weather/Cargo.lock
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "crux_http"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
## Why

`just check` currently fails on `master` with stable 1.97.1 — nine diagnostics, none of which existed when the code was written. They come from lints that have landed since: `useless_borrows_in_formatting`, `manual_assert_eq`, `redundant_closure`, `needless_collect`, `uninlined_format_args`. Since `rust-toolchain.toml` tracks `channel = "stable"`, CI will hit these on its own as runners update.

## What

All mechanical, and all in test or `Display` code — no behaviour change:

| Lint | Where |
| --- | --- |
| `useless_borrows_in_formatting` | `crux_http/src/response/decode.rs`, `crux_core/tests/json_bridge.rs`, `crux_http/tests/command_with_shell.rs` |
| `manual_assert_eq` | `crux_http/src/request.rs` (2 tests) |
| `uninlined_format_args` | `crux_core/tests/json_bridge.rs` |
| `redundant_closure`, `needless_collect` | `crux_http/src/compat.rs` |

Two are small improvements beyond silencing the lint:

- `assert!(req.is_empty() == Some(true))` → `assert_eq!(req.is_empty(), Some(true))`, which reports the actual value on failure instead of just "assertion failed".
- a `collect()` into a `Vec<&HeaderValue>` used only for `.len()` → `.count()`.

Worth knowing if you re-run this yourself: **the diagnostics surface in waves.** A failure in `crux_http`'s lib stops its dependents being checked at all, so fixing the first five revealed four more. I iterated until `cargo clippy --all-targets --all-features -- --no-deps -Dclippy::pedantic -Dclippy::nursery -Dwarnings` came back clean.

## Also

Refreshes `crux_http` 0.18.0 → 0.19.0 in the three example lockfiles that still pinned the old version (`counter-middleware`, `counter-routing`, `weather`).

## Testing

- `cargo clippy --all-targets --all-features -- --no-deps -Dclippy::pedantic -Dclippy::nursery -Dwarnings` — clean.
- `cargo fmt --all --check` — clean.
- `cargo nextest run --all-features` — 216 passed, 2 skipped.
- `cargo test --doc --all-features` — all passed.
- `just examples/check` — all Rust fmt/clippy checks pass. The recipe then fails in `web-nextjs` on `pnpm install`, because `examples/counter/web-nextjs/generated/types` doesn't exist until typegen has been run; that's unrelated to this change and reproduces on `master`.

Stacked on nothing — this is independent of #552 and either can land first.