### PR TITLE
fix(core): don't reuse bridge effect ids, and don't retain fire-and-forget requests

### DIFF
--- a/crux_core/CHANGELOG.md
+++ b/crux_core/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+
+- **A resolved request's `EffectId` is no longer handed to a later request.** Ids were
+  slab indices, and the slab reused an index as soon as its request completed. If a shell
+  resolved an id twice — a retry, a race, a bug — the second resolve landed on whichever
+  unrelated request had inherited the slot. When the two outputs happened to deserialize
+  compatibly, which two HTTP requests generally do, it succeeded silently and delivered
+  one request's response to another.
+
+  Ids are now issued in ascending order and not reused, so resolving a completed request
+  is a lookup miss:
+
+  ```
+  Err(BridgeError::ProcessResponse(ResolveError::NotFound(id)))
+  ```
+
+  Nothing changes for a shell that resolves each request once. The counter wraps after
+  `u32::MAX` requests and steps over any id still outstanding, so a live request cannot
+  be displaced even then. `EffectId` is unchanged on the wire — still a transparent
+  `u32` — so no generated types or shell code are affected.
+
+  This also removes the `EffectId overflow` panic: ids are `u32` by construction rather
+  than a `usize` slab index narrowed on the way out.
+
 ## [0.19.0](https://github.com/redbadger/crux/compare/crux_core-v0.18.0...crux_core-v0.19.0) - 2026-06-08
 
 ### 🚀 Features

--- a/crux_core/CHANGELOG.md
+++ b/crux_core/CHANGELOG.md
@@ -32,6 +32,36 @@ and this project adheres to
   This also removes the `EffectId overflow` panic: ids are `u32` by construction rather
   than a `usize` slab index narrowed on the way out.
 
+- **Fire-and-forget requests no longer accumulate in the bridge registry.** Every effect
+  was registered so that the shell could resolve it later, but a fire-and-forget request
+  — `Render`, most of all — has no continuation and is never resolved, and only a resolve
+  removed an entry. So each one occupied a registry slot for the life of the process:
+  five `Trigger` events in a row produced render ids `[0, 1, 2, 3, 4]`, never reusing a
+  slot, because none was ever freed. An app rendering ten times a second leaked roughly a
+  megabyte a day.
+
+  Such a request now takes an id, as before, but stores nothing.
+
+  The observable difference is the error from resolving one. It used to report
+
+  ```
+  Attempted to resolve a request that is not expected to be resolved.
+  ```
+
+  and now reports
+
+  ```
+  Request with id 0 not found.
+  ```
+
+  `ResolveError::Never` is therefore no longer reachable through the bridge; it remains
+  in the enum, and is still produced by the `Core` API. Only a shell resolving an id it
+  was never meant to resolve sees either message.
+
+  Streaming requests still hold their entry after the stream ends — the registry is not
+  told when a `Many` finishes. That needs `ResolveSerialized` to report completion, and
+  is left for its own change.
+
 ## [0.19.0](https://github.com/redbadger/crux/compare/crux_core-v0.18.0...crux_core-v0.19.0) - 2026-06-08
 
 ### 🚀 Features

--- a/crux_core/src/bridge/registry.rs
+++ b/crux_core/src/bridge/registry.rs
@@ -78,7 +78,12 @@ impl<T: FfiFormat> ResolveRegistry<T> {
             let mut outstanding = self.0.lock().expect("Registry Mutex poisoned.");
             let id = outstanding.issue_id();
 
-            outstanding.entries.insert(id, resolve);
+            // A request that cannot be resolved has nothing worth keeping: storing
+            // one would add an entry per fire-and-forget effect — every render, for
+            // the life of the process — that nothing would ever remove.
+            if !matches!(resolve, ResolveSerialized::Never) {
+                outstanding.entries.insert(id, resolve);
+            }
 
             id
         };
