### PR TITLE
feat(http)!: split non-rejection errors out of HttpError::Http

### DIFF
--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -130,6 +130,16 @@ and this project adheres to
   **not** `#[non_exhaustive]`, so a new failure mode is a compile error you get to think
   about, rather than something that silently lands in a wildcard.
 
+- **`From<http_types::Error> for HttpError` is gone** (`http-types` feature only). It mapped
+  a middleware error onto `HttpError::Http`, which now means only a server rejection, and it
+  has no callers inside the crate. `http-types` middleware must map its own errors
+  explicitly.
+
+  It isn't rehomed onto a new variant because **the `http-types` feature is slated for
+  removal in full** — `http` is the only HTTP type system `crux_http` will keep. This is the
+  first piece to go; `crux_http::compat` and the `pub use http_types` re-export follow in
+  their own release. If you still depend on the feature, now is the time to say so.
+
 - **`HttpError::Http` has a new `headers` field**, so that a rejection's headers reach the
   app (see `HttpError::header` above). It is `Option<Box<HeaderMap>>`, boxed only because a
   bare `HeaderMap` is 96 bytes and this type is the

--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -141,10 +141,17 @@ and this project adheres to
   their own release. If you still depend on the feature, now is the time to say so.
 
 - **`HttpError::Http` has a new `headers` field**, so that a rejection's headers reach the
-  app (see `HttpError::header` above). It is `Option<Box<HeaderMap>>`, boxed only because a
-  bare `HeaderMap` is 96 bytes and this type is the
-  `Err` of nearly every function in the crate — inline, it pushed `HttpError` to 160 bytes
-  and tripped `clippy::result_large_err` across the crate.
+  app (see `HttpError::header` above). It is `Box<HeaderMap>`, boxed only because a bare
+  `HeaderMap` is 96 bytes and this type is the `Err` of nearly every function in the crate —
+  inline, it pushed `HttpError` to 160 bytes and tripped `clippy::result_large_err` across
+  the crate.
+
+  Neither `headers` nor `body` is optional, and `body` is now a plain `Vec<u8>` rather than
+  `Option<Vec<u8>>`. `Response::new` is the variant's only constructor and always supplies
+  both, so the `Option`s described states that could not arise. Both types are
+  niche-optimised, so this costs nothing at runtime — `HttpError` stays 72 bytes — and the
+  accessors are unchanged: `body()` still returns `None` for an empty body, and `headers()`
+  still returns `None`, but now that means simply "not a rejection".
 
   `match` arms that name only the fields they use are unaffected:
 
