### PR TITLE
fix(macros): register generic operations through a qualified path

### DIFF
--- a/crux_macros/src/effect/macro_impl.rs
+++ b/crux_macros/src/effect/macro_impl.rs
@@ -341,7 +341,7 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
                 let operation = &effect.operation;
 
                 quote! {
-                    #operation::register_types(generator)?;
+                    <#operation>::register_types(generator)?;
                 }
             });
             quote! {
@@ -365,7 +365,7 @@ pub fn effect_impl(args: Option<Ident>, input: ItemEnum) -> TokenStream {
                 let operation = &effect.operation;
 
                 quote! {
-                    let generator = #operation::register_types_facet(generator)
+                    let generator = <#operation>::register_types_facet(generator)
                         .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(err.to_string()))?;
                 }
             });

--- a/crux_macros/src/effect/tests.rs
+++ b/crux_macros/src/effect/tests.rs
@@ -126,7 +126,7 @@ fn single_with_typegen() {
             generator: &mut ::crux_core::type_generation::serde::TypeGen,
         ) -> ::crux_core::type_generation::serde::Result {
             use ::crux_core::capability::Operation;
-            RenderOperation::register_types(generator)?;
+            <RenderOperation>::register_types(generator)?;
             generator.register_type::<EffectFfi>()?;
             generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
             Ok(())
@@ -238,7 +238,7 @@ fn single_with_new_name() {
             generator: &mut ::crux_core::type_generation::serde::TypeGen,
         ) -> ::crux_core::type_generation::serde::Result {
             use ::crux_core::capability::Operation;
-            RenderOperation::register_types(generator)?;
+            <RenderOperation>::register_types(generator)?;
             generator.register_type::<MyEffectFfi>()?;
             generator.register_type::<::crux_core::bridge::Request<MyEffectFfi>>()?;
             Ok(())
@@ -359,7 +359,7 @@ fn single_with_facet_typegen() {
             ::crux_core::type_generation::facet::TypeGenError,
         > {
             use ::crux_core::capability::Operation;
-            let generator = RenderOperation::register_types_facet(generator)
+            let generator = <RenderOperation>::register_types_facet(generator)
                 .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
                     err.to_string(),
                 ))?;
@@ -494,7 +494,7 @@ fn single_facet_typegen_with_new_name() {
             ::crux_core::type_generation::facet::TypeGenError,
         > {
             use ::crux_core::capability::Operation;
-            let generator = RenderOperation::register_types_facet(generator)
+            let generator = <RenderOperation>::register_types_facet(generator)
                 .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
                     err.to_string(),
                 ))?;
@@ -767,8 +767,8 @@ fn multiple_with_typegen() {
             generator: &mut ::crux_core::type_generation::serde::TypeGen,
         ) -> ::crux_core::type_generation::serde::Result {
             use ::crux_core::capability::Operation;
-            RenderOperation::register_types(generator)?;
-            HttpRequest::register_types(generator)?;
+            <RenderOperation>::register_types(generator)?;
+            <HttpRequest>::register_types(generator)?;
             generator.register_type::<EffectFfi>()?;
             generator.register_type::<::crux_core::bridge::Request<EffectFfi>>()?;
             Ok(())
@@ -952,11 +952,11 @@ fn multiple_with_facet_typegen() {
             ::crux_core::type_generation::facet::TypeGenError,
         > {
             use ::crux_core::capability::Operation;
-            let generator = RenderOperation::register_types_facet(generator)
+            let generator = <RenderOperation>::register_types_facet(generator)
                 .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
                     err.to_string(),
                 ))?;
-            let generator = HttpRequest::register_types_facet(generator)
+            let generator = <HttpRequest>::register_types_facet(generator)
                 .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
                     err.to_string(),
                 ))?;
@@ -1323,7 +1323,7 @@ fn facet_typegen_with_namespace_attribute() {
             ::crux_core::type_generation::facet::TypeGenError,
         > {
             use ::crux_core::capability::Operation;
-            let generator = RenderOperation::register_types_facet(generator)
+            let generator = <RenderOperation>::register_types_facet(generator)
                 .map_err(|err| ::crux_core::type_generation::facet::TypeGenError::Generation(
                     err.to_string(),
                 ))?;
@@ -1344,4 +1344,35 @@ fn facet_typegen_with_namespace_attribute() {
         }
     }
     "#);
+}
+
+/// A generic operation type has to be registered through a *qualified* path.
+///
+/// `#operation` is a `syn::Type`, and every other use of it in the expansion is
+/// in type position, where a generic argument list is unambiguous. These two are
+/// in expression position, where `Navigate<Route>::register_types(generator)`
+/// parses as a chain of comparisons instead — the generated code does not
+/// compile, and the error surfaces inside macro output rather than at the
+/// definition. `<Navigate<Route>>::register_types(generator)` parses for any
+/// type, generic or not.
+///
+/// `pretty_print` parses the expansion, so this test panics rather than fails
+/// when the qualification is missing.
+#[test]
+fn a_generic_operation_registers_through_a_qualified_path() {
+    for kind in ["typegen", "facet_typegen"] {
+        let args = Some(format_ident!("{}", kind));
+        let input = parse_quote! {
+            pub enum Effect {
+                Navigate(Navigate<Route>),
+            }
+        };
+
+        let expanded = pretty_print(&effect_impl(args, input));
+
+        assert!(
+            expanded.contains("<Navigate<Route>>::register_types"),
+            "{kind} should register a generic operation through a qualified path:\n{expanded}"
+        );
+    }
 }


### PR DESCRIPTION
`#[effect]` interpolates each variant's operation type into *expression* position when generating the typegen `register_types` impls:

```rust
#operation::register_types(generator)?;
```

For a bare path that is fine, which is why this has never surfaced — every operation in this repo is one. For a generic operation it is not: `Navigate<Route>::register_types(generator)` parses as a chain of comparisons, so an app that declares one gets a syntax error pointing into macro output rather than at its own code.

Qualified-path syntax parses for any type, generic or not:

```rust
<#operation>::register_types(generator)?;
```

Both typegen paths were affected, serde and facet. Every *other* use of `#operation` in the expansion is in type position, where a generic argument list is unambiguous — and where the macro already reaches for the qualified form (`<#operation as Operation>::Output`).

## Why it matters

A generic operation lets a capability stay app-agnostic while the app decides what its payload carries — e.g. a navigation capability whose location type is the app's own route type. Today that is only reachable via a type alias:

```rust
pub type NavigateOperation = Navigate<Route>;  // works: a bare path again
```

## Testing

New test `a_generic_operation_registers_through_a_qualified_path` expands an effect enum with a generic operation under both typegen kinds. `pretty_print` parses the expansion, so it panics rather than merely failing when the qualification is missing — verified by reverting the fix.

Seven existing snapshots shift to the qualified form. `just ci` passes.