### PR TITLE
fix(http): make a rejection's body reachable, and stop tests asserting a state apps can't receive

### DIFF
--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -10,6 +10,46 @@ and this project adheres to
 
 ### Added
 
+- **`HttpError::body`, `HttpError::body_json` and `HttpError::code`** — read what the
+  server said when it rejected a request, without destructuring the variant.
+
+  A 4xx/5xx arrives as `Err(HttpError::Http { code, message, body })`, and `body` has
+  always held the server's own explanation. But `Display` shows only the status
+  (`"HTTP error 409: 409 Conflict"`), so getting at the message meant hand-rolling
+  this in every app:
+
+  ```rust
+  // before
+  let crux_http::HttpError::Http { body: Some(body), .. } = error else { return None };
+  serde_json::from_slice::<serde_json::Value>(body)
+      .ok()
+      .and_then(|b| b.get("error").and_then(|e| e.as_str()).map(String::from))
+
+  // after
+  error.body_json::<serde_json::Value>().ok()
+      .and_then(|b| b["error"].as_str().map(String::from))
+  ```
+
+  `body_json` deserializes into whatever shape your API uses — your own envelope, an
+  RFC 7807 `problem+json` struct, or `serde_json::Value`. Note that body decoding is
+  skipped for an error status, so the raw error body survives even for a request
+  built with `expect_json::<T>()`; there is now a test pinning that.
+
+- **`crux_http::testing::rejection(status, body)`** — builds the
+  `crux_http::Result<Response<Body>>` a feature receives when the server rejects a
+  request, via the same conversion a real shell response takes:
+
+  ```rust
+  let event = Event::Saved(crux_http::testing::rejection(409, r#"{"error":"…"}"#));
+  ```
+
+  Use it wherever you would previously have fabricated `Ok(response_with_409)` (see
+  the breaking change below).
+
+- `crux_http::testing` now has module docs, stating the invariant the two builders
+  divide: `ResponseBuilder` for the `Ok(Response)` of a successful exchange,
+  `rejection` for the `Err` of a rejection. There is no third case.
+
 - `HttpRequestBuilder::body_json`, which sets a JSON body **and**
   `content-type: application/json`, mirroring what
   `command::RequestBuilder::body_json` puts on the wire.
@@ -37,6 +77,52 @@ and this project adheres to
   protocol-layer values, so they must stay able to express a JSON body with no
   `content-type` (or a malformed one), and changing `json` would silently break
   tests that already add the header themselves.
+
+### 💥 Breaking Changes
+
+- **`ResponseBuilder::with_status` now panics for a 4xx or 5xx status.** It could
+  previously build a `Response` carrying an error status — a value no app can ever
+  receive, because `crux_http` converts those responses into
+  `Err(HttpError::Http { .. })` before the event is sent.
+
+  This mattered in practice. A downstream app had eight call sites shaped like this:
+
+  ```rust
+  match result {
+      Ok(mut response) => {
+          if response.status().is_success() { /* … */ }
+          else { show(api::error_reason(&mut response)) }  // unreachable
+      }
+      Err(error) => fail(&error),  // "HTTP error 409: 409 Conflict"
+  }
+  ```
+
+  The `else` branch cannot run, so users saw the bare status instead of the sentence
+  the service had written for them. Seven of those sites had **passing tests** for the
+  message, because each test built the impossible value —
+  `Ok(ResponseBuilder::with_status(409).body(…).build())` — and asserted the dead
+  branch. Code review passed all eight.
+
+  The panic turns exactly those tests red, with a message naming the replacement.
+  Migration is mechanical:
+
+  ```rust
+  // before — asserts a state the app can never observe
+  let result = Ok(ResponseBuilder::with_status(409).body(body).build());
+  // after — what the app really receives
+  let result = crux_http::testing::rejection(409, body);
+  ```
+
+  Non-error statuses (1xx, 2xx, 3xx) are unaffected, including non-standard ones.
+  Nothing about the runtime behaviour of a request changes — this is a test-helper
+  guard rail plus documentation of an invariant `crux_http` already had.
+
+### Documentation
+
+- `Response`, `Response::status`, `HttpError::Http` and the crate root now state the
+  invariant plainly: an `Ok(Response)` never carries a 4xx or 5xx status, so a
+  rejection can only be handled on the `Err` side. The `Response` docs carry the
+  correct match shape as a compiled example.
 
 ## [0.19.0](https://github.com/redbadger/crux/compare/crux_http-v0.18.0...crux_http-v0.19.0) - 2026-07-06
 

--- a/crux_http/src/error.rs
+++ b/crux_http/src/error.rs
@@ -1,6 +1,8 @@
 use facet::Facet;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error as ThisError;
+
+use crate::Result;
 
 /// An error produced when an HTTP request fails.
 ///
@@ -17,8 +19,34 @@ use thiserror::Error as ThisError;
 ///   a 4xx or 5xx status. At the *protocol* level these arrive as
 ///   [`HttpResult::Ok`](crate::protocol::HttpResult::Ok); `Response::new()` converts
 ///   them here, so app code using `crux_http::Result<Response<T>>` will see them as