@@ -165,10 +172,9 @@ and this project adheres to
   let error = crux_http::testing::rejection::<Vec<u8>>(409, body).unwrap_err();
   ```
 
-  Note that `HttpError`'s `PartialEq` now compares headers too, so a hand-built variant no
-  longer equals the real thing: `rejection(409, body)` carries `Some(<empty map>)`, which is
-  not equal to `headers: None`. Another reason to compare against `rejection` /
-  `rejection_from` rather than a value assembled by hand.
+  Note that `HttpError`'s `PartialEq` now compares headers too, so two rejections that
+  differ only in what the server sent in its headers are no longer equal. Compare against
+  `rejection` / `rejection_from` rather than a value assembled by hand.
 
 - **`ResponseBuilder::with_status` now panics for a 4xx or 5xx status.** It could
   previously build a `Response` carrying an error status — a value no app can ever

--- a/crux_http/CHANGELOG.md
+++ b/crux_http/CHANGELOG.md
@@ -106,10 +106,33 @@ and this project adheres to
 
 ### 💥 Breaking Changes
 
+- **`HttpError` has two new variants, and `HttpError::Http` now means only a server
+  rejection.** Two things that were not rejections used to report themselves as one:
+
+  | Was | Is now |
+  | --- | --- |
+  | `Response::body_bytes` on an already-taken body → `Http { code: <the success status>, headers: <that response's>, .. }` | `HttpError::BodyAlreadyTaken` |
+  | A shell status outside 100–999 → `Http { code: 999, .. }` | `HttpError::InvalidStatusCode(999)` |
+
+  So `error.code()` could return `Some(200)`, and `matches!(err, HttpError::Http { .. })`
+  was not a reliable test for "the server rejected this". Both now are:
+
+  ```rust
+  // `Some` if and only if the server rejected the request
+  if let Some(code) = error.code() { … }
+  ```
+
+  `BodyAlreadyTaken` carries nothing: the caller still holds the `Response`, so the status
+  and headers the old error reported were already in hand — and they described a *successful*
+  response, which is what made them misleading.
+
+  An exhaustive `match` on `HttpError` needs two new arms. That is deliberate: the enum is
+  **not** `#[non_exhaustive]`, so a new failure mode is a compile error you get to think
+  about, rather than something that silently lands in a wildcard.
+
 - **`HttpError::Http` has a new `headers` field**, so that a rejection's headers reach the
-  app (see `HttpError::header` above). It is `Option<Box<HeaderMap>>`: `None` when the error
-  was raised with no response to describe (a transport failure, or a status code that wasn't
-  valid HTTP), and boxed only because a bare `HeaderMap` is 96 bytes and this type is the
+  app (see `HttpError::header` above). It is `Option<Box<HeaderMap>>`, boxed only because a
+  bare `HeaderMap` is 96 bytes and this type is the
   `Err` of nearly every function in the crate — inline, it pushed `HttpError` to 160 bytes
   and tripped `clippy::result_large_err` across the crate.
 

--- a/crux_http/src/error.rs
+++ b/crux_http/src/error.rs
@@ -17,12 +17,16 @@ use crate::Result;
 /// These are never serialized or visible to shells:
 ///
 /// - [`Http`](HttpError::Http) — produced by `Response::new()` when the server returns
-///   a 4xx or 5xx status. At the *protocol* level these arrive as
+///   a 4xx or 5xx status, and **only** then. At the *protocol* level these arrive as
 ///   [`HttpResult::Ok`](crate::protocol::HttpResult::Ok); `Response::new()` converts
 ///   them here, so app code using `crux_http::Result<Response<T>>` will see them as
 ///   `Err(HttpError::Http { code, .. })` — **never** as `Ok(response)` with an error
 ///   status.
 /// - [`Json`](HttpError::Json) — produced when response body deserialisation fails.
+/// - [`BodyAlreadyTaken`](HttpError::BodyAlreadyTaken) — a caller took the response body
+///   twice.
+/// - [`InvalidStatusCode`](HttpError::InvalidStatusCode) — the shell sent a status that
+///   isn't valid HTTP.
 ///
 /// # Reading what the server said
 ///
@@ -68,7 +72,9 @@ pub enum HttpError {
     ///
     /// This is what a feature receives *instead of* a [`Response`](crate::Response)
     /// when the server rejects a request, so it is the only place a rejection can be
-    /// handled.
+    /// handled — and a rejection is the only thing that produces it. Nothing else in the
+    /// crate raises an `Http`, so `matches!(error, HttpError::Http { .. })` (or, more
+    /// simply, [`code`](HttpError::code) returning `Some`) means the server said no.
     ///
     /// `body` is the response body exactly as the server sent it. Body decoding
     /// (`expect_json`, `expect_string`) is skipped for an error status, so a server's
@@ -87,8 +93,7 @@ pub enum HttpError {
     /// lives there and nowhere else: `Retry-After` on a 429 or 503, `WWW-Authenticate` on
     /// a 401, rate-limit headers, or the `Content-Type` that says whether the body is JSON,
     /// HTML or prose. Read them with [`HttpError::header`], [`HttpError::content_type`] or
-    /// [`HttpError::headers`]. `None` when the error was raised with no response to describe
-    /// — a transport failure, or a status code that wasn't valid HTTP.
+    /// [`HttpError::headers`].
     ///
     /// (The map is boxed only to keep `HttpError` small: a bare `HeaderMap` is 96 bytes, and
     /// this type is the `Err` of nearly every function in the crate.)
@@ -114,18 +119,42 @@ pub enum HttpError {
     #[serde(skip)]
     #[facet(skip)]
     Json(String),
+
+    /// The response body had already been taken.
+    ///
+    /// A caller error rather than anything the server did: [`body_bytes`], [`body_string`],
+    /// [`body_json`] and [`body_form`] each *take* the body, so only the first call can
+    /// succeed. It carries nothing, because the caller still holds the
+    /// [`Response`](crate::Response) and so already has its status and headers.
+    ///
+    /// [`body_bytes`]: crate::Response::body_bytes
+    /// [`body_string`]: crate::Response::body_string
+    /// [`body_json`]: crate::Response::body_json
+    /// [`body_form`]: crate::Response::body_form
+    #[error("response body had already been taken")]
+    #[serde(skip)]
+    #[facet(skip)]
+    BodyAlreadyTaken,
+
+    /// The shell sent a status code that is not valid HTTP (outside the range 100–999).
+    ///
+    /// The response never became one, so there is nothing to read from it. This means the
+    /// shell is misbehaving, not that the request was rejected.
+    #[error("invalid HTTP status code: {0}")]
+    #[serde(skip)]
+    #[facet(skip)]
+    InvalidStatusCode(u16),
 }
 
 impl HttpError {
-    /// The status code of the response this error came from, if there was one.
+    /// The status the server rejected the request with.
     ///
-    /// Normally the 4xx or 5xx the server rejected the request with. It can also be a
-    /// *non-error* status: [`Response::body_bytes`](crate::Response::body_bytes) reports an
-    /// already-taken body as an `Http` error carrying that response's own status, so `Some`
-    /// is not by itself proof of a rejection — test the value if you need one.
-    ///
-    /// `None` for errors that never had a response at all: transport failures and body
-    /// deserialisation failures.
+    /// `Some` if and only if this error *is* a rejection — nothing else in the crate carries
+    /// a status. `None` covers everything the server didn't decide: transport failures, a
+    /// body that wouldn't deserialize, a body taken twice, and a status the shell sent that
+    /// wasn't valid HTTP (that one keeps its number on
+    /// [`InvalidStatusCode`](HttpError::InvalidStatusCode), which is not a status a server
+    /// ever answered with).
     ///
     /// # Examples
     ///
@@ -136,6 +165,7 @@ impl HttpError {
     /// assert_eq!(error.code(), Some(404));
     ///
     /// assert_eq!(HttpError::Timeout.code(), None);
+    /// assert_eq!(HttpError::InvalidStatusCode(999).code(), None);
     /// ```
     #[must_use]
     pub const fn code(&self) -> Option<u16> {
@@ -398,17 +428,14 @@ mod tests {
         assert_eq!(HttpError::Timeout.headers(), None);
         assert_eq!(HttpError::Timeout.content_type(), None);
 
-        // Nor does a status the crate rejected before a response existed.
-        let error = HttpError::Http {
-            code: 999,
-            message: "invalid HTTP status code: 999".to_string(),
-            headers: None,
-            body: None,
-        };
+        // Nor does a status the crate rejected before a response existed. That is no longer
+        // an `Http` at all, which is the point of the variant: it was never a rejection.
+        let error = HttpError::InvalidStatusCode(999);
+        assert_eq!(error.header("retry-after"), None);
         assert_eq!(error.headers(), None);
         assert_eq!(error.content_type(), None);
 
-        // A real response with no headers is `Some`, but empty — the two are different
+        // A real rejection that sent no headers is `Some`, but empty — the two are different
         // things, and only the accessors' `None` conflates them.
         let error = HttpError::Http {
             code: 500,
@@ -445,7 +472,11 @@ mod tests {
             Err(HttpError::Json(_))
         ));
 
-        // Nor did an error status the crate raised itself, e.g. a body already taken.
+        // Nor do the two errors the crate raises itself, neither of which is a rejection.
+        assert_eq!(HttpError::BodyAlreadyTaken.body(), None);
+        assert_eq!(HttpError::InvalidStatusCode(999).body(), None);
+
+        // A rejection that sent no body still reports its status.
         let error = HttpError::Http {
             code: 500,
             message: "500 Internal Server Error".to_string(),
@@ -454,6 +485,37 @@ mod tests {
         };
         assert_eq!(error.code(), Some(500));
         assert_eq!(error.body(), None);
+    }
+
+    /// The invariant this split exists to establish: a status on the error means the server
+    /// rejected the request, and nothing else does.
+    #[test]
+    fn only_a_rejection_has_a_code() {
+        assert_eq!(
+            crate::testing::rejection::<Vec<u8>>(409, "")
+                .expect_err("a 409 is never Ok")
+                .code(),
+            Some(409)
+        );
+
+        assert_eq!(HttpError::BodyAlreadyTaken.code(), None);
+        assert_eq!(HttpError::InvalidStatusCode(999).code(), None);
+        assert_eq!(HttpError::Timeout.code(), None);
+        assert_eq!(HttpError::Io("refused".to_string()).code(), None);
+        assert_eq!(HttpError::Url("bad".to_string()).code(), None);
+        assert_eq!(HttpError::Json("nope".to_string()).code(), None);
+    }
+
+    #[test]
+    fn the_new_variants_display_usefully() {
+        assert_eq!(
+            HttpError::BodyAlreadyTaken.to_string(),
+            "response body had already been taken"
+        );
+        assert_eq!(
+            HttpError::InvalidStatusCode(999).to_string(),
+            "invalid HTTP status code: 999"
+        );
     }
 
     #[test]

--- a/crux_http/src/error.rs
+++ b/crux_http/src/error.rs
@@ -122,15 +122,14 @@ pub enum HttpError {
 
     /// The response body had already been taken.
     ///
-    /// A caller error rather than anything the server did: [`body_bytes`], [`body_string`],
-    /// [`body_json`] and [`body_form`] each *take* the body, so only the first call can
-    /// succeed. It carries nothing, because the caller still holds the
-    /// [`Response`](crate::Response) and so already has its status and headers.
+    /// A caller error rather than anything the server did: [`body_bytes`], [`body_string`]
+    /// and [`body_json`] all *take* the body, so only the first call can succeed. It carries
+    /// nothing, because the caller still holds the [`Response`](crate::Response) and so
+    /// already has its status and headers.
     ///
     /// [`body_bytes`]: crate::Response::body_bytes
     /// [`body_string`]: crate::Response::body_string
     /// [`body_json`]: crate::Response::body_json
-    /// [`body_form`]: crate::Response::body_form
     #[error("response body had already been taken")]
     #[serde(skip)]
     #[facet(skip)]
@@ -307,19 +306,6 @@ impl HttpError {
             .body()
             .ok_or_else(|| Self::Json("error has no response body".to_string()))?;
         serde_json::from_slice(body).map_err(Self::from)
-    }
-}
-
-#[cfg(feature = "http-types")]
-impl From<http_types::Error> for HttpError {
-    fn from(e: http_types::Error) -> Self {
-        Self::Http {
-            code: e.status().into(),
-            message: e.to_string(),
-            // An `http_types::Error` is a status and a message; it has no response.
-            headers: None,
-            body: None,
-        }
     }
 }
 

--- a/crux_http/src/error.rs
+++ b/crux_http/src/error.rs
@@ -93,7 +93,9 @@ pub enum HttpError {
     /// lives there and nowhere else: `Retry-After` on a 429 or 503, `WWW-Authenticate` on
     /// a 401, rate-limit headers, or the `Content-Type` that says whether the body is JSON,
     /// HTML or prose. Read them with [`HttpError::header`], [`HttpError::content_type`] or
-    /// [`HttpError::headers`].
+    /// [`HttpError::headers`]. A rejection that sent no headers has an empty map, not an
+    /// absent one — there was always a response here, which is what distinguishes this
+    /// variant from every other.
     ///
     /// (The map is boxed only to keep `HttpError` small: a bare `HeaderMap` is 96 bytes, and
     /// this type is the `Err` of nearly every function in the crate.)
@@ -111,8 +113,8 @@ pub enum HttpError {
         code: u16,
         message: String,
         #[facet(opaque)]
-        headers: Option<Box<HeaderMap>>,
-        body: Option<Vec<u8>>,
+        headers: Box<HeaderMap>,
+        body: Vec<u8>,
     },
     /// A response body could not be deserialized (or a request body serialized).
     #[error("JSON serialization error: {0}")]
@@ -178,8 +180,9 @@ impl HttpError {
     ///
     /// This is the server's own account of why it rejected the request — usually far
     /// more useful to a user than [`Display`](std::fmt::Display), which can only report
-    /// the status. Returns `None` for errors that carry no body (transport failures, and
-    /// responses with an empty body).
+    /// the status. `None` for anything that isn't a rejection, and for a rejection whose
+    /// body was empty — every real 4xx arrives with bytes, and `Some(&[])` would only make
+    /// the obvious `if let Some(body)` idiom display blanks.
     ///
     /// # Examples
     ///
@@ -191,9 +194,7 @@ impl HttpError {
     #[must_use]
     pub fn body(&self) -> Option<&[u8]> {
         match self {
-            Self::Http {
-                body: Some(body), ..
-            } if !body.is_empty() => Some(body),
+            Self::Http { body, .. } if !body.is_empty() => Some(body),
             _ => None,
         }
     }
@@ -204,8 +205,8 @@ impl HttpError {
     /// `Retry-After` on a 429 or 503, `WWW-Authenticate` on a 401, rate-limit headers.
     /// None of it can be recovered from the status or the body.
     ///
-    /// Returns `None` for errors with no response behind them, and for a name the response
-    /// didn't carry. Lookup is case-insensitive, as HTTP requires.
+    /// Returns `None` for anything that isn't a rejection, and for a name the rejected
+    /// response didn't carry. Lookup is case-insensitive, as HTTP requires.
     ///
     /// # Examples
     ///
@@ -229,12 +230,12 @@ impl HttpError {
     /// [`HttpError::content_type`] don't cover — multi-value headers, iteration, or
     /// forwarding the lot to a logger.
     ///
-    /// `None` for errors with no response behind them, which is a different thing from
-    /// `Some(&empty_map)`: a response that sent no headers at all.
+    /// `Some` for a rejection — possibly an empty map, if the server sent no headers — and
+    /// `None` for every other error, none of which had a response behind them.
     #[must_use]
     pub fn headers(&self) -> Option<&HeaderMap> {
         match self {
-            Self::Http { headers, .. } => headers.as_deref(),
+            Self::Http { headers, .. } => Some(headers),
             _ => None,
         }
     }
@@ -342,8 +343,8 @@ mod tests {
         let error = HttpError::Http {
             code: 400,
             message: "Bad Request".to_string(),
-            headers: None,
-            body: None,
+            headers: Box::default(),
+            body: vec![],
         };
         assert_eq!(error.to_string(), "HTTP error 400: Bad Request");
     }
@@ -354,8 +355,8 @@ mod tests {
         let error = HttpError::Http {
             code: 404u16,
             message: "Not Found".to_string(),
-            headers: None,
-            body: None,
+            headers: Box::default(),
+            body: vec![],
         };
         assert_eq!(error.to_string(), "HTTP error 404: Not Found");
     }
@@ -393,8 +394,8 @@ mod tests {
         let error = HttpError::Http {
             code: 409,
             message: "409 Conflict".to_string(),
-            headers: Some(Box::new(headers)),
-            body: Some(br#"{"error":"already booked"}"#.to_vec()),
+            headers: Box::new(headers),
+            body: br#"{"error":"already booked"}"#.to_vec(),
         };
 
         assert_eq!(error.code(), Some(409));
@@ -421,15 +422,16 @@ mod tests {
         assert_eq!(error.headers(), None);
         assert_eq!(error.content_type(), None);
 
-        // A real rejection that sent no headers is `Some`, but empty — the two are different
-        // things, and only the accessors' `None` conflates them.
+        // Whereas a rejection always has a header map, even when the server sent nothing in
+        // it — so `headers()` is `Some(&empty)` here, never `None`. That is the whole
+        // distinction the accessor draws: `None` means "not a rejection".
         let error = HttpError::Http {
             code: 500,
             message: "500 Internal Server Error".to_string(),
-            headers: Some(Box::default()),
-            body: None,
+            headers: Box::default(),
+            body: vec![],
         };
-        assert!(error.headers().expect("a response's headers").is_empty());
+        assert!(error.headers().expect("a rejection has headers").is_empty());
         assert_eq!(error.content_type(), None);
     }
 
@@ -466,8 +468,8 @@ mod tests {
         let error = HttpError::Http {
             code: 500,
             message: "500 Internal Server Error".to_string(),
-            headers: None,
-            body: None,
+            headers: Box::default(),
+            body: vec![],
         };
         assert_eq!(error.code(), Some(500));
         assert_eq!(error.body(), None);
@@ -509,8 +511,8 @@ mod tests {
         let error = HttpError::Http {
             code: 404,
             message: "404 Not Found".to_string(),
-            headers: None,
-            body: Some(vec![]),
+            headers: Box::default(),
+            body: vec![],
         };
         assert_eq!(error.body(), None);
     }
@@ -520,8 +522,8 @@ mod tests {
         let error = HttpError::Http {
             code: 502,
             message: "502 Bad Gateway".to_string(),
-            headers: None,
-            body: Some(b"<html>nginx</html>".to_vec()),
+            headers: Box::default(),
+            body: b"<html>nginx</html>".to_vec(),
         };
         assert!(matches!(
             error.body_json::<serde_json::Value>(),

--- a/crux_http/src/lib.rs
+++ b/crux_http/src/lib.rs
@@ -15,6 +15,11 @@
 //! put in the headers (`Retry-After`, `WWW-Authenticate`) with [`HttpError::header`].
 //! [`Response`] documents the shape to write, and [`testing`] the two values a test
 //! should build.
+//!
+//! `HttpError::Http` means a rejection and nothing else, so [`HttpError::code`] returning
+//! `Some` is the test for one. The crate's own failures are separate variants —
+//! [`HttpError::Json`], [`HttpError::BodyAlreadyTaken`], [`HttpError::InvalidStatusCode`] —
+//! as are the shell's ([`HttpError::Url`], [`HttpError::Io`], [`HttpError::Timeout`]).
 // #![warn(missing_docs)]
 
 mod config;

--- a/crux_http/src/response/raw_response.rs
+++ b/crux_http/src/response/raw_response.rs
@@ -290,13 +290,8 @@ impl TryFrom<HttpResponse> for RawResponse {
             body,
         } = r;
 
-        let status = StatusCode::from_u16(status_u16).map_err(|_| HttpError::Http {
-            code: status_u16,
-            message: format!("invalid HTTP status code: {status_u16}"),
-            // The response never became one, so there are no headers to describe it with.
-            headers: None,
-            body: None,
-        })?;
+        let status = StatusCode::from_u16(status_u16)
+            .map_err(|_| HttpError::InvalidStatusCode(status_u16))?;
 
         let mut headers = HeaderMap::new();
         for header in header_fields {
@@ -391,8 +386,8 @@ mod tests {
             let err = RawResponse::try_from(http_response)
                 .expect_err(&format!("{bad_code} should be rejected"));
             assert!(
-                matches!(err, HttpError::Http { code, .. } if code == bad_code),
-                "expected HttpError::Http with code {bad_code}, got: {err:?}"
+                matches!(err, HttpError::InvalidStatusCode(code) if code == bad_code),
+                "expected HttpError::InvalidStatusCode({bad_code}), got: {err:?}"
             );
         }
     }

--- a/crux_http/src/response/response.rs
+++ b/crux_http/src/response/response.rs
@@ -264,7 +264,8 @@ impl Response<Vec<u8>> {
     ///
     /// # Errors
     ///
-    /// Returns an error if the body has already been taken.
+    /// Returns [`HttpError::BodyAlreadyTaken`] if the body has already been taken — this and
+    /// the other `body_*` readers each take it, so only the first call can succeed.
     ///
     /// # Examples
     ///
@@ -278,17 +279,7 @@ impl Response<Vec<u8>> {
     /// # Ok(()) }
     /// ```
     pub fn body_bytes(&mut self) -> Result<Vec<u8>> {
-        // Deliberately a `match` rather than `ok_or_else`: the closure would have to
-        // capture the cloned headers, cloning them on every successful read too.
-        match self.body.take() {
-            Some(body) => Ok(body),
-            None => Err(HttpError::Http {
-                code: self.status().as_u16(),
-                message: "Body had no bytes".to_string(),
-                headers: Some(Box::new(self.headers.clone())),
-                body: None,
-            }),
-        }
+        self.body.take().ok_or(HttpError::BodyAlreadyTaken)
     }
 
     /// Reads the entire response body into a string.
@@ -557,7 +548,11 @@ mod tests {
         let mut res: Response<Vec<u8>> = ResponseBuilder::ok().body(b"hello".to_vec()).build();
         let _ = res.body_bytes().unwrap();
         let err = res.body_bytes().expect_err("second call must fail");
-        assert!(matches!(err, HttpError::Http { .. }));
+
+        // Not a rejection: the server answered 200. It used to report itself as
+        // `Http { code: 200, .. }`, which made `code()` unusable as a rejection test.
+        assert!(matches!(err, HttpError::BodyAlreadyTaken), "got: {err:?}");
+        assert_eq!(err.code(), None);
     }
 
     #[test]

--- a/crux_http/src/response/response.rs
+++ b/crux_http/src/response/response.rs
@@ -68,8 +68,8 @@ impl<Body> Response<Body> {
             return Err(HttpError::Http {
                 code: status.as_u16(),
                 message: status.to_string(),
-                headers: Some(Box::new(headers)),
-                body: Some(body),
+                headers: Box::new(headers),
+                body,
             });
         }
 

--- a/crux_http/src/testing/rejection.rs
+++ b/crux_http/src/testing/rejection.rs
@@ -124,11 +124,8 @@ mod tests {
         };
         assert_eq!(code, 409);
         assert_eq!(message, "409 Conflict");
-        assert!(
-            headers.expect("a rejection has headers").is_empty(),
-            "rejection() sets no headers"
-        );
-        assert_eq!(body.unwrap(), br#"{"error":"management cycle"}"#);
+        assert!(headers.is_empty(), "rejection() sets no headers");
+        assert_eq!(body, br#"{"error":"management cycle"}"#);
     }
 
     /// `rejection_from` is the header-carrying form, and must agree with `rejection` when

--- a/docs/src/guide/http-rejections.md
+++ b/docs/src/guide/http-rejections.md
@@ -56,7 +56,7 @@ need to destructure the variant:
 
 | Accessor | What you get |
 | --- | --- |
-| `code()` | The status code, e.g. `Some(409)` |
+| `code()` | The status the server rejected with, e.g. `Some(409)` |
 | `body()` | The raw body bytes the server sent, if any |
 | `body_json::<T>()` | That body deserialized — your own error envelope, an RFC 7807 `problem+json` struct, or `serde_json::Value` |
 | `header(name)` | One header, looked up case-insensitively |
@@ -66,6 +66,13 @@ need to destructure the variant:
 Body decoding is skipped for an error status, so the raw error body survives even when
 the request was built with `.expect_json::<T>()` — an error envelope that doesn't match
 `T` still reaches you intact.
+
+`HttpError::Http` is raised for a rejection and nothing else, so `code().is_some()` is the
+test for "the server said no". The crate's own failures have their own variants —
+`Json` (a body that wouldn't deserialize), `BodyAlreadyTaken` (you read the body twice),
+`InvalidStatusCode` (the shell sent a status that isn't valid HTTP) — as do the shell's
+transport failures (`Url`, `Io`, `Timeout`). None of them carry a status, because no server
+chose one.
 
 The headers matter more than they first appear, because some of what an app needs in
 order to *act* on a rejection is only there:


### PR DESCRIPTION
> **Third of three stacked PRs — merge last.** Based on `http-rejection-headers` (#555),
> which is based on `http-rejection-ergonomics` (#554). Merge #554, then #555, then this.

## Why

`HttpError::Http` is documented as "the exchange completed, but the server answered with a
4xx or 5xx" — the one place an app handles a rejection. It wasn't only that. Two other
things constructed it, and after #555 gave the variant headers, both presented as
fully-formed rejections:

| Site | What it really is | What it claimed |
| --- | --- | --- |
| `Response::body_bytes` on an already-taken body | A caller took the body twice | `Http { code: <the success status>, headers: <that response's>, .. }` |
| `RawResponse::try_from` with a status outside 100–999 | The shell is misbehaving | `Http { code: 999, .. }` |

So `error.code()` could return `Some(200)`, and `matches!(err, HttpError::Http { .. })` was
not a reliable test for "the server rejected this". #554 papered over the first case with an
honest-but-awkward `code()` doc — *"`Some` is not by itself proof of a rejection"* — which is
the sort of caveat that means the type is wrong.

Doing it now rather than later: 0.20 is unreleased and #555 already breaks this variant, so
one release absorbs the lot. Adding a variant is breaking regardless, so waiting means a
second break.

## What changed

Two new variants, and `Http` now means a server rejection and nothing else:

```rust
/// The response body had already been taken.
HttpError::BodyAlreadyTaken,
/// The shell sent a status code that is not valid HTTP (outside 100–999).
HttpError::InvalidStatusCode(u16),
```

`code()` therefore gets its invariant back, and it's worth stating plainly: **`Some` if and
only if the server rejected the request.** Nothing else in the crate carries a status.
`InvalidStatusCode` keeps its number, but not via `code()` — it isn't a status any server
answered with.

`BodyAlreadyTaken` deliberately carries nothing. The caller still holds the `Response` (the
method takes `&mut self`), so the status and headers the old error reported were already in
hand — and they described a *successful* response, which is exactly what made them
misleading.

A side benefit: `Response::body_bytes` goes back to one line. #555 had to restructure it to
avoid cloning the `HeaderMap` on every successful read; with no headers to attach there is
nothing to clone.

```rust
self.body.take().ok_or(HttpError::BodyAlreadyTaken)
```

**`From<http_types::Error>` is removed** (second commit, `http-types` feature only). It
mapped a middleware error onto `Http`, and nothing in the crate consumes it — `compat.rs`
converts `Request` and `Response`, not `Error`. It is not rehomed onto a new variant because
the `http-types` feature is slated for removal in full; `http` is the only HTTP type system
`crux_http` will keep. **`mod compat` and the `pub use http_types` re-export deliberately
stay in this PR** and come out in their own change — they're not an oversight.

## Third commit — the payoff

Making `Response::new` the variant's only constructor retires both of its `Option`s: it
always supplied `Some` headers and `Some` body, so those `Option`s described states that
could not arise.

```rust
-    headers: Option<Box<HeaderMap>>,
-    body: Option<Vec<u8>>,
+    headers: Box<HeaderMap>,
+    body: Vec<u8>,
```

This is what the variant-level `#[non_exhaustive]` from #555 was *for*: nothing outside the
crate can construct the variant, so nobody downstream can observe the change. The accessors
keep their signatures, because the other variants still have neither headers nor a body.

`headers()` gets the better contract out of it. It used to need a paragraph explaining that
`None` meant "no response behind this error" while `Some(&empty_map)` meant "a response that
sent no headers" — a distinction that existed only because non-rejections were sharing the
variant. Now `None` means one thing: not a rejection. `body()` is unchanged, still mapping an
empty body to `None`.

Free at runtime, too: `Box` and `Vec` are both niche-optimised, so `HttpError` stays 72 bytes.
The `Option`s were costing nothing and claiming something false.

## The enum stays exhaustive

I had proposed `#[non_exhaustive]` on `HttpError` and talked myself out of it. `crux_http` is
pre-1.0, so every breaking change is already a minor bump — the attribute would buy the
freedom to add variants without a major, which is freedom we already have. What it would cost
is the compile error an app *wants*: if `HttpError` grows a failure mode, code mapping it
onto its own error type should be made to decide what the user sees, not have it land
silently in a wildcard. And after this split the taxonomy looks complete — transport
(`Url`/`Io`/`Timeout`), rejection (`Http`), decode (`Json`), caller error
(`BodyAlreadyTaken`), malformed shell response (`InvalidStatusCode`) — so it would be
flexibility for growth I can't name. Revisit at 1.0, where it has to be settled anyway.

The variant-level `#[non_exhaustive]` on `Http` from #555 is a different question and stays:
it governs *fields*, where patterns already need `..` so no useful compile error is lost, and
where growth is concrete.

## Migration

```rust
// an exhaustive match gains two arms
match error {
    HttpError::Http { code, .. } => …,
    HttpError::Json(msg) => …,
    HttpError::BodyAlreadyTaken => …,          // new
    HttpError::InvalidStatusCode(code) => …,   // new
    HttpError::Url(_) | HttpError::Io(_) | HttpError::Timeout => …,
}

// code that tested Http to mean "rejected" is now correct rather than nearly correct
if let Some(code) = error.code() { /* the server said no */ }
```

Anything already using a wildcard — including this repo's weather example — is unaffected.

The field-type change needs no migration for the same reason `#[non_exhaustive]` exists: you
cannot construct the variant. The one thing that does break is code that *destructures* the
fields and then unwraps them — `HttpError::Http { body, .. } => body.unwrap()` becomes
`=> body`. Prefer `error.body()`, which is unchanged.

## Tests

- `only_a_rejection_has_a_code` pins the invariant across every variant.
- `body_bytes_returns_error_when_body_already_taken` asserts `BodyAlreadyTaken` **and**
  `code() == None`, with a comment recording that it used to report `Http { code: 200 }`.
- `from_http_response_rejects_out_of_range_status` asserts `InvalidStatusCode(code)` for
  `0`, `99`, `1000`, `u16::MAX`.
- `there_are_no_headers_without_a_response` rewritten: the `code: 999` case isn't an `Http`
  at all any more, which is the point.
- `the_new_variants_display_usefully` pins both `Display` strings.

## CI

Green locally: `cargo fmt --check`; `cargo clippy --workspace --all-targets --all-features
-Dpedantic -Dnursery`; `cargo nextest run --workspace --all-features` (241 tests, 112 in
`crux_http`); `cargo test --doc --all-features` (75 doc tests); `cargo doc` with
`-D rustdoc::broken_intra_doc_links`; `mdbook build` with the linkcheck backend; and
`cargo check` for `--features http-types`, `--no-default-features` and
`--target wasm32-unknown-unknown` — the last three because removing that `From` impl is the
kind of change that only breaks under one feature combination.

**FFI surface verified, not assumed.** Both new variants are `#[serde(skip)]` +
`#[facet(skip)]` like `Http`/`Json`, so shells are untouched. I ran the real generator
(`examples/counter-http/shared --bin codegen --language typescript`) and the emitted type is
still exactly:

```ts
export type HttpError =
    | { kind: "Url"; value: str }
    | { kind: "Io"; value: str }
    | { kind: "Timeout" };
```

`size_of::<HttpError>()` is unchanged at 72 bytes, so `clippy::result_large_err` stays quiet
(the crate has no `allow` for it anywhere).