@@ -92,8 +97,9 @@ impl<T: FfiFormat> ResolveRegistry<T> {
 
     /// Resume a previously registered effect.
     ///
-    /// Fails with [`ResolveError::NotFound`] if `id` is not outstanding, either
-    /// because it was never issued or because it has already been resolved.
+    /// Fails with [`ResolveError::NotFound`] if `id` is not outstanding —
+    /// because it was never issued, because it has already been resolved, or
+    /// because it belongs to a request that never expected a response.
     ///
     /// # Errors
     ///

--- a/crux_core/src/bridge/registry.rs
+++ b/crux_core/src/bridge/registry.rs
@@ -1,24 +1,59 @@
+use std::collections::HashMap;
 use std::sync::Mutex;
 
 use facet::Facet;
 use serde::{Deserialize, Serialize};
-use slab::Slab;
 
 use super::{BridgeError, FfiFormat, Request};
 use crate::bridge::request_serde::ResolveSerialized;
 use crate::{EffectFFI, ResolveError};
 
+/// Identifies one request across the FFI boundary, for as long as anything
+/// could still refer to it.
+///
+/// Ids are issued in ascending order and are not reused when a request
+/// completes, so an id that has been resolved stays unusable rather than being
+/// handed to some unrelated later request.
 #[allow(clippy::unsafe_derive_deserialize)]
 #[derive(Facet, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 #[facet(transparent)]
 pub struct EffectId(pub u32);
 
-pub struct ResolveRegistry<T: FfiFormat>(Mutex<Slab<ResolveSerialized<T>>>);
+pub struct ResolveRegistry<T: FfiFormat>(Mutex<Outstanding<T>>);
+
+/// The requests the shell could still resolve, keyed by the id it was given.
+struct Outstanding<T: FfiFormat> {
+    entries: HashMap<u32, ResolveSerialized<T>>,
+    next_id: u32,
+}
+
+impl<T: FfiFormat> Outstanding<T> {
+    /// Issue the next id.
+    ///
+    /// Ids ascend rather than filling gaps, so resolving a completed request is
+    /// a lookup miss instead of a hit on whichever request happened to inherit
+    /// its storage. The counter wraps after `u32::MAX` requests; ids still
+    /// outstanding are stepped over, so a live request can never be displaced
+    /// even then.
+    fn issue_id(&mut self) -> u32 {
+        loop {
+            let id = self.next_id;
+            self.next_id = self.next_id.wrapping_add(1);
+
+            if !self.entries.contains_key(&id) {
+                return id;
+            }
+        }
+    }
+}
 
 impl<T: FfiFormat> Default for ResolveRegistry<T> {
     fn default() -> Self {
-        Self(Mutex::new(Slab::with_capacity(1024)))
+        Self(Mutex::new(Outstanding {
+            entries: HashMap::new(),
+            next_id: 0,
+        }))
     }
 }
 
@@ -31,9 +66,7 @@ impl<T: FfiFormat> ResolveRegistry<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the internal mutex has been poisoned, or if we've run out of
-    /// available effect IDs
-    // used in docs/internals/bridge.md
+    /// Panics if the internal mutex has been poisoned
     // ANCHOR: register
     pub fn register<Eff>(&self, effect: Eff) -> Request<Eff::Ffi>
     where
@@ -41,21 +74,26 @@ impl<T: FfiFormat> ResolveRegistry<T> {
     {
         let (effect, resolve) = effect.serialize();
 
-        let id = self
-            .0
-            .lock()
-            .expect("Registry Mutex poisoned.")
-            .insert(resolve);
+        let id = {
+            let mut outstanding = self.0.lock().expect("Registry Mutex poisoned.");
+            let id = outstanding.issue_id();
+
+            outstanding.entries.insert(id, resolve);
+
+            id
+        };
 
         Request {
-            id: EffectId(id.try_into().expect("EffectId overflow")),
+            id: EffectId(id),
             effect,
         }
     }
     // ANCHOR_END: register
 
-    /// Resume a previously registered effect. This may fail, either because `EffectId` wasn't
-    /// found or because this effect was not expected to be resumed again.
+    /// Resume a previously registered effect.
+    ///
+    /// Fails with [`ResolveError::NotFound`] if `id` is not outstanding, either
+    /// because it was never issued or because it has already been resolved.
     ///
     /// # Errors
     ///
@@ -65,11 +103,9 @@ impl<T: FfiFormat> ResolveRegistry<T> {
     ///
     /// Panics if the internal mutex has been poisoned
     pub fn resume(&self, id: EffectId, response: &[u8]) -> Result<(), BridgeError<T>> {
-        let mut registry_lock = self.0.lock().expect("Registry Mutex poisoned");
+        let mut outstanding = self.0.lock().expect("Registry Mutex poisoned");
 
-        let entry = registry_lock.get_mut(id.0 as usize);
-
-        let Some(entry) = entry else {
+        let Some(entry) = outstanding.entries.get_mut(&id.0) else {
             return Err(BridgeError::ProcessResponse(ResolveError::NotFound(
                 id.0.into(),
             )));
@@ -77,10 +113,55 @@ impl<T: FfiFormat> ResolveRegistry<T> {
 
         let resolved = entry.resolve(response);
 
+        // A `Once` turns itself into a `Never` as it resolves: the request is
+        // finished, and its id will not be issued again, so drop it.
         if matches!(entry, ResolveSerialized::Never) {
-            registry_lock.remove(id.0 as usize);
+            outstanding.entries.remove(&id.0);
         }
 
         resolved
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Outstanding, ResolveSerialized};
+    use crate::bridge::JsonFfiFormat;
+    use std::collections::HashMap;
+
+    fn outstanding(next_id: u32) -> Outstanding<JsonFfiFormat> {
+        Outstanding {
+            entries: HashMap::new(),
+            next_id,
+        }
+    }
+
+    #[test]
+    fn ids_ascend_and_are_never_reused() {
+        let mut outstanding = outstanding(0);
+
+        let ids: Vec<_> = (0..4).map(|_| outstanding.issue_id()).collect();
+        assert_eq!(ids, vec![0, 1, 2, 3]);
+
+        // Finishing a request frees its entry, but not its id.
+        outstanding.entries.remove(&1);
+
+        assert_eq!(outstanding.issue_id(), 4);
+    }
+
+    #[test]
+    fn wrapping_steps_over_outstanding_ids() {
+        let mut outstanding = outstanding(u32::MAX);
+
+        // Still awaiting a response on 0 and 1 when the counter comes round.
+        outstanding.entries.insert(0, ResolveSerialized::Never);
+        outstanding.entries.insert(1, ResolveSerialized::Never);
+
+        assert_eq!(outstanding.issue_id(), u32::MAX);
+        assert_eq!(
+            outstanding.issue_id(),
+            2,
+            "wrapping displaced a request that was still outstanding"
+        );
     }
 }

--- a/crux_core/tests/json_bridge.rs
+++ b/crux_core/tests/json_bridge.rs
@@ -14,6 +14,11 @@ mod app {
     pub enum Event {
         Trigger,
         Get,
+        /// Like `Get`, but settles without emitting a follow-up effect, so the
+        /// request's registry slot is left free rather than immediately taken
+        /// by the render that `Get` would cause.
+        GetQuietly,
+        Settle,
     }
 
     #[effect(typegen)]
@@ -36,6 +41,10 @@ mod app {
                 Event::Get => Http::get("http://example.com/")
                     .build()
                     .then_send(|_| Event::Trigger),
+                Event::GetQuietly => Http::get("http://example.com/")
+                    .build()
+                    .then_send(|_| Event::Settle),
+                Event::Settle => Command::done(),
             }
         }
 
@@ -57,7 +66,11 @@ mod tests {
     use crate::app::EffectFfi;
 
     use super::core::Bridge;
-    use crux_core::{Core, bridge::Request};
+    use crux_core::{
+        Core,
+        bridge::{EffectId, Request},
+    };
+    use crux_http::protocol::{HttpResponse, HttpResult};
     use serde_json::Value;
 
     #[test]
@@ -114,7 +127,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "could not deserialize event: unknown variant `Nopes`, expected `Trigger` or `Get` at line 1 column 7"
+            "could not deserialize event: unknown variant `Nopes`, expected one of `Trigger`, `Get`, `GetQuietly`, `Settle` at line 1 column 7"
         );
     }
 
@@ -202,5 +215,76 @@ mod tests {
             error.to_string(),
             "could not deserialize provided effect output: expected value at line 1 column 1"
         );
+    }
+
+    /// An id identifies one request for the lifetime of the bridge, and is never
+    /// handed out again once that request has been resolved.
+    ///
+    /// Ids used to be slab indices, which the slab reused the moment a request
+    /// completed. A shell that resolved an id twice — a retry, a race, a bug —
+    /// would then resolve whichever *unrelated* request had inherited the slot,
+    /// and if the two outputs happened to deserialize compatibly (two HTTP
+    /// requests, say) it succeeded silently.
+    #[test]
+    fn ids_are_not_reused_after_a_request_resolves() {
+        let bridge = Bridge::new(Core::default());
+
+        let first = request_http(&bridge);
+        resolve_http(&bridge, first.id).expect("first resolve should work");
+
+        // The slot backing `first` is now free.
+        let second = request_http(&bridge);
+
+        assert_ne!(
+            first.id, second.id,
+            "a resolved request's id was handed out again"
+        );
+    }
+
+    #[test]
+    fn resolving_a_request_twice_is_an_error() {
+        let bridge = Bridge::new(Core::default());
+
+        let first = request_http(&bridge);
+        resolve_http(&bridge, first.id).expect("first resolve should work");
+
+        // A second request, which previously inherited `first`'s slot and so
+        // received the duplicate resolve below.
+        let _second = request_http(&bridge);
+
+        let Err(error) = resolve_http(&bridge, first.id) else {
+            panic!("expected resolving a completed request to fail");
+        };
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "could not process response: Request with id {} not found.",
+                first.id.0
+            )
+        );
+    }
+
+    fn request_http(bridge: &Bridge) -> Request<EffectFfi> {
+        let mut effects_bytes = vec![];
+        bridge
+            .update(b"\"GetQuietly\"", &mut effects_bytes)
+            .expect("event should process");
+
+        let mut effects: Vec<Request<EffectFfi>> =
+            serde_json::from_slice(&effects_bytes).expect("to deserialise");
+
+        effects.remove(0)
+    }
+
+    fn resolve_http(
+        bridge: &Bridge,
+        id: EffectId,
+    ) -> Result<(), crux_core::bridge::BridgeError<crux_core::bridge::JsonFfiFormat>> {
+        let response = HttpResult::Ok(HttpResponse::ok().body("hello").build());
+        let response = serde_json::to_vec(&response).expect("to serialise");
+
+        let mut effects_bytes = vec![];
+        bridge.resolve(id, &response, &mut effects_bytes)
     }
 }