-///   `Err(HttpError::Http { code, .. })`.
+///   `Err(HttpError::Http { code, .. })` — **never** as `Ok(response)` with an error
+///   status.
 /// - [`Json`](HttpError::Json) — produced when response body deserialisation fails.
+///
+/// # Reading what the server said
+///
+/// Because a rejection arrives as an error rather than a response, the server's own
+/// explanation lives on this type. [`HttpError::body`] and [`HttpError::body_json`]
+/// read it without matching on the variant's fields by hand:
+///
+/// ```
+/// # use serde::Deserialize;
+/// #[derive(Deserialize)]
+/// struct ApiError {
+///     error: String,
+/// }
+///
+/// // the `crux_http::Result` a feature receives when the server rejects a request
+/// let result: crux_http::Result<crux_http::Response<Vec<u8>>> =
+///     crux_http::testing::rejection(409, r#"{"error":"that overlaps a booked day"}"#);
+///
+/// let error = result.expect_err("a 409 is never Ok");
+/// assert_eq!(error.code(), Some(409));
+/// assert_eq!(
+///     error.body_json::<ApiError>().unwrap().error,
+///     "that overlaps a booked day"
+/// );
+/// ```
 #[derive(Facet, Serialize, Deserialize, PartialEq, Eq, Clone, ThisError, Debug)]
 #[repr(C)]
 pub enum HttpError {
@@ -34,6 +62,24 @@ pub enum HttpError {
     Timeout,
 
     // Internal only — not serialized, never sent over the FFI boundary.
+    /// The exchange completed, but the server answered with a 4xx or 5xx status.
+    ///
+    /// This is what a feature receives *instead of* a [`Response`](crate::Response)
+    /// when the server rejects a request, so it is the only place a rejection can be
+    /// handled.
+    ///
+    /// `body` is the response body exactly as the server sent it. Body decoding
+    /// (`expect_json`, `expect_string`) is skipped for an error status, so a server's
+    /// error envelope — `{"error": "…"}`, an RFC 7807 `problem+json` document, a plain
+    /// sentence — survives here even for a request built with
+    /// [`expect_json`](crate::command::RequestBuilder::expect_json). Read it with
+    /// [`HttpError::body`] or [`HttpError::body_json`] rather than destructuring.
+    ///
+    /// `code` is the status code and `message` its canonical reason phrase (e.g.
+    /// `"409 Conflict"`) — a description of the status, never the server's own
+    /// explanation. [`Display`](std::fmt::Display) shows only those two, so an app that
+    /// reports `error.to_string()` to a user shows `"HTTP error 409: 409 Conflict"` and
+    /// discards whatever the server took the trouble to say.
     #[error("HTTP error {code}: {message}")]
     #[serde(skip)]
     #[facet(skip)]
@@ -42,10 +88,101 @@ pub enum HttpError {
         message: String,
         body: Option<Vec<u8>>,
     },
+    /// A response body could not be deserialized (or a request body serialized).
     #[error("JSON serialization error: {0}")]
     #[serde(skip)]
     #[facet(skip)]
     Json(String),
+}
+
+impl HttpError {
+    /// The status code of the response this error came from, if there was one.
+    ///
+    /// Normally the 4xx or 5xx the server rejected the request with. It can also be a
+    /// *non-error* status: [`Response::body_bytes`](crate::Response::body_bytes) reports an
+    /// already-taken body as an `Http` error carrying that response's own status, so `Some`
+    /// is not by itself proof of a rejection — test the value if you need one.
+    ///
+    /// `None` for errors that never had a response at all: transport failures and body
+    /// deserialisation failures.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use crux_http::HttpError;
+    /// let error: HttpError = crux_http::testing::rejection::<Vec<u8>>(404, "")
+    ///     .expect_err("a 404 is never Ok");
+    /// assert_eq!(error.code(), Some(404));
+    ///
+    /// assert_eq!(HttpError::Timeout.code(), None);
+    /// ```
+    #[must_use]
+    pub const fn code(&self) -> Option<u16> {
+        match self {
+            Self::Http { code, .. } => Some(*code),
+            _ => None,
+        }
+    }
+
+    /// The raw response body that came with an error status, if there was one.
+    ///
+    /// This is the server's own account of why it rejected the request — usually far
+    /// more useful to a user than [`Display`](std::fmt::Display), which can only report
+    /// the status. Returns `None` for errors that carry no body (transport failures, and
+    /// responses with an empty body).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let error = crux_http::testing::rejection::<Vec<u8>>(422, "name is required")
+    ///     .expect_err("a 422 is never Ok");
+    /// assert_eq!(error.body(), Some(&b"name is required"[..]));
+    /// ```
+    #[must_use]
+    pub fn body(&self) -> Option<&[u8]> {
+        match self {
+            Self::Http {
+                body: Some(body), ..
+            } if !body.is_empty() => Some(body),
+            _ => None,
+        }
+    }
+
+    /// Deserialize the error response body from JSON.
+    ///
+    /// Works for any JSON error shape — deserialize into your API's own envelope, or
+    /// into an RFC 7807 `problem+json` struct, or into [`serde_json::Value`] if you
+    /// don't know which you'll get.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HttpError::Json`] if the error carries no body, or if the body is not
+    /// valid JSON for `T`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use serde::Deserialize;
+    /// #[derive(Deserialize)]
+    /// struct Problem {
+    ///     detail: String,
+    /// }
+    ///
+    /// let error = crux_http::testing::rejection::<Vec<u8>>(
+    ///     409,
+    ///     r#"{"title":"Conflict","detail":"that would create a management cycle"}"#,
+    /// )
+    /// .expect_err("a 409 is never Ok");
+    ///
+    /// let problem: Problem = error.body_json().unwrap();
+    /// assert_eq!(problem.detail, "that would create a management cycle");
+    /// ```
+    pub fn body_json<T: DeserializeOwned>(&self) -> Result<T> {
+        let body = self
+            .body()
+            .ok_or_else(|| Self::Json("error has no response body".to_string()))?;
+        serde_json::from_slice(body).map_err(Self::from)
+    }
 }
 
 #[cfg(feature = "http-types")]
@@ -129,6 +266,66 @@ mod tests {
         let url_err = url::Url::parse("not a url").unwrap_err();
         let http_err = HttpError::from(url_err);
         assert!(matches!(http_err, HttpError::Url(_)));
+    }
+
+    #[test]
+    fn accessors_read_the_error_response() {
+        let error = HttpError::Http {
+            code: 409,
+            message: "409 Conflict".to_string(),
+            body: Some(br#"{"error":"already booked"}"#.to_vec()),
+        };
+
+        assert_eq!(error.code(), Some(409));
+        assert_eq!(error.body(), Some(&br#"{"error":"already booked"}"#[..]));
+        let body: serde_json::Value = error.body_json().expect("body is JSON");
+        assert_eq!(body["error"], "already booked");
+    }
+
+    #[test]
+    fn accessors_are_empty_for_errors_without_a_response() {
+        // A transport error never had a response to read.
+        let error = HttpError::Timeout;
+        assert_eq!(error.code(), None);
+        assert_eq!(error.body(), None);
+        assert!(matches!(
+            error.body_json::<serde_json::Value>(),
+            Err(HttpError::Json(_))
+        ));
+
+        // Nor did an error status the crate raised itself, e.g. a body already taken.
+        let error = HttpError::Http {
+            code: 500,
+            message: "500 Internal Server Error".to_string(),
+            body: None,
+        };
+        assert_eq!(error.code(), Some(500));
+        assert_eq!(error.body(), None);
+    }
+
+    #[test]
+    fn an_empty_body_reads_as_no_body() {
+        let error = HttpError::Http {
+            code: 404,
+            message: "404 Not Found".to_string(),
+            body: Some(vec![]),
+        };
+        assert_eq!(error.body(), None);
+    }
+
+    #[test]
+    fn body_json_reports_a_body_that_is_not_json() {
+        let error = HttpError::Http {
+            code: 502,
+            message: "502 Bad Gateway".to_string(),
+            body: Some(b"<html>nginx</html>".to_vec()),
+        };
+        assert!(matches!(
+            error.body_json::<serde_json::Value>(),
+            Err(HttpError::Json(_))
+        ));
+        // ... but the raw body is still there to log or display.
+        assert_eq!(error.body(), Some(&b"<html>nginx</html>"[..]));
     }
 
     #[test]

--- a/crux_http/src/lib.rs
+++ b/crux_http/src/lib.rs
@@ -4,6 +4,16 @@
 //! `crux_http` allows Crux apps to make HTTP requests by asking the Shell to perform them.
 //!
 //! This is still work in progress and large parts of HTTP are not yet supported.
+//!
+//! # Errors and rejections
+//!
+//! A request resolves to a [`Result<Response<T>>`](Result), and a 4xx or 5xx response is
+//! on the **`Err`** side of it: `crux_http` turns those into
+//! [`HttpError::Http`] — body included — before the event reaches the
+//! app, so [`Response::status`] is never an error status. Read the server's own
+//! explanation of a rejection with [`HttpError::body`] or [`HttpError::body_json`].
+//! [`Response`] documents the shape to write, and [`testing`] the two values a test
+//! should build.
 // #![warn(missing_docs)]
 
 mod config;

--- a/crux_http/src/response/response.rs
+++ b/crux_http/src/response/response.rs
@@ -5,6 +5,41 @@ use serde::de::DeserializeOwned;
 use std::{fmt, ops::Index};
 
 /// An HTTP Response that will be passed to an app's update function.
+///
+/// # A `Response` never carries an error status
+///
+/// Holding one of these means the server did **not** reject the request. `crux_http`
+/// converts every 4xx and 5xx response into an [`HttpError::Http`](crate::HttpError::Http)
+/// — keeping the body — and delivers it on the `Err` side, so [`status`](Self::status) is
+/// always a 1xx, 2xx or 3xx. A `match` arm that checks it for failure is dead code:
+///
+/// ```
+/// # use crux_http::{HttpError, Response};
+/// # fn saved() {}
+/// # fn show_error(_message: &str) {}
+/// fn on_result(result: crux_http::Result<Response<Vec<u8>>>) {
+///     match result {
+///         // this arm cannot see a 4xx or 5xx, so don't test the status here
+///         Ok(_response) => saved(),
+///         Err(error) => {
+///             // the server's own message, e.g. {"error": "…"}, not just "409 Conflict"
+///             let message = error
+///                 .body_json::<serde_json::Value>()
+///                 .ok()
+///                 .and_then(|body| body["error"].as_str().map(str::to_string))
+///                 .unwrap_or_else(|| error.to_string());
+///             show_error(&message);
+///         }
+///     }
+/// }
+///
+/// // a rejection, as a feature receives it
+/// on_result(crux_http::testing::rejection(409, r#"{"error":"already booked"}"#));
+/// ```
+///
+/// The matching testing rule: build success cases with
+/// [`ResponseBuilder`](crate::testing::ResponseBuilder), and rejections with
+/// [`rejection`](crate::testing::rejection).
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct Response<Body> {
     #[serde(skip, default)]
@@ -18,6 +53,11 @@ pub struct Response<Body> {
 
 impl<Body> Response<Body> {
     /// Create a new instance.
+    ///
+    /// A 4xx or 5xx status is not a response as far as the app is concerned: it becomes
+    /// [`HttpError::Http`], carrying the body so the caller can still read what the
+    /// server said. This is the single place that invariant is established — see the
+    /// [type docs](Response) for what it means for app and test code.
     pub(crate) fn new(mut res: super::RawResponse) -> Result<Response<Vec<u8>>> {
         let body = res.body_bytes()?;
         let status = res.status();
@@ -41,6 +81,11 @@ impl<Body> Response<Body> {
     }
 
     /// Get the HTTP status code.
+    ///
+    /// Never a client (4xx) or server (5xx) error: those are delivered as an
+    /// [`HttpError::Http`](crate::HttpError::Http) on the `Err` side, not as a `Response`,
+    /// so there is nothing to be learned by testing this for failure. Handle rejections
+    /// there instead — see the [type docs](Response).
     ///
     /// # Examples
     ///
@@ -489,19 +534,15 @@ mod tests {
     }
 
     #[test]
-    fn response_builder_with_non_standard_status_499() {
-        let res: Response<Vec<u8>> = ResponseBuilder::with_status(499).build();
-        assert_eq!(res.status().as_u16(), 499);
-    }
-
-    #[test]
     fn response_serde_roundtrip_with_non_standard_status() {
-        let res: Response<Vec<u8>> = ResponseBuilder::with_status(499)
+        // 299 is non-standard but not an error, so it is a status a Response can hold —
+        // a non-standard 4xx/5xx becomes HttpError::Http instead (see the tests above).
+        let res: Response<Vec<u8>> = ResponseBuilder::with_status(299)
             .body(b"test".to_vec())
             .build();
         let json = serde_json::to_string(&res).expect("should serialize");
         let back: Response<Vec<u8>> = serde_json::from_str(&json).expect("should deserialize");
-        assert_eq!(back.status().as_u16(), 499);
+        assert_eq!(back.status().as_u16(), 299);
     }
 
     #[test]

--- a/crux_http/src/testing/mod.rs
+++ b/crux_http/src/testing/mod.rs
@@ -1,8 +1,21 @@
+//! Helpers for testing apps that use `crux_http`.
+//!
+//! The two entry points mirror the two things a feature can receive:
+//!
+//! - [`ResponseBuilder`] builds the `Ok(Response)` of a successful exchange.
+//! - [`rejection`] builds the `Err(HttpError::Http { .. })` of a 4xx/5xx rejection,
+//!   body included.
+//!
+//! There is no third case: a `Response` never carries an error status, so
+//! `ResponseBuilder` refuses to build one.
+
+mod rejection;
 mod response_builder;
 
 #[cfg(test)]
 mod fake_shell;
 
+pub use rejection::rejection;
 pub use response_builder::ResponseBuilder;
 
 #[cfg(test)]

--- a/crux_http/src/testing/rejection.rs
+++ b/crux_http/src/testing/rejection.rs
@@ -1,0 +1,119 @@
+use crate::{RawResponse, Response, Result, protocol::HttpResponse};
+
+/// Build the [`crux_http::Result`](crate::Result) a feature receives when the server
+/// rejects a request.
+///
+/// A 4xx or 5xx response never reaches an app as `Ok(Response)` — `crux_http` converts it
+/// to an [`HttpError::Http`](crate::HttpError::Http) on the `Err` side, keeping the body,
+/// before the event is sent. So this, and not a
+/// [`ResponseBuilder`](super::ResponseBuilder) with an error status, is the value to assert
+/// against (or feed to an update function) when testing how a feature handles a rejection:
+///
+/// ```
+/// # use crux_http::testing::rejection;
+/// # #[derive(Debug, PartialEq)] enum Event { Saved(crux_http::Result<crux_http::Response<Vec<u8>>>) }
+/// let event = Event::Saved(rejection(409, r#"{"error":"that overlaps a booked day"}"#));
+///
+/// let Event::Saved(Err(error)) = event else {
+///     panic!("a 409 is delivered as an error, not a response")
+/// };
+/// assert_eq!(error.code(), Some(409));
+/// assert_eq!(error.to_string(), "HTTP error 409: 409 Conflict");
+/// ```
+///
+/// The `Body` type parameter is the one the app's event carries (`Vec<u8>`, `String`, or
+/// whatever [`expect_json`](crate::command::RequestBuilder::expect_json) decodes to); it
+/// is usually inferred, and never appears in the value, because body decoding is skipped
+/// for an error status.
+///
+/// The status and reason phrase are produced by the same code path a real response takes,
+/// so the value is byte-for-byte what the shell's response would have produced.
+///
+/// # Errors
+///
+/// Always `Err` — a rejection has no other form. The `Result` is the return type so that
+/// the value can be used exactly where the app receives one.
+///
+/// # Panics
+///
+/// Panics if `status` is outside the valid HTTP range (100–999), or if it is not a client
+/// (4xx) or server (5xx) error — for any other status a feature receives
+/// `Ok(Response)`, which is what [`ResponseBuilder`](super::ResponseBuilder) builds.
+pub fn rejection<Body>(status: u16, body: impl AsRef<[u8]>) -> Result<Response<Body>> {
+    let response = HttpResponse::status(status)
+        .body(body.as_ref().to_vec())
+        .build();
+    let raw = RawResponse::try_from(response)
+        .expect("rejection called with an out-of-range status code (must be 100–999)");
+
+    match Response::<Vec<u8>>::new(raw) {
+        Err(error) => Err(error),
+        Ok(_) => panic!(
+            "rejection called with status {status}, which is not a client (4xx) or server (5xx) \
+             error — a feature receives that as Ok(Response), which ResponseBuilder builds"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{HttpError, protocol::HttpResponse};
+
+    use super::rejection;
+
+    #[test]
+    fn carries_code_reason_and_body() {
+        let error = rejection::<Vec<u8>>(409, r#"{"error":"management cycle"}"#)
+            .expect_err("4xx is always an error");
+
+        let HttpError::Http {
+            code,
+            message,
+            body,
+        } = error
+        else {
+            panic!("expected HttpError::Http, got {error:?}")
+        };
+        assert_eq!(code, 409);
+        assert_eq!(message, "409 Conflict");
+        assert_eq!(body.unwrap(), br#"{"error":"management cycle"}"#);
+    }
+
+    /// The whole point of the helper: what it produces must be indistinguishable from
+    /// what the real shell → `Response::new` path produces, or tests written against it
+    /// would once again be asserting a shape features never see.
+    #[test]
+    fn matches_the_real_conversion() {
+        let from_helper =
+            rejection::<String>(422, "name is required").expect_err("4xx is always an error");
+
+        let raw = crate::RawResponse::try_from(
+            HttpResponse::status(422)
+                .body(b"name is required".to_vec())
+                .build(),
+        )
+        .expect("422 is a valid status");
+        let from_shell = crate::Response::<Vec<u8>>::new(raw).expect_err("4xx is always an error");
+
+        assert_eq!(from_helper, from_shell);
+    }
+
+    #[test]
+    fn body_is_optional() {
+        let error = rejection::<Vec<u8>>(404, "").expect_err("4xx is always an error");
+        assert_eq!(error.code(), Some(404));
+        assert_eq!(error.body(), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "which is not a client (4xx) or server (5xx) error")]
+    fn refuses_a_success_status() {
+        let _ = rejection::<Vec<u8>>(200, "");
+    }
+
+    #[test]
+    #[should_panic(expected = "out-of-range status code")]
+    fn refuses_an_out_of_range_status() {
+        let _ = rejection::<Vec<u8>>(99, "");
+    }
+}

--- a/crux_http/src/testing/response_builder.rs
+++ b/crux_http/src/testing/response_builder.rs
@@ -5,6 +5,11 @@ use crate::response::Response;
 /// Allows users to build an http response.
 ///
 /// This is mostly expected to be useful in tests rather than application code.
+///
+/// Only responses a feature can actually receive are buildable: a
+/// [`Response`](crate::Response) never carries a 4xx or 5xx status, because `crux_http`
+/// converts those to [`HttpError::Http`](crate::HttpError::Http) before the app sees
+/// them. Use [`rejection`](super::rejection) to build a rejection.
 pub struct ResponseBuilder<Body> {
     response: Response<Body>,
 }
@@ -20,11 +25,28 @@ impl ResponseBuilder<Vec<u8>> {
     ///
     /// # Panics
     ///
-    /// Panics if `status` is outside the valid HTTP range (100–999).
+    /// Panics if `status` is outside the valid HTTP range (100–999), or if it is a client
+    /// (4xx) or server (5xx) error. Such a response is not a state any app can observe —
+    /// `crux_http` delivers it as an [`HttpError::Http`](crate::HttpError::Http) on the
+    /// `Err` side, so a test that builds one asserts against a branch the app can never
+    /// take. Build the rejection a feature really receives with
+    /// [`rejection`](super::rejection):
+    ///
+    /// ```
+    /// # use crux_http::testing::rejection;
+    /// let result = rejection::<Vec<u8>>(409, r#"{"error":"already booked"}"#);
+    /// assert_eq!(result.unwrap_err().code(), Some(409));
+    /// ```
     #[must_use]
     pub fn with_status(status: u16) -> Self {
         let status = StatusCode::from_u16(status).expect(
             "ResponseBuilder::with_status called with an out-of-range code (must be 100–999)",
+        );
+        assert!(
+            !status.is_client_error() && !status.is_server_error(),
+            "ResponseBuilder::with_status called with {status}, but a Response never carries a \
+             client (4xx) or server (5xx) status — those reach the app as \
+             Err(HttpError::Http {{ .. }}). Use crux_http::testing::rejection instead."
         );
         let response = Response::new_with_status(status);
         Self { response }
@@ -74,5 +96,32 @@ impl<Body> ResponseBuilder<Body> {
     /// Builds the response.
     pub fn build(self) -> Response<Body> {
         self.response
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ResponseBuilder;
+
+    #[test]
+    fn builds_any_non_error_status() {
+        for status in [200, 201, 204, 299, 302, 304] {
+            assert_eq!(
+                ResponseBuilder::with_status(status).build().status(),
+                status
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "a Response never carries a client (4xx) or server (5xx) status")]
+    fn refuses_a_client_error_status() {
+        let _ = ResponseBuilder::with_status(409);
+    }
+
+    #[test]
+    #[should_panic(expected = "a Response never carries a client (4xx) or server (5xx) status")]
+    fn refuses_a_server_error_status() {
+        let _ = ResponseBuilder::with_status(503);
     }
 }

--- a/crux_http/tests/rejections.rs
+++ b/crux_http/tests/rejections.rs
@@ -1,0 +1,135 @@
+//! What a feature actually receives when the server rejects a request.
+//!
+//! Every test here resolves a real `Command` with a real [`HttpResult`], because that is
+//! the only way to observe the value an app is given. A test that instead *fabricates* the
+//! value — `Ok(ResponseBuilder::with_status(409).body(…).build())` — asserts a state the
+//! machinery below can never produce, and so passes while the code it covers is dead.
+//! `ResponseBuilder` now refuses to build such a response; [`rejection`] builds the real
+//! thing.
+//!
+//! [`rejection`]: crux_http::testing::rejection
+
+mod shared {
+    use crux_core::{Command, macros::effect};
+    use crux_http::{command::Http, protocol::HttpRequest};
+    use serde::{Deserialize, Serialize};
+
+    /// The body the API returns on success.
+    #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+    pub struct Leave {
+        pub id: String,
+    }
+
+    #[derive(Debug)]
+    pub enum Event {
+        Booked(crux_http::Result<crux_http::Response<Leave>>),
+    }
+
+    #[effect]
+    pub enum Effect {
+        Http(HttpRequest),
+    }
+
+    pub const URL: &str = "https://example.com/leave";
+
+    /// A body-less write, of the kind whose only interesting outcome is the rejection.
+    pub fn book() -> Command<Effect, Event> {
+        Http::post(URL)
+            .expect_json::<Leave>()
+            .build()
+            .then_send(Event::Booked)
+    }
+
+    /// What such a feature wants to show the user: the server's sentence if it sent one,
+    /// and only otherwise the status.
+    pub fn message(result: crux_http::Result<crux_http::Response<Leave>>) -> String {
+        match result {
+            // No status check here: this arm cannot see a 4xx or 5xx.
+            Ok(response) => format!("booked {}", response.body().unwrap().id),
+            Err(error) => error
+                .body_json::<serde_json::Value>()
+                .ok()
+                .and_then(|body| body["error"].as_str().map(str::to_string))
+                .unwrap_or_else(|| error.to_string()),
+        }
+    }
+}
+
+use crux_http::{
+    protocol::{HttpResponse, HttpResult},
+    testing::rejection,
+};
+use shared::{Effect, Event, Leave, URL, book, message};
+
+/// Drive `book()` to completion against the given protocol response, returning what the
+/// app's `Booked` event is handed.
+fn resolve(response: HttpResponse) -> crux_http::Result<crux_http::Response<Leave>> {
+    let mut cmd = book();
+
+    let Effect::Http(mut request) = cmd.effects().next().expect("an HTTP effect");
+    assert_eq!(request.operation.url, URL);
+
+    request
+        .resolve(HttpResult::Ok(response))
+        .expect("should resolve");
+
+    let Event::Booked(result) = cmd.events().next().expect("an event");
+    result
+}
+
+#[test]
+fn a_rejection_arrives_as_an_error_carrying_the_servers_message() {
+    let result = resolve(
+        HttpResponse::status(409)
+            .header("content-type", "application/json")
+            .json(serde_json::json!({"error": "those dates overlap a booked day"}))
+            .build(),
+    );
+
+    // The status is not observable as a response — only as an error.
+    let error = result.expect_err("a 409 is never Ok");
+    assert_eq!(error.code(), Some(409));
+    assert_eq!(
+        message(Err(error)),
+        "those dates overlap a booked day",
+        "the server's own message must survive, not just the status"
+    );
+}
+
+/// `expect_json::<Leave>()` cannot decode an error envelope — and doesn't try. Decoding is
+/// skipped for an error status, so the raw body reaches the app whatever it contains.
+#[test]
+fn the_error_body_survives_a_typed_expectation() {
+    let error = resolve(
+        HttpResponse::status(422)
+            .json(serde_json::json!({"error": "end date is before start date"}))
+            .build(),
+    )
+    .expect_err("a 422 is never Ok");
+
+    assert_eq!(
+        error.body(),
+        Some(&br#"{"error":"end date is before start date"}"#[..])
+    );
+}
+
+/// The value `testing::rejection` builds is the value the machinery delivers — so a test
+/// that asserts against it is testing the live path.
+#[test]
+fn the_testing_helper_matches_what_the_shell_produces() {
+    let body = r#"{"error":"that would create a management cycle"}"#;
+
+    let from_shell = resolve(HttpResponse::status(409).body(body).build());
+
+    assert_eq!(from_shell, rejection::<Leave>(409, body));
+}
+
+#[test]
+fn a_success_still_decodes_the_body() {
+    let leave = Leave {
+        id: "leave-1".to_string(),
+    };
+    let result = resolve(HttpResponse::status(201).json(&leave).build());
+
+    assert_eq!(message(result), "booked leave-1");
+}


### PR DESCRIPTION
## Why

`crux_http` converts every 4xx/5xx into `Err(HttpError::Http { code, message, body })`
before an app sees it, so an `Ok(Response)` can never carry an error status. That
invariant was undocumented, and two parts of the API actively pointed away from it:

- `Response::status()` is public, prominent, and documented with
  `assert_eq!(res.status(), 200)` — nothing said the status on the `Ok` side is always
  non-error, so checking it for failure reads like sensible defensive code.
- `ResponseBuilder::with_status(409)` let a **test** construct a `Response` with an error
  status — a value a feature can never receive.

In a downstream app (an HR service with a Crux UI), those two facts together produced
**eight independent call sites** shaped like this:

```rust
match result {                                   // crux_http::Result<Response<Vec<u8>>>
    Ok(mut response) => {
        if (200_u16..300).contains(&response.status().into()) {
            /* success */
        } else {
            ctx.error(api::error_reason(&mut response));  // read {"error": …} from the body
        }
    }
    Err(error) => ctx.fail("Failed to …", &error),
}
```

The `else` branch is unreachable. Every one of those eight sites showed users
`"Failed to …: HTTP error 409: 409 Conflict"` where the service had sent a sentence
written specifically for them — *"assignment would create a management cycle"*, *"Those
dates overlap a request you already have from 3 to 7 April 2026"*.

The part that makes this a library problem rather than eight authorial mistakes: **all
seven pre-existing sites had passing tests for their rejection message.** Each test
hand-built the impossible state with
`ResponseBuilder::with_status(409).body(…)` and fabricated `Ok(that_response)`, so the
tests asserted the dead branch and left the live path uncovered. Code review passed all
eight.

## What changed

Three commits, in the order they build on each other:

**1. `HttpError::code`, `HttpError::body`, `HttpError::body_json` + `testing::rejection`**

The rejection body was already preserved — it just wasn't reachable without
destructuring:

```rust
// before, hand-rolled in every app
let HttpError::Http { body: Some(body), .. } = error else { return None };
serde_json::from_slice::<Value>(body).ok()
    .and_then(|b| b["error"].as_str().map(String::from))

// after
error.body_json::<Value>().ok().and_then(|b| b["error"].as_str().map(String::from))
```

`body_json` deserializes into whatever shape the service uses — an app's own envelope,
an RFC 7807 `problem+json` struct, or `serde_json::Value` — so **no `problem+json` type
is added**; generic access is the requirement. An empty body reads as `None`, because
every real 4xx arrives with `Some(bytes)` and `Some(&[])` would make the obvious
`if let Some(body)` idiom display blanks.

`crux_http::testing::rejection(status, body)` builds the `crux_http::Result<Response<Body>>`
a feature genuinely receives for a rejection:

```rust
let event = Event::Saved(crux_http::testing::rejection(409, r#"{"error":"…"}"#));
```

It runs the *real* conversion (protocol response → `RawResponse` → `Response::new`)
rather than assembling the error by hand, and a test pins that its output is equal to
what the machinery produces. It panics for a non-error status, so it can't be misused
for the success case.

**2. Documentation of the invariant**

Stated on `Response` (with the correct match shape as a compiled example), on
`Response::status`, on `Response::new` where the invariant is established, on
`HttpError` / `HttpError::Http`, on the new `testing` module docs, and in the crate root.
`HttpError::Http`'s docs also spell out that `Display` shows only the status, which is
what makes `error.to_string()` such a lossy thing to show a user.

**3. `ResponseBuilder::with_status` now panics for 4xx/5xx** (breaking, test-only)

This is the item that would actually have caught the downstream bug: it turns those
seven green-but-dead tests red, with a message naming `testing::rejection` as the
replacement. Migration is mechanical:

```rust
// before — asserts a state the app can never observe
let result = Ok(ResponseBuilder::with_status(409).body(body).build());
// after — what the app really receives
let result = crux_http::testing::rejection(409, body);
```

Nothing about the runtime behaviour of a request changes. Non-error statuses, including
non-standard ones, are unaffected. Two of `crux_http`'s own tests built a 499 `Response`;
one is now covered by the panic test, and the status-serialisation round-trip uses 299
(still non-standard, but a status a `Response` can actually hold).

## Tests

- `crux_http/tests/rejections.rs` (new) drives a real `Command` resolved with a real
  `HttpResult`, and pins: a rejection arrives as `Err` with the server's message intact;
  the raw error body survives a `expect_json::<T>()` request (the expectation decode never
  runs on an error status, because `and_then` short-circuits); `testing::rejection`'s value
  equals what the machinery delivers.
- `ResponseBuilder` tests: builds any non-error status, panics for 409 and 503. **These two
  panic tests fail before this change** — that is the point.
- `HttpError` accessor tests, and `testing::rejection` tests including equality with the
  shell path.
- Doc examples throughout are compiled.

## Deliberately not done

- **No reqwest-style semantics** (`Ok` for 4xx plus an opt-in `error_for_status()`).
  Arguably the better design, but the migration would be *silent*: every existing crux app
  that propagates with `?` would start treating a 409 as success, with no compile error
  anywhere. Not worth it without a much larger, deliberate migration.
- ~~**`HttpError::Http` keeps `body: Option<Vec<u8>>`; it does not carry the whole
  `Response<Vec<u8>>`.**~~ **Superseded by #555**, which adds the headers after all —
  they turned out to be unreachable by any route, which the reasoning below missed. Kept
  for the record: Headers would be nice (to tell `problem+json` from an app's own
  envelope), and the variant is `#[serde(skip)] #[facet(skip)]` so this isn't FFI-breaking.

  One obstacle I initially thought was decisive turned out not to be: `#[facet(skip)]` on a
  variant does **not** exempt its field types from `Facet` (adding a `Response<Vec<u8>>`
  field to a skipped variant fails with "the trait `Facet<'_>` is not implemented for
  `Response<Vec<u8>>`") — but `#[facet(opaque)]` on the field waives exactly that, which I
  verified compiles, and which is what `HttpError` carried for its `StatusCode` before
  0.19. The derive is not a blocker.

  What decided it is cost against demonstrated need:
  1. Two of the three construction sites have no response to supply
     (`Response::body_bytes`'s "body had no bytes", and `From<http_types::Error>`), so the
     field would be `Option<Response<…>>` sitting alongside `code`/`message` — three fields
     where two overlap.
  2. It breaks every downstream `match` on the variant's fields **and** every construction
     of it, including app tests that build one, for a benefit nothing has asked for yet.
     `body_json::<T>()` is content-type-agnostic, so `problem+json` is already readable
     without headers.

  Adding the accessors first is the hedge: the shape to move to is
  `response: Option<Response<Vec<u8>>>` with `#[facet(opaque)]` (or `Option<HttpResponse>`,
  the protocol type, which is `Facet` already), and readers of `body()` / `body_json()`
  won't notice the change.

## CI

`cargo fmt --check`, `cargo check`, `cargo clippy --all-targets -Dpedantic -Dnursery`,
`cargo build`, `cargo nextest run` and `cargo test --doc` are all green for the root
workspace (all features). No insta snapshots changed.

`just ci` cannot complete on my machine: `just examples/check` fails in
`examples/counter/web-nextjs` at `pnpm install`, because
`examples/counter/web-nextjs/generated/pkg` doesn't exist until the BoltFFI wasm package
is built. That failure is environmental and is hit before any `crux_http`-dependent
example. To compensate I ran, per example, `cargo clippy --all-targets --all-features
-Dpedantic -Dnursery` and the test suites for `counter`, `counter-http`,
`counter-middleware`, `counter-routing`, `notes` and `weather` shared crates: all tests
pass. Two pre-existing failures unrelated to this PR, for the record:
`counter-routing/shared` has four clippy pedantic/nursery findings in `app.rs` and
`capabilities/sse.rs`, and `notes/shared`'s `starts_a_timer_after_an_edit` fails under
`cargo test` (a `TimerId` counter shared between tests) but passes under `cargo nextest`,
which is what CI uses.


## Review follow-up

- `HttpError::code`'s doc no longer claims that processing errors have no status.
  `Response::body_bytes` reports an already-taken body as an `Http` error carrying that
  response's own (non-error) status, so a `Some` is not by itself proof of a rejection.
  Giving that case a variant of its own would be the better fix, and a third breaking
  change — left for its own PR.
