### PR TITLE
refactor(core)!: rename effects::EffectId to ParkedEffectId

### DIFF
--- a/crux_core/CHANGELOG.md
+++ b/crux_core/CHANGELOG.md
@@ -8,6 +8,40 @@ and this project adheres to
 
 ## [Unreleased]
 
+### 💥 Breaking Changes
+
+- **`crux_core::effects::EffectId` is renamed to `ParkedEffectId`.** There were two public
+  types called `EffectId`, and they are not interchangeable:
+
+  | | `crux_core::bridge::EffectId` | was `crux_core::effects::EffectId<T>` |
+  | --- | --- | --- |
+  | Shape | `pub struct EffectId(pub u32)` | opaque `u64`, phantom-typed by `Op::Output` |
+  | Contents | a slab index | slab index **and** generation |
+  | Used by | every shell, on the serialized lane | the `Parked` lane only |
+
+  A shell wiring up both lanes needs both in scope, so one of them has to be aliased —
+  as `crux_core`'s own routing test had to do. The `Parked` one is renamed because it is
+  the newer of the two (0.19.0), is used by no example, and reaches only the handful of
+  people using a custom FFI lane; `EffectId` stays the name of the id in `Request`, which
+  every integration already writes as `EffectId(id)`.
+
+  If you resolve a parked request, rename the type at your call site — the API is
+  otherwise unchanged:
+
+  ```rust
+  // before
+  use crux_core::effects::EffectId;
+  camera.resolve(EffectId::from_raw(id), output)?;
+
+  // after
+  use crux_core::effects::ParkedEffectId;
+  camera.resolve(ParkedEffectId::from_raw(id), output)?;
+  ```
+
+  Nothing crosses the FFI differently: `bridge::EffectId` is `#[serde(transparent)]` and
+  `#[facet(transparent)]`, so generated Swift, Kotlin, TypeScript and C# see a plain
+  `u32` and are unaffected by either name.
+
 ### 🐛 Bug Fixes
 
 - **A resolved request's `EffectId` is no longer handed to a later request.** Ids were

--- a/crux_core/src/effects/mod.rs
+++ b/crux_core/src/effects/mod.rs
@@ -26,7 +26,7 @@
 //! - [`Parked`](routes::Parked) supports payloads and results that are awkward
 //!   or undesirable to serialize (for example opaque pointer-style handles),
 //!   using a custom, user-owned FFI. The request is parked under an
-//!   [`EffectId`] which the shell passes back when resolving.
+//!   [`ParkedEffectId`] which the shell passes back when resolving.
 //! - [`Buffer`](routes::Buffer) collects requests for the caller to drain and
 //!   handle synchronously, which is useful in tests and simple in-process
 //!   handlers.
@@ -55,7 +55,7 @@ use std::sync::{Arc, Weak};
 
 use crate::{Core, Request, Resolvable, ResolveError, capability::Operation};
 
-pub use registry::EffectId;
+pub use registry::ParkedEffectId;
 
 /// Wraps a [`Core`] and routes each emitted effect to a type-specific handler.
 ///

--- a/crux_core/src/effects/registry.rs
+++ b/crux_core/src/effects/registry.rs
@@ -4,14 +4,14 @@ mod storage;
 use std::sync::Mutex;
 
 use crate::{Request, RequestHandle, ResolveError, capability::Operation};
-pub use effect_id::EffectId;
+pub use effect_id::ParkedEffectId;
 
-/// Stores parked effect requests under an [`EffectId`] so they can be resolved
+/// Stores parked effect requests under a [`ParkedEffectId`] so they can be resolved
 /// later, possibly after the request handle has crossed a custom FFI boundary.
 ///
 /// A [`Request`] holds a [`RequestHandle`] continuation that cannot itself cross
 /// an FFI boundary. The registry keeps that continuation on the Rust side and
-/// hands out an opaque [`EffectId`] in its place; the shell passes the id back
+/// hands out an opaque [`ParkedEffectId`] in its place; the shell passes the id back
 /// when it has a result, and [`Registry::resolve`] reconnects it with the parked
 /// handle.
 ///
@@ -42,7 +42,7 @@ where
     ///
     /// Panics if the lock around the underlying storage was poisoned, or if the
     /// storage index exceeds the available ID space.