--- a/crux_core/tests/json_bridge.rs
+++ b/crux_core/tests/json_bridge.rs
@@ -151,8 +151,11 @@ mod tests {
         );
     }
 
+    /// A fire-and-forget request has no continuation to store, so its id is
+    /// simply not outstanding — resolving it is the same "not found" as
+    /// resolving an id that was never issued.
     #[test]
-    fn resolve_error() {
+    fn resolve_fire_and_forget() {
         let bridge = Bridge::new(Core::default());
         let event = b"\"Trigger\"";
 
@@ -180,7 +183,7 @@ mod tests {
 
         assert_eq!(
             error.to_string(),
-            "could not process response: Attempted to resolve a request that is not expected to be resolved."
+            "could not process response: Request with id 0 not found."
         );
     }
 


### PR DESCRIPTION
Two bugs in the bridge's resolve registry, found while looking at the two
public types called `EffectId`. Both are in the same ~90-line file, and the
second is only fixable once the first is.

Intended for **0.20.0**, merged ahead of the release prep PR (#565) rather than
stacked on it, so it can be reviewed on its own. #565's changelog currently
promises that `crux_core`'s behaviour is unchanged from 0.19.0; that wording
needs correcting when it rebases onto this.

## 1. A resolved request's id was handed to a later request

`EffectId`s were slab indices, and the slab reused an index the moment its
request completed. A shell that resolved an id twice — a retry, a race, a bug —
had its second resolve land on whichever unrelated request had inherited the
slot. If the two outputs deserialized compatibly, which two HTTP requests
generally do, it succeeded **silently**, delivering one request's response to
another.

`tests/json_bridge.rs` demonstrates it. With an app whose HTTP resolution
settles without a follow-up effect, the second request is handed `EffectId(0)`
again, and resolving the first id a second time returns `Ok`:

```
assertion `left != right` failed: a resolved request's id was handed out again
  left: EffectId(0)
 right: EffectId(0)
```

Ids are now issued from an ascending counter, with outstanding requests in a
`HashMap<u32, _>` keyed by that id, so a completed request's id is a lookup miss
rather than a hit on its successor — `ResolveError::NotFound`, the error already
returned for an id that was never issued.

**Why not generational ids?** `effects::registry` already solves this that way:
a 32-bit generation beside a 32-bit index in an opaque `u64`, with
`Storage::take` rejecting a stale one. The bridge can't afford it — its id is a
`u32` on the wire. Splitting those bits (say 22 index, 10 generation) buys only
1024 reuses of a slot before the generation wraps; widening to `u64` changes the
FFI type every shell passes. Spending all 32 bits on identity and detecting
reuse by absence needs no wire change at all.

The counter wraps after `u32::MAX` requests and steps over any id still
outstanding, so a live request can't be displaced even then — unit-tested, since
no integration test can reach that path. The `EffectId overflow` panic is gone
too: ids are `u32` by construction rather than a `usize` slab index narrowed on
the way out.

## 2. Fire-and-forget requests were never released

Every effect was registered so the shell could resolve it later, but a
fire-and-forget request has no continuation, and only a resolve removed an
entry — which for these never comes. So each one held a registry slot for the
life of the process. `Render` is one of them, so that's a leaked entry **per UI
update, forever**.

It's visible in the ids: five `Trigger` events in a row produced render ids
`[0, 1, 2, 3, 4]` under the old slab. The slab always hands out the lowest
vacant index, so ids that never repeat prove nothing was ever freed. An app
rendering ten times a second leaks on the order of a megabyte a day, and marches
toward exhausting the id space.

Such a request now takes an id, so the shell still sees one on the `Request`,
but stores nothing.

### The one observable change

Resolving a fire-and-forget id used to report

> Attempted to resolve a request that is not expected to be resolved.

and now reports

> Request with id 0 not found.

There's no longer an entry to tell those cases apart. `ResolveError::Never`
stays in the enum and is still produced by the `Core` API. Only a shell
resolving an id it was never meant to resolve sees either message.

## Not fixed here

A streaming (`Many`) request keeps its entry after the stream ends, because
nothing tells the registry a stream has finished. That needs `ResolveSerialized`
to report completion — a change to the resolve plumbing rather than to storage
policy — so it belongs in its own PR.

## Verification

- `cargo nextest run --all-features`: 246 tests (242 + 4 new)
- clippy clean across the workspace with `--all-features --all-targets`
- doctests, `cargo fmt --check`
- `cargo nextest run --all-features` in all six example workspaces

Both new integration tests fail on `master` in exactly the way described above,
and the two unit tests cover the id policy including the wrap path.
