### PR TITLE
feat(http)!: carry the rejected response's headers on HttpError::Http

### DIFF
--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -181,6 +181,12 @@ and this project adheres to
   rejection can only be handled on the `Err` side. The `Response` docs carry the
   correct match shape as a compiled example.
 
+- `command::RequestBuilder::middleware` now warns that it is a **no-op**: nothing on the
+  command API executes a middleware stack, so middleware pushed there — `Redirect`
+  included — is accepted and silently ignored. Its example previously implied redirects
+  were followed. This documents existing behaviour; the underlying gap is
+  [#556](https://github.com/redbadger/crux/issues/556).
+
 ## [0.19.0](https://github.com/redbadger/crux/compare/crux_http-v0.18.0...crux_http-v0.19.0) - 2026-07-06
 
 > **📖 See the [Migrating `crux_http` to native `http` types](https://redbadger.github.io/crux/guide/migrate-crux-http.html)

--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -35,6 +35,22 @@ and this project adheres to
   skipped for an error status, so the raw error body survives even for a request
   built with `expect_json::<T>()`; there is now a test pinning that.
 
+- **`HttpError::header`, `HttpError::headers` and `HttpError::content_type`** — read the
+  headers of the response that was rejected.
+
+  A rejection's *policy* often lives only in its headers, and none of it is recoverable
+  from the status or the body: `Retry-After` on a 429 or 503, `WWW-Authenticate` on a 401
+  (expired token vs insufficient scope), rate-limit headers, or the `Content-Type` that
+  says whether an error body is JSON, an RFC 7807 document, or a proxy's HTML page.
+  `Response::new` used to drop the `HeaderMap` on the error branch, and since `crux_http`
+  middleware does not run in the command API, an app had no way to see any of it.
+
+  ```rust
+  if let Some(retry_after) = error.header("retry-after") { /* back off politely */ }
+  ```
+
+  This adds a `headers` field to `HttpError::Http` — see the breaking change below.
+
 - **`crux_http::testing::rejection(status, body)`** — builds the
   `crux_http::Result<Response<Body>>` a feature receives when the server rejects a
   request, via the same conversion a real shell response takes:
@@ -46,9 +62,19 @@ and this project adheres to
   Use it wherever you would previously have fabricated `Ok(response_with_409)` (see
   the breaking change below).
 
-- `crux_http::testing` now has module docs, stating the invariant the two builders
-  divide: `ResponseBuilder` for the `Ok(Response)` of a successful exchange,
-  `rejection` for the `Err` of a rejection. There is no third case.
+- **`crux_http::testing::rejection_from(HttpResponse)`** — the header-carrying form,
+  taking the same protocol response you would resolve a request with in an end-to-end
+  test, so both styles of test describe a rejection the same way:
+
+  ```rust
+  let result = rejection_from(HttpResponse::status(429).header("retry-after", "30").build());
+  ```
+
+  `rejection(status, body)` is unchanged, and is now sugar over it.
+
+- `crux_http::testing` now has module docs, stating the invariant the builders divide:
+  `ResponseBuilder` for the `Ok(Response)` of a successful exchange, `rejection` /
+  `rejection_from` for the `Err` of a rejection. There is no third case.
 
 - `HttpRequestBuilder::body_json`, which sets a JSON body **and**
   `content-type: application/json`, mirroring what
@@ -79,6 +105,37 @@ and this project adheres to
   tests that already add the header themselves.
 
 ### 💥 Breaking Changes
+
+- **`HttpError::Http` has a new `headers` field**, so that a rejection's headers reach the
+  app (see `HttpError::header` above). It is `Option<Box<HeaderMap>>`: `None` when the error
+  was raised with no response to describe (a transport failure, or a status code that wasn't
+  valid HTTP), and boxed only because a bare `HeaderMap` is 96 bytes and this type is the
+  `Err` of nearly every function in the crate — inline, it pushed `HttpError` to 160 bytes
+  and tripped `clippy::result_large_err` across the crate.
+
+  `match` arms that name only the fields they use are unaffected:
+
+  ```rust
+  Err(HttpError::Http { code, .. }) if code == 401 => { … }      // still compiles
+  ```
+
+  The variant is also now **`#[non_exhaustive]`**, so this is the last time a new field
+  breaks you: only `crux_http` constructs it, and what a rejection carries can grow behind
+  the accessors. Code that *constructed* it — in practice, tests — must switch to
+  `crux_http::testing::rejection` / `rejection_from`, which build it through the real
+  conversion:
+
+  ```rust
+  // before
+  let error = HttpError::Http { code: 409, message: "409 Conflict".into(), body: Some(body) };
+  // after
+  let error = crux_http::testing::rejection::<Vec<u8>>(409, body).unwrap_err();
+  ```
+
+  Note that `HttpError`'s `PartialEq` now compares headers too, so a hand-built variant no
+  longer equals the real thing: `rejection(409, body)` carries `Some(<empty map>)`, which is
+  not equal to `headers: None`. Another reason to compare against `rejection` /
+  `rejection_from` rather than a value assembled by hand.
 
 - **`ResponseBuilder::with_status` now panics for a 4xx or 5xx status.** It could
   previously build a `Response` carrying an error status — a value no app can ever

--- a/crux_http/src/command.rs
+++ b/crux_http/src/command.rs
@@ -338,6 +338,19 @@ where
 
     /// Push middleware onto a per-request middleware stack.
     ///
+    /// # Warning: middleware does not run on this API
+    ///
+    /// Nothing executes the stack this pushes onto. [`build`](Self::build) turns the request
+    /// straight into a protocol request for the shell, and the only executor of a middleware
+    /// stack is `Client::send`, reachable solely from the deprecated capability API. So
+    /// middleware added here is accepted and then silently ignored — including
+    /// [`Redirect`](crate::middleware::Redirect), which means redirects are **not** followed
+    /// and a 3xx arrives at your app as a `Response` with a `Location` header.
+    ///
+    /// Until [issue #556](https://github.com/redbadger/crux/issues/556) is resolved, treat
+    /// this method as a no-op rather than a way to intercept requests. `Config` (base URL,
+    /// per-client default headers) is skipped on this API for the same reason.
+    ///
     /// **Important**: Setting per-request middleware incurs extra allocations.
     /// Creating a `Client` with middleware is recommended.
     ///
@@ -358,6 +371,7 @@ where
     /// # enum Effect { Http(HttpRequest) }
     /// # type Http = crux_http::command::Http<Effect, Event>;
     /// Http::get("https://httpbin.org/redirect/2")
+    ///     // accepted, but never run — the two redirects are not followed
     ///     .middleware(crux_http::middleware::Redirect::default())
     ///     .build()
     ///     .then_send(Event::ReceiveResponse);

--- a/crux_http/src/error.rs
+++ b/crux_http/src/error.rs
@@ -1,4 +1,5 @@
 use facet::Facet;
+use http::{HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error as ThisError;
 
@@ -25,9 +26,10 @@ use crate::Result;
 ///
 /// # Reading what the server said
 ///
-/// Because a rejection arrives as an error rather than a response, the server's own
-/// explanation lives on this type. [`HttpError::body`] and [`HttpError::body_json`]
-/// read it without matching on the variant's fields by hand:
+/// Because a rejection arrives as an error rather than a response, everything the server
+/// sent with it lives on this type: [`HttpError::body`] and [`HttpError::body_json`] for
+/// the body, [`HttpError::header`] and [`HttpError::content_type`] for the headers. No
+/// matching on the variant's fields required:
 ///
 /// ```
 /// # use serde::Deserialize;
@@ -80,12 +82,31 @@ pub enum HttpError {
     /// explanation. [`Display`](std::fmt::Display) shows only those two, so an app that
     /// reports `error.to_string()` to a user shows `"HTTP error 409: 409 Conflict"` and
     /// discards whatever the server took the trouble to say.
+    ///
+    /// `headers` are the rejected response's headers, because a rejection's *policy* often
+    /// lives there and nowhere else: `Retry-After` on a 429 or 503, `WWW-Authenticate` on
+    /// a 401, rate-limit headers, or the `Content-Type` that says whether the body is JSON,
+    /// HTML or prose. Read them with [`HttpError::header`], [`HttpError::content_type`] or
+    /// [`HttpError::headers`]. `None` when the error was raised with no response to describe
+    /// — a transport failure, or a status code that wasn't valid HTTP.
+    ///
+    /// (The map is boxed only to keep `HttpError` small: a bare `HeaderMap` is 96 bytes, and
+    /// this type is the `Err` of nearly every function in the crate.)
+    ///
+    /// The variant is `#[non_exhaustive]`: only `crux_http` constructs it, so that what a
+    /// rejection carries can grow without breaking you. Match it with `{ code, .. }` and
+    /// read the rest through the accessors above; in tests, build one with
+    /// [`rejection`](crate::testing::rejection) or
+    /// [`rejection_from`](crate::testing::rejection_from).
     #[error("HTTP error {code}: {message}")]
     #[serde(skip)]
     #[facet(skip)]
+    #[non_exhaustive]
     Http {
         code: u16,
         message: String,
+        #[facet(opaque)]
+        headers: Option<Box<HeaderMap>>,
         body: Option<Vec<u8>>,
     },
     /// A response body could not be deserialized (or a request body serialized).
@@ -148,6 +169,80 @@ impl HttpError {
         }
     }
 
+    /// A header from the rejected response.
+    ///
+    /// Some of what an app needs to *act on* a rejection is only in the headers:
+    /// `Retry-After` on a 429 or 503, `WWW-Authenticate` on a 401, rate-limit headers.
+    /// None of it can be recovered from the status or the body.
+    ///
+    /// Returns `None` for errors with no response behind them, and for a name the response
+    /// didn't carry. Lookup is case-insensitive, as HTTP requires.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use crux_http::{protocol::HttpResponse, testing::rejection_from};
+    /// let error = rejection_from::<Vec<u8>>(
+    ///     HttpResponse::status(429).header("retry-after", "30").build(),
+    /// )
+    /// .expect_err("a 429 is never Ok");
+    ///
+    /// assert_eq!(error.header("Retry-After").unwrap(), "30");
+    /// ```
+    #[must_use]
+    pub fn header(&self, name: impl http::header::AsHeaderName) -> Option<&HeaderValue> {
+        self.headers()?.get(name)
+    }
+
+    /// All headers from the rejected response.
+    ///
+    /// The escape hatch for anything [`HttpError::header`] and
+    /// [`HttpError::content_type`] don't cover — multi-value headers, iteration, or
+    /// forwarding the lot to a logger.
+    ///
+    /// `None` for errors with no response behind them, which is a different thing from
+    /// `Some(&empty_map)`: a response that sent no headers at all.
+    #[must_use]
+    pub fn headers(&self) -> Option<&HeaderMap> {
+        match self {
+            Self::Http { headers, .. } => headers.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// The content type of the error response body, if it declared one.
+    ///
+    /// Tells an error envelope (`application/json`) from an RFC 7807 document
+    /// (`application/problem+json`) from a proxy's HTML page (`text/html`) — which decides
+    /// whether it is worth handing the body to [`HttpError::body_json`], and whether the
+    /// body is safe to show a user as text.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use crux_http::{protocol::HttpResponse, testing::rejection_from};
+    /// let error = rejection_from::<Vec<u8>>(
+    ///     HttpResponse::status(400)
+    ///         .header("content-type", "application/problem+json")
+    ///         .body(br#"{"detail":"nope"}"#.to_vec())
+    ///         .build(),
+    /// )
+    /// .expect_err("a 400 is never Ok");
+    ///
+    /// assert_eq!(
+    ///     error.content_type().map(|mime| mime.to_string()),
+    ///     Some("application/problem+json".to_string())
+    /// );
+    /// ```
+    #[must_use]
+    pub fn content_type(&self) -> Option<mime::Mime> {
+        self.header(http::header::CONTENT_TYPE)?
+            .to_str()
+            .ok()?
+            .parse()
+            .ok()
+    }
+
     /// Deserialize the error response body from JSON.
     ///
     /// Works for any JSON error shape — deserialize into your API's own envelope, or
@@ -191,6 +286,8 @@ impl From<http_types::Error> for HttpError {
         Self::Http {
             code: e.status().into(),
             message: e.to_string(),
+            // An `http_types::Error` is a status and a message; it has no response.
+            headers: None,
             body: None,
         }
     }
@@ -229,6 +326,7 @@ mod tests {
         let error = HttpError::Http {
             code: 400,
             message: "Bad Request".to_string(),
+            headers: None,
             body: None,
         };
         assert_eq!(error.to_string(), "HTTP error 400: Bad Request");
@@ -240,6 +338,7 @@ mod tests {
         let error = HttpError::Http {
             code: 404u16,
             message: "Not Found".to_string(),
+            headers: None,
             body: None,
         };
         assert_eq!(error.to_string(), "HTTP error 404: Not Found");
@@ -270,9 +369,15 @@ mod tests {
 
     #[test]
     fn accessors_read_the_error_response() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            http::header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
         let error = HttpError::Http {
             code: 409,
             message: "409 Conflict".to_string(),
+            headers: Some(Box::new(headers)),
             body: Some(br#"{"error":"already booked"}"#.to_vec()),
         };
 
@@ -280,6 +385,53 @@ mod tests {
         assert_eq!(error.body(), Some(&br#"{"error":"already booked"}"#[..]));
         let body: serde_json::Value = error.body_json().expect("body is JSON");
         assert_eq!(body["error"], "already booked");
+        assert_eq!(error.content_type(), Some(mime::APPLICATION_JSON));
+        // HTTP header names are case-insensitive; HeaderMap handles that for us.
+        assert_eq!(error.header("Content-Type").unwrap(), "application/json");
+        assert_eq!(error.header("x-absent"), None);
+    }
+
+    #[test]
+    fn there_are_no_headers_without_a_response() {
+        // A transport error never had a response, so there is nothing to describe.
+        assert_eq!(HttpError::Timeout.header("retry-after"), None);
+        assert_eq!(HttpError::Timeout.headers(), None);
+        assert_eq!(HttpError::Timeout.content_type(), None);
+
+        // Nor does a status the crate rejected before a response existed.
+        let error = HttpError::Http {
+            code: 999,
+            message: "invalid HTTP status code: 999".to_string(),
+            headers: None,
+            body: None,
+        };
+        assert_eq!(error.headers(), None);
+        assert_eq!(error.content_type(), None);
+
+        // A real response with no headers is `Some`, but empty — the two are different
+        // things, and only the accessors' `None` conflates them.
+        let error = HttpError::Http {
+            code: 500,
+            message: "500 Internal Server Error".to_string(),
+            headers: Some(Box::default()),
+            body: None,
+        };
+        assert!(error.headers().expect("a response's headers").is_empty());
+        assert_eq!(error.content_type(), None);
+    }
+
+    /// `Retry-After` is the case that cannot be recovered any other way: it is not in the
+    /// status, and not in the body.
+    #[test]
+    fn retry_after_survives_on_the_error() {
+        let error = crate::testing::rejection_from::<Vec<u8>>(
+            crate::HttpResponse::status(429)
+                .header("retry-after", "30")
+                .build(),
+        )
+        .expect_err("a 429 is never Ok");
+
+        assert_eq!(error.header("retry-after").unwrap(), "30");
     }
 
     #[test]
@@ -297,6 +449,7 @@ mod tests {
         let error = HttpError::Http {
             code: 500,
             message: "500 Internal Server Error".to_string(),
+            headers: None,
             body: None,
         };
         assert_eq!(error.code(), Some(500));
@@ -308,6 +461,7 @@ mod tests {
         let error = HttpError::Http {
             code: 404,
             message: "404 Not Found".to_string(),
+            headers: None,
             body: Some(vec![]),
         };
         assert_eq!(error.body(), None);
@@ -318,6 +472,7 @@ mod tests {
         let error = HttpError::Http {
             code: 502,
             message: "502 Bad Gateway".to_string(),
+            headers: None,
             body: Some(b"<html>nginx</html>".to_vec()),
         };
         assert!(matches!(

--- a/crux_http/src/lib.rs
+++ b/crux_http/src/lib.rs
@@ -9,9 +9,10 @@
 //!
 //! A request resolves to a [`Result<Response<T>>`](Result), and a 4xx or 5xx response is
 //! on the **`Err`** side of it: `crux_http` turns those into
-//! [`HttpError::Http`] — body included — before the event reaches the
-//! app, so [`Response::status`] is never an error status. Read the server's own
-//! explanation of a rejection with [`HttpError::body`] or [`HttpError::body_json`].
+//! [`HttpError::Http`] — headers and body included — before the event reaches the app, so
+//! [`Response::status`] is never an error status. Read the server's own explanation of a
+//! rejection with [`HttpError::body`] or [`HttpError::body_json`], and whatever policy it
+//! put in the headers (`Retry-After`, `WWW-Authenticate`) with [`HttpError::header`].
 //! [`Response`] documents the shape to write, and [`testing`] the two values a test
 //! should build.
 // #![warn(missing_docs)]

--- a/crux_http/src/response/raw_response.rs
+++ b/crux_http/src/response/raw_response.rs
@@ -293,6 +293,8 @@ impl TryFrom<HttpResponse> for RawResponse {
         let status = StatusCode::from_u16(status_u16).map_err(|_| HttpError::Http {
             code: status_u16,
             message: format!("invalid HTTP status code: {status_u16}"),
+            // The response never became one, so there are no headers to describe it with.
+            headers: None,
             body: None,
         })?;
 

--- a/crux_http/src/response/response.rs
+++ b/crux_http/src/response/response.rs
@@ -10,8 +10,9 @@ use std::{fmt, ops::Index};
 ///
 /// Holding one of these means the server did **not** reject the request. `crux_http`
 /// converts every 4xx and 5xx response into an [`HttpError::Http`](crate::HttpError::Http)
-/// — keeping the body — and delivers it on the `Err` side, so [`status`](Self::status) is
-/// always a 1xx, 2xx or 3xx. A `match` arm that checks it for failure is dead code:
+/// — keeping the headers and body — and delivers it on the `Err` side, so
+/// [`status`](Self::status) is always a 1xx, 2xx or 3xx. A `match` arm that checks it for
+/// failure is dead code:
 ///
 /// ```
 /// # use crux_http::{HttpError, Response};
@@ -55,22 +56,22 @@ impl<Body> Response<Body> {
     /// Create a new instance.
     ///
     /// A 4xx or 5xx status is not a response as far as the app is concerned: it becomes
-    /// [`HttpError::Http`], carrying the body so the caller can still read what the
-    /// server said. This is the single place that invariant is established — see the
+    /// [`HttpError::Http`], carrying the headers and body so the caller can still read what
+    /// the server said. This is the single place that invariant is established — see the
     /// [type docs](Response) for what it means for app and test code.
     pub(crate) fn new(mut res: super::RawResponse) -> Result<Response<Vec<u8>>> {
         let body = res.body_bytes()?;
         let status = res.status();
+        let headers = res.as_ref().clone();
 
         if status.is_client_error() || status.is_server_error() {
             return Err(HttpError::Http {
                 code: status.as_u16(),
                 message: status.to_string(),
+                headers: Some(Box::new(headers)),
                 body: Some(body),
             });
         }
-
-        let headers = res.as_ref().clone();
 
         Ok(Response {
             status,
@@ -277,11 +278,17 @@ impl Response<Vec<u8>> {
     /// # Ok(()) }
     /// ```
     pub fn body_bytes(&mut self) -> Result<Vec<u8>> {
-        self.body.take().ok_or_else(|| HttpError::Http {
-            code: self.status().as_u16(),
-            message: "Body had no bytes".to_string(),
-            body: None,
-        })
+        // Deliberately a `match` rather than `ok_or_else`: the closure would have to
+        // capture the cloned headers, cloning them on every successful read too.
+        match self.body.take() {
+            Some(body) => Ok(body),
+            None => Err(HttpError::Http {
+                code: self.status().as_u16(),
+                message: "Body had no bytes".to_string(),
+                headers: Some(Box::new(self.headers.clone())),
+                body: None,
+            }),
+        }
     }
 
     /// Reads the entire response body into a string.

--- a/crux_http/src/testing/mod.rs
+++ b/crux_http/src/testing/mod.rs
@@ -3,8 +3,8 @@
 //! The two entry points mirror the two things a feature can receive:
 //!
 //! - [`ResponseBuilder`] builds the `Ok(Response)` of a successful exchange.
-//! - [`rejection`] builds the `Err(HttpError::Http { .. })` of a 4xx/5xx rejection,
-//!   body included.
+//! - [`rejection`] builds the `Err(HttpError::Http { .. })` of a 4xx/5xx rejection, body
+//!   included — or [`rejection_from`], when the rejection's headers matter too.
 //!
 //! There is no third case: a `Response` never carries an error status, so
 //! `ResponseBuilder` refuses to build one.
@@ -15,7 +15,7 @@ mod response_builder;
 #[cfg(test)]
 mod fake_shell;
 
-pub use rejection::rejection;
+pub use rejection::{rejection, rejection_from};
 pub use response_builder::ResponseBuilder;
 
 #[cfg(test)]

--- a/crux_http/src/testing/rejection.rs
+++ b/crux_http/src/testing/rejection.rs
@@ -40,16 +40,63 @@ use crate::{RawResponse, Response, Result, protocol::HttpResponse};
 /// (4xx) or server (5xx) error — for any other status a feature receives
 /// `Ok(Response)`, which is what [`ResponseBuilder`](super::ResponseBuilder) builds.
 pub fn rejection<Body>(status: u16, body: impl AsRef<[u8]>) -> Result<Response<Body>> {
-    let response = HttpResponse::status(status)
-        .body(body.as_ref().to_vec())
-        .build();
-    let raw = RawResponse::try_from(response)
-        .expect("rejection called with an out-of-range status code (must be 100–999)");
+    build_rejection(
+        "rejection",
+        HttpResponse::status(status)
+            .body(body.as_ref().to_vec())
+            .build(),
+    )
+}
+
+/// Build the [`crux_http::Result`](crate::Result) a feature receives for a rejection, from
+/// a full protocol response.
+///
+/// Use this over [`rejection`] when the rejection's *headers* are what the feature acts on
+/// — `Retry-After`, `WWW-Authenticate`, `Content-Type` — since those are readable from the
+/// error via [`HttpError::header`](crate::HttpError::header) and
+/// [`HttpError::content_type`](crate::HttpError::content_type):
+///
+/// ```
+/// # use crux_http::{protocol::HttpResponse, testing::rejection_from};
+/// let result = rejection_from::<Vec<u8>>(
+///     HttpResponse::status(503)
+///         .header("retry-after", "120")
+///         .body(b"maintenance".to_vec())
+///         .build(),
+/// );
+///
+/// let error = result.expect_err("a 503 is never Ok");
+/// assert_eq!(error.header("retry-after").unwrap(), "120");
+/// assert_eq!(error.body(), Some(&b"maintenance"[..]));
+/// ```
+///
+/// It takes the same [`HttpResponse`] you would resolve a request with in an end-to-end
+/// test, so the two styles of test describe a rejection the same way.
+///
+/// # Errors
+///
+/// Always `Err`, for the reason given on [`rejection`].
+///
+/// # Panics
+///
+/// Panics if the response's status is outside the valid HTTP range (100–999), or if it is
+/// not a client (4xx) or server (5xx) error.
+pub fn rejection_from<Body>(response: HttpResponse) -> Result<Response<Body>> {
+    build_rejection("rejection_from", response)
+}
+
+/// The shared body of [`rejection`] and [`rejection_from`]. `caller` names whichever of
+/// them the test actually called, so a panic points at the right function.
+fn build_rejection<Body>(caller: &str, response: HttpResponse) -> Result<Response<Body>> {
+    let status = response.status;
+    let raw = RawResponse::try_from(response).unwrap_or_else(|_| {
+        panic!("{caller} called with an out-of-range status code ({status}, must be 100–999)")
+    });
 
     match Response::<Vec<u8>>::new(raw) {
         Err(error) => Err(error),
         Ok(_) => panic!(
-            "rejection called with status {status}, which is not a client (4xx) or server (5xx) \
+            "{caller} called with status {status}, which is not a client (4xx) or server (5xx) \
              error — a feature receives that as Ok(Response), which ResponseBuilder builds"
         ),
     }
@@ -59,7 +106,7 @@ pub fn rejection<Body>(status: u16, body: impl AsRef<[u8]>) -> Result<Response<B
 mod tests {
     use crate::{HttpError, protocol::HttpResponse};
 
-    use super::rejection;
+    use super::{rejection, rejection_from};
 
     #[test]
     fn carries_code_reason_and_body() {
@@ -69,6 +116,7 @@ mod tests {
         let HttpError::Http {
             code,
             message,
+            headers,
             body,
         } = error
         else {
@@ -76,7 +124,42 @@ mod tests {
         };
         assert_eq!(code, 409);
         assert_eq!(message, "409 Conflict");
+        assert!(
+            headers.expect("a rejection has headers").is_empty(),
+            "rejection() sets no headers"
+        );
         assert_eq!(body.unwrap(), br#"{"error":"management cycle"}"#);
+    }
+
+    /// `rejection_from` is the header-carrying form, and must agree with `rejection` when
+    /// there are no headers to carry.
+    #[test]
+    fn rejection_is_the_header_less_case_of_rejection_from() {
+        let sugar = rejection::<Vec<u8>>(409, "nope");
+        let explicit =
+            rejection_from::<Vec<u8>>(HttpResponse::status(409).body(b"nope".to_vec()).build());
+
+        assert_eq!(sugar, explicit);
+    }
+
+    #[test]
+    fn rejection_from_keeps_the_headers() {
+        let error = rejection_from::<Vec<u8>>(
+            HttpResponse::status(401)
+                .header("www-authenticate", r#"Bearer error="invalid_token""#)
+                .header("content-type", "application/problem+json")
+                .build(),
+        )
+        .expect_err("a 401 is never Ok");
+
+        assert_eq!(
+            error.header("www-authenticate").unwrap(),
+            r#"Bearer error="invalid_token""#
+        );
+        assert_eq!(
+            error.content_type().map(|mime| mime.to_string()),
+            Some("application/problem+json".to_string())
+        );
     }
 
     /// The whole point of the helper: what it produces must be indistinguishable from
@@ -106,13 +189,20 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "which is not a client (4xx) or server (5xx) error")]
+    #[should_panic(expected = "rejection called with status 200, which is not a client")]
     fn refuses_a_success_status() {
         let _ = rejection::<Vec<u8>>(200, "");
     }
 
+    /// A panic must name the function the test called, not the one it delegates to.
     #[test]
-    #[should_panic(expected = "out-of-range status code")]
+    #[should_panic(expected = "rejection_from called with status 200, which is not a client")]
+    fn rejection_from_refuses_a_success_status() {
+        let _ = rejection_from::<Vec<u8>>(HttpResponse::status(200).build());
+    }
+
+    #[test]
+    #[should_panic(expected = "rejection called with an out-of-range status code (99")]
     fn refuses_an_out_of_range_status() {
         let _ = rejection::<Vec<u8>>(99, "");
     }

--- a/crux_http/tests/rejections.rs
+++ b/crux_http/tests/rejections.rs
@@ -57,7 +57,7 @@ mod shared {
 
 use crux_http::{
     protocol::{HttpResponse, HttpResult},
-    testing::rejection,
+    testing::{rejection, rejection_from},
 };
 use shared::{Effect, Event, Leave, URL, book, message};
 
@@ -113,15 +113,54 @@ fn the_error_body_survives_a_typed_expectation() {
     );
 }
 
+/// `Retry-After` is only in the headers — not in the status, not in the body — so this is
+/// the case that proves the headers have to survive the conversion into an error.
+#[test]
+fn a_rejections_headers_reach_the_app() {
+    let error = resolve(
+        HttpResponse::status(503)
+            .header("retry-after", "120")
+            .header("content-type", "text/plain")
+            .body(b"maintenance until 09:00".to_vec())
+            .build(),
+    )
+    .expect_err("a 503 is never Ok");
+
+    assert_eq!(error.header("Retry-After").unwrap(), "120");
+    assert_eq!(
+        error
+            .content_type()
+            .map(|mime| mime.essence_str().to_string()),
+        Some("text/plain".to_string())
+    );
+    assert_eq!(error.body(), Some(&b"maintenance until 09:00"[..]));
+}
+
 /// The value `testing::rejection` builds is the value the machinery delivers — so a test
-/// that asserts against it is testing the live path.
+/// that asserts against it is testing the live path. With headers in play, that equality
+/// only holds for the header-carrying form.
 #[test]
 fn the_testing_helper_matches_what_the_shell_produces() {
     let body = r#"{"error":"that would create a management cycle"}"#;
 
     let from_shell = resolve(HttpResponse::status(409).body(body).build());
-
     assert_eq!(from_shell, rejection::<Leave>(409, body));
+
+    let with_headers = resolve(
+        HttpResponse::status(409)
+            .header("content-type", "application/json")
+            .body(body)
+            .build(),
+    );
+    assert_eq!(
+        with_headers,
+        rejection_from::<Leave>(
+            HttpResponse::status(409)
+                .header("content-type", "application/json")
+                .body(body)
+                .build()
+        )
+    );
 }
 
 #[test]

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -47,6 +47,7 @@
 # Guides
 
 1. [Migrating crux_http to native http types](./guide/migrate-crux-http.md)
+1. [Handling crux_http rejections](./guide/http-rejections.md)
 
 # RFCs
 

--- a/docs/src/guide/http-rejections.md
+++ b/docs/src/guide/http-rejections.md
@@ -1,0 +1,134 @@
+# Handling `crux_http` rejections
+
+When a server rejects a request — a 4xx or a 5xx — `crux_http` does **not** hand your
+app a `Response` with that status on it. It converts the rejection into an
+`Err(HttpError::Http { .. })`, keeping the status, the headers and the body, and sends
+*that* to your update function.
+
+So an `Ok(Response)` always means the server did not reject the request, and
+`Response::status()` is always a 1xx, 2xx or 3xx.
+
+---
+
+## The shape to write
+
+This is the trap the invariant exists to close:
+
+```rust
+// WRONG — the `else` branch is dead code
+match result {
+    Ok(mut response) => {
+        if response.status().is_success() {
+            // …
+        } else {
+            // unreachable: a 4xx never arrives as Ok(Response)
+            show(error_reason(&mut response));
+        }
+    }
+    // …so this is where a 409 lands, and `to_string()` is only "HTTP error 409: 409 Conflict"
+    Err(error) => show(&error.to_string()),
+}
+```
+
+Everything the server said about *why* it refused is on the error, so read it there:
+
+```rust
+match result {
+    // no status check here — this arm cannot see a 4xx or 5xx
+    Ok(response) => saved(response.body()),
+    Err(error) => {
+        let message = error
+            .body_json::<serde_json::Value>()
+            .ok()
+            .and_then(|body| body["error"].as_str().map(str::to_string))
+            .unwrap_or_else(|| error.to_string());
+        show(&message);
+    }
+}
+```
+
+---
+
+## Reading a rejection
+
+`HttpError` has accessors for everything the rejected response carried, so you never
+need to destructure the variant:
+
+| Accessor | What you get |
+| --- | --- |
+| `code()` | The status code, e.g. `Some(409)` |
+| `body()` | The raw body bytes the server sent, if any |
+| `body_json::<T>()` | That body deserialized — your own error envelope, an RFC 7807 `problem+json` struct, or `serde_json::Value` |
+| `header(name)` | One header, looked up case-insensitively |
+| `content_type()` | The parsed `Content-Type`, if the response declared one |
+| `headers()` | The whole `HeaderMap`, for multi-value headers or logging |
+
+Body decoding is skipped for an error status, so the raw error body survives even when
+the request was built with `.expect_json::<T>()` — an error envelope that doesn't match
+`T` still reaches you intact.
+
+The headers matter more than they first appear, because some of what an app needs in
+order to *act* on a rejection is only there:
+
+```rust
+// back off politely instead of hammering the server
+if let Some(retry_after) = error.header("Retry-After") { … }
+
+// silent token refresh, or send the user back to the login screen?
+if error.code() == Some(401) {
+    match error.header("WWW-Authenticate") { … }
+}
+
+// is this body an error envelope, or a proxy's HTML page?
+match error.content_type() { … }
+```
+
+```admonish note
+`HttpError::Http` is `#[non_exhaustive]`: only `crux_http` constructs it, so what a
+rejection carries can grow without breaking your code. Match it with `{ code, .. }` and
+reach for the accessors above for the rest.
+```
+
+---
+
+## Testing a rejection
+
+There are exactly two values a feature can receive, and `crux_http::testing` has one
+builder for each:
+
+- `ResponseBuilder` — the `Ok(Response)` of a successful exchange. It **panics** if you
+  give it a 4xx or 5xx, because no app can ever receive one.
+- `rejection(status, body)` — the `Err` of a rejection. Use `rejection_from(response)`
+  when the rejection's headers are what your feature acts on.
+
+Both run the same conversion a real shell response takes, so what they produce is what
+your app is really handed.
+
+```rust
+// before — asserts a state the app can never observe, so the test passes
+// while the code it covers is dead
+let result = Ok(ResponseBuilder::with_status(409).body(body).build());
+
+// after — what the app really receives
+let result = crux_http::testing::rejection(409, body);
+
+// …or, when the headers are the point
+let result = crux_http::testing::rejection_from(
+    HttpResponse::status(503)
+        .header("retry-after", "120")
+        .body(b"maintenance".to_vec())
+        .build(),
+);
+```
+
+If you have tests that assert on a rejection message and they pass today, check which
+value they build. A test that fabricates `Ok(response_with_409)` is asserting the dead
+`else` branch above, and will happily stay green while your users see
+`"HTTP error 409: 409 Conflict"`.
+
+---
+
+## See also
+
+- [Migrating `crux_http` to native `http` types](./migrate-crux-http.md), for the 0.19
+  change from `http-types` to the `http` crate.

--- a/docs/src/part-2/capabilities.md
+++ b/docs/src/part-2/capabilities.md
@@ -16,6 +16,8 @@ The weather app's current-weather fetch shows the same pattern in production cod
 
 `Http::get(...)` starts a builder, `.expect_json::<T>()` pins down the response type, `.query(...)` adds URL parameters, `.build()` produces a `RequestBuilder`, and `.map(...)` translates the shell's `Result<Response, HttpError>` into the more convenient `Result<CurrentWeatherResponse, WeatherError>`. The caller finishes it off with `.then_send(SomeEvent)` — `fetch` returns a builder, not a command, so callers can hook it into their own event type.
 
+Note that a 4xx or 5xx response arrives on the **`Err`** side of that `Result`, never as an `Ok(Response)` carrying an error status — see [Handling `crux_http` rejections](../guide/http-rejections.md) for how to read one and how to test it.
+
 That's how a capability gets used. But where do these APIs come from? Let's build one.
 
 ## A simple custom capability: Location


### PR DESCRIPTION
> **Stacked on #554** — base it on `http-rejection-ergonomics`, or merge #554 first and this
> becomes three commits against `master` (one feature, two docs). The accessors #554 adds
> (`HttpError::body`, `body_json`, `code`, and `testing::rejection`) are what make this
> change small.

## Why

#554 deliberately left `HttpError::Http` alone, on the grounds that nothing had asked for a
rejection's headers. That was wrong, and checking it turned up why: **the headers are
currently unreachable by any route.**

- `Response::new` discards the `HeaderMap` on the error branch — 4xx/5xx keeps only
  `code`, `message` and `body`.
- `crux_http`'s own middleware, which *does* see the full `RawResponse` (that is how
  `Redirect` reads `Location`), **never runs in the command API**: `command::RequestBuilder::build`
  goes straight `into_protocol_request()` → `request_from_shell`, and the only executor of a
  middleware stack is `Client::send`, reached solely from the deprecated
  `request_builder.rs`. `command::RequestBuilder::middleware(…)` is accepted and silently
  dropped. (Separate bug — #556. Not fixed here, but no longer undocumented; see below.)

So for an app on the current API, everything a server says in the headers of a rejection is
gone. That is not cosmetic:

| Header | Why it can't be recovered otherwise |
| --- | --- |
| `Retry-After` (429, 503) | Not in the status, not in the body. An app cannot back off politely or say "try again in 5 minutes". |
| `WWW-Authenticate` (401) | `Bearer error="invalid_token"` vs insufficient scope decides silent refresh vs re-login. |
| `X-RateLimit-*` | Same. |
| `Content-Type` | Tells an app envelope from an RFC 7807 document from a proxy's HTML page — i.e. whether the body is worth deserializing, and whether it is safe to show as text. |

## What changed

**`HttpError::Http` grows a `headers` field**, read through three accessors that sit
alongside the `body`/`body_json` pair from #554:

```rust
if let Some(retry_after) = error.header("Retry-After") { /* back off */ }   // case-insensitive
match error.content_type() { … }
error.headers()   // escape hatch: multi-value, iteration, logging
```

The field is `Option<Box<HeaderMap>>`:

- `Option`, so `None` means "there was no response to describe" (a transport failure, or a
  status code that wasn't valid HTTP) as distinct from a response that sent no headers.
- `Box`, because a bare `HeaderMap` is **96 bytes**, which took `HttpError` to 160 and
  tripped `clippy::result_large_err` in `config.rs`, `expect.rs` and `error.rs` — this type
  is the `Err` of nearly every function in the crate. Boxed, it's 8 bytes and `HttpError` is
  back to 72. (Measured, not guessed.)

I chose `HeaderMap` over the protocol's `Vec<HttpHeader>` (which would have needed no
`#[facet(opaque)]` and no box) so that case-insensitive lookup and multi-value handling are
**inherited rather than re-implemented** — this crate has already been bitten by multi-value
header bugs, per the 0.19 changelog — and so that `header()`/`content_type()` have exactly
the same signatures as they do on `Response`.

**The variant is now `#[non_exhaustive]`.** Since this PR is already breaking construction of
it, this is the moment to make that the *last* time: only `crux_http` constructs the variant,
so what a rejection carries can keep growing behind the accessors. It also pushes callers
onto `{ code, .. }` plus `header()`/`body()`, which is the shape both PRs are arguing for.

**`testing::rejection_from(HttpResponse)`** is the header-carrying test helper, taking the
same protocol response you would resolve a request with, so both styles of test describe a
rejection identically. `rejection(status, body)` is unchanged and is now sugar over it —
with a test pinning that equivalence.

**Two docs commits ride along:**

- `command::RequestBuilder::middleware` gets a `# Warning` that nothing executes the stack —
  `Redirect` included, so redirects are not followed — pointing at #556. Its example
  previously implied otherwise. Documents existing behaviour; fixes nothing.
- A new book page, [Handling `crux_http` rejections](docs/src/guide/http-rejections.md),
  covering the invariant, the dead-`else` trap, the accessors, and the two test builders,
  linked from `SUMMARY.md` and from `part-2/capabilities.md` where the weather example's
  `Result<Response, HttpError>` is first explained.

## Migration

`match` arms that name only the fields they use are unaffected — including the pattern in
this repo's own weather example:

```rust
Err(HttpError::Http { code, .. }) if code == 401 => { … }   // still compiles
```

Code that *constructs* the variant can no longer do so at all (`#[non_exhaustive]`). In
tests, that was the wrong move anyway:

```rust
// before
HttpError::Http { code: 409, message: "409 Conflict".into(), body: Some(body) }
// after
crux_http::testing::rejection::<Vec<u8>>(409, body).unwrap_err()
```

One subtlety worth knowing if you have tests comparing whole errors: `PartialEq` now
includes the headers, and `rejection(409, body)` carries `Some(<empty map>)`, which does not
equal a hand-built `headers: None`. Compare against `rejection` / `rejection_from` rather
than a value assembled by hand.

## Tests

- `tests/rejections.rs`: a 503 resolved through a real `Command` — `Retry-After`,
  `Content-Type` and body all reach the app. This is the test that fails without the change.
- `testing::rejection` still equals what the shell path produces, now also for a
  header-carrying rejection; `rejection` proven equal to `rejection_from` with no headers.
- Accessor unit tests: case-insensitive lookup, `content_type` parsing, `problem+json`,
  `WWW-Authenticate`, and the three-way distinction between no response, an empty header
  map, and a populated one.
- Both helpers' panics assert the *calling* function's name, so `rejection_from` can't
  report itself as `rejection`.

## Review follow-ups

Applied after review, each in the commit that introduced the problem:

- `Response::body_bytes` no longer clones the `HeaderMap` on the success path. The
  `ok_or_else` closure had to capture the clone, so every successful `body_bytes` /
  `body_string` / `body_json` paid for a map it threw away; it's a `match` now, with a
  comment saying why.
- `HttpError::headers`' doc said "empty for errors with no response behind them" when it
  returns `None` — which contradicted the deliberate `None` vs `Some(&empty)` distinction.
- `HttpError::code`'s doc (in #554) claimed processing errors have no status. Not true:
  `Response::body_bytes` reports an already-taken body as an `Http` error carrying that
  response's own non-error status, so `Some` isn't proof of a rejection. Now says so.
  Giving that case its own variant would be a better fix and a third breaking change —
  left for its own PR.
- The shared panic path named `rejection` even when `rejection_from` was called.

## Not done here

- **The middleware no-op** (#556). It needs `build()` to route through `Client::send`, which
  needs an `EffectSender` backed by the command context — doable (the trait is the right
  shape), but it's a behaviour change (redirects would start being followed) and a separate
  discussion about whether `crux_http` middleware survives the capability deprecation. This
  PR only stops the doc example promising redirect-following that does not happen.
- **A separate variant for "body had no bytes"**, which is not a rejection but now presents
  as one, complete with headers. Third breaking change; wants its own PR.
- No RFC 7807 type. `body_json::<T>()` plus `content_type()` covers it without the crate
  taking a position on the shape.

## CI

`cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -Dpedantic
-Dnursery`, `cargo nextest run --all-features` (239 workspace tests, 110 in `crux_http`),
`cargo test --doc --all-features` (75 `crux_http` doc tests), `cargo doc` with
`-D rustdoc::broken_intra_doc_links`, and `mdbook build` with the linkcheck backend are all
green locally, as is #554's tip on its own. Same caveat as #554: `just examples/check` can't
complete on my machine because `examples/counter/web-nextjs` needs a BoltFFI-generated wasm
package before `pnpm install` will resolve; the per-example shared-crate clippy and test runs
pass.