-    pub fn register(&self, request: Request<Op>) -> (EffectId<Op::Output>, Op) {
+    pub fn register(&self, request: Request<Op>) -> (ParkedEffectId<Op::Output>, Op) {
         let (operation, handle) = request.split();
         let id = self
             .requests
@@ -65,7 +65,7 @@ where
     /// Panics if the lock around the underlying storage was poisoned.
     pub fn resolve(
         &self,
-        id: EffectId<Op::Output>,
+        id: ParkedEffectId<Op::Output>,
         output: Op::Output,
     ) -> Result<(), ResolveError> {
         let mut handle = self

--- a/crux_core/src/effects/registry/effect_id.rs
+++ b/crux_core/src/effects/registry/effect_id.rs
@@ -14,25 +14,25 @@ const INDEX_MASK: u64 = u32::MAX as u64;
 /// callers can pass it over custom FFI boundaries without learning the storage
 /// layout.
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub struct EffectId<T = ()> {
+pub struct ParkedEffectId<T = ()> {
     pub(crate) raw: u64,
     pub(crate) phantom: PhantomData<fn(T) -> T>,
 }
 
-impl<T> Clone for EffectId<T> {
+impl<T> Clone for ParkedEffectId<T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<T> Copy for EffectId<T> {}
+impl<T> Copy for ParkedEffectId<T> {}
 
-impl<T> EffectId<T> {
-    /// Reconstruct an `EffectId` from its raw integer representation.
+impl<T> ParkedEffectId<T> {
+    /// Reconstruct a `ParkedEffectId` from its raw integer representation.
     ///
     /// Use this on the resolve path to turn an id received back from a custom
-    /// FFI (as a plain integer) into a typed `EffectId`. The `raw` value must be
-    /// one previously produced by [`EffectId::into_raw`]; arbitrary integers may
+    /// FFI (as a plain integer) into a typed `ParkedEffectId`. The `raw` value must be
+    /// one previously produced by [`ParkedEffectId::into_raw`]; arbitrary integers may
     /// refer to no request, or to a stale slot.
     #[must_use]
     pub const fn from_raw(raw: u64) -> Self {
@@ -46,7 +46,7 @@ impl<T> EffectId<T> {
     /// custom FFI boundary.
     ///
     /// The returned value packs both the slab index and the generation, and can
-    /// be turned back into an `EffectId` with [`EffectId::from_raw`].
+    /// be turned back into a `ParkedEffectId` with [`ParkedEffectId::from_raw`].
     #[must_use]
     pub const fn into_raw(self) -> u64 {
         self.raw

--- a/crux_core/src/effects/registry/storage.rs
+++ b/crux_core/src/effects/registry/storage.rs
@@ -18,7 +18,7 @@ impl<Out> Default for Storage<Out> {
 }
 
 impl<Out> Storage<Out> {
-    pub(crate) fn insert(&mut self, handle: RequestHandle<Out>) -> effect_id::EffectId<Out> {
+    pub(crate) fn insert(&mut self, handle: RequestHandle<Out>) -> effect_id::ParkedEffectId<Out> {
         let entry = self.handles.vacant_entry();
         let index = entry.key();
 
@@ -30,10 +30,13 @@ impl<Out> Storage<Out> {
         let generation = self.generations[index];
         entry.insert(Some(handle));
 
-        effect_id::EffectId::new(index, generation)
+        effect_id::ParkedEffectId::new(index, generation)
     }
 
-    pub(crate) fn take(&mut self, id: effect_id::EffectId<Out>) -> Option<RequestHandle<Out>> {
+    pub(crate) fn take(
+        &mut self,
+        id: effect_id::ParkedEffectId<Out>,
+    ) -> Option<RequestHandle<Out>> {
         if self.generations.get(id.index()).copied()? != id.generation() {
             return None;
         }
@@ -41,7 +44,11 @@ impl<Out> Storage<Out> {
         self.handles.get_mut(id.index())?.take()
     }
 
-    pub(crate) fn reinsert(&mut self, id: effect_id::EffectId<Out>, handle: RequestHandle<Out>) {
+    pub(crate) fn reinsert(
+        &mut self,
+        id: effect_id::ParkedEffectId<Out>,
+        handle: RequestHandle<Out>,
+    ) {
         let Some(entry) = self.handles.get_mut(id.index()) else {
             return;
         };
@@ -52,7 +59,7 @@ impl<Out> Storage<Out> {
         *entry = Some(handle);
     }
 
-    pub(crate) fn remove(&mut self, id: effect_id::EffectId<Out>) {
+    pub(crate) fn remove(&mut self, id: effect_id::ParkedEffectId<Out>) {
         if self.generations.get(id.index()).copied() != Some(id.generation()) {
             return;
         }

--- a/crux_core/src/effects/routes/mod.rs
+++ b/crux_core/src/effects/routes/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! - [`Serialized`] is the default, bridge-like lane that exchanges bytes with
 //!   the shell.
-//! - [`Parked`] holds requests under an [`EffectId`](super::EffectId) for a
+//! - [`Parked`] holds requests under a [`ParkedEffectId`](super::ParkedEffectId) for a
 //!   custom, user-owned FFI carrying opaque or non-serializable data.
 //! - [`Buffer`] collects requests for the caller to drain and handle in process.
 

--- a/crux_core/src/effects/routes/parked.rs
+++ b/crux_core/src/effects/routes/parked.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Weak};
 use crate::{
     Request, ResolveError,
     capability::Operation,
-    effects::{EffectId, EffectRouter, Routes, registry::Registry},
+    effects::{EffectRouter, ParkedEffectId, Routes, registry::Registry},
 };
 
 /// A route for effects handled over a custom, user-owned FFI.
@@ -11,7 +11,7 @@ use crate::{
 /// The "opaque typed" lane is for operations whose payloads or results are
 /// awkward or undesirable to serialize, such as pointer-style handles or large
 /// non-serializable buffers. Instead of bytes, the request is *parked* under an
-/// [`EffectId`] with [`Parked::park`], and the shell receives that id together
+/// [`ParkedEffectId`] with [`Parked::park`], and the shell receives that id together
 /// with the (typed) operation. When the shell has a result, it calls
 /// [`Parked::resolve`] with the id and the typed output.
 ///
@@ -57,7 +57,7 @@ where
     /// been poisoned.
     pub fn resolve(
         &self,
-        id: EffectId<Op::Output>,
+        id: ParkedEffectId<Op::Output>,
         output: Op::Output,
     ) -> Result<(), ResolveError> {
         self.registry.resolve(id, output)?;
@@ -83,7 +83,7 @@ where
     ///
     /// Panics if the internal registry lock has been poisoned.
     #[must_use]
-    pub fn park(&self, request: Request<Op>) -> (EffectId<Op::Output>, Op) {
+    pub fn park(&self, request: Request<Op>) -> (ParkedEffectId<Op::Output>, Op) {
         let (id, operation) = self.registry.register(request);
 
         (id, operation)

--- a/crux_core/tests/effect_router_prototype.rs
+++ b/crux_core/tests/effect_router_prototype.rs
@@ -229,9 +229,9 @@ mod app {
 mod ffi {
     use crux_core::{
         Core,
-        bridge::{EffectId as BridgeEffectId, FfiFormat, JsonFfiFormat, Request as BridgeRequest},
+        bridge::{EffectId, FfiFormat, JsonFfiFormat, Request as BridgeRequest},
         effects::{
-            EffectId, EffectRouter, Routes,
+            EffectRouter, ParkedEffectId, Routes,
             routes::{Parked, Serialized},
         },
         render::RenderOperation,
@@ -375,7 +375,7 @@ mod ffi {
             self.router
                 .routes
                 .serialized
-                .resolve(BridgeEffectId(id), data)
+                .resolve(EffectId(id), data)
                 .expect("serialized resolve should work");
         }
 
@@ -384,7 +384,7 @@ mod ffi {
             self.router
                 .routes
                 .camera
-                .resolve(EffectId::from_raw(id), output)
+                .resolve(ParkedEffectId::from_raw(id), output)
                 .expect("camera resolve should work");
         }
 


### PR DESCRIPTION
There are two public types called `EffectId`, and they are not interchangeable:

|  | `crux_core::bridge::EffectId` | `crux_core::effects::EffectId<T>` |
| --- | --- | --- |
| Shape | `pub struct EffectId(pub u32)` | opaque `u64`, phantom-typed by `Op::Output` |
| Contents | a slab index | slab index **and** generation |
| Used by | every shell, on the serialized lane | the `Parked` lane only |

A shell wiring up both lanes needs both in scope, so one of them has to be
aliased. `crux_core`'s own routing test already had to:

```rust
bridge::{EffectId as BridgeEffectId, FfiFormat, JsonFfiFormat, Request as BridgeRequest},
effects::{EffectId, EffectRouter, Routes, ...},
```

and then, twenty lines apart, `resolve(BridgeEffectId(id), data)` next to
`resolve(EffectId::from_raw(id), output)`. That alias is gone now.

## Why rename the parked one

- It is the newer of the two — 0.19.0, two months ago — against a `bridge::EffectId`
  that predates it by years.
- `Registry`, the generational one, has exactly one user: `Parked`.
- No example references it. `counter-routing`, the flagship routing demo, imports
  only `bridge::EffectId`.
- It reaches only people running a custom FFI lane, where `bridge::EffectId` is in
  all six example `ffi.rs` files and in every shell wrapper ever written against Crux,
  each of which spells it `EffectId(id)`.

It is also the name the code already believed it had: `effect_id.rs` has always
panicked with `"ParkedEffectId index overflow"`.

## Migration

If you resolve a parked request, rename the type at the call site. The API is
otherwise unchanged:

```rust
// before
use crux_core::effects::EffectId;
camera.resolve(EffectId::from_raw(id), output)?;

// after
use crux_core::effects::ParkedEffectId;
camera.resolve(ParkedEffectId::from_raw(id), output)?;
```

Nothing crosses the FFI differently: `bridge::EffectId` is `#[serde(transparent)]`
and `#[facet(transparent)]`, so generated Swift, Kotlin, TypeScript and C# see a
plain `u32` and are unaffected by either name. The only occurrence of "EffectId"
in generated code is a doc comment carried over from `Request`.

Intended for **0.20.0**, alongside #568, landing on master ahead of the release
prep PR (#565) so it reviews on its own.

## Verification

- `cargo nextest run --all-features`: 246 tests
- `cargo clippy --all-targets -- --no-deps -Dclippy::pedantic -Dclippy::nursery -Dwarnings`
- doctests, `cargo fmt --check`
