### PR TITLE
docs: update cargo-nextest installation command with --locked

### DIFF
--- a/docs/src/part-1/getting_started.md
+++ b/docs/src/part-1/getting_started.md
@@ -29,7 +29,7 @@ For testing, we also recommend to install [`cargo-nextest`](https://nexte.st/), 
 in the examples.
 
 ```sh
-cargo install cargo-nextest
+cargo install cargo-nextest --locked
 ```
 
 ## Create the core crate


### PR DESCRIPTION
Reading the [getting started page](https://redbadger.github.io/crux/part-1/getting_started.html) it says:

> For testing, we also recommend to install [cargo-nextest](https://nexte.st/), the test runner we'll be using in the examples.

When trying to install it I get:

```
error: Nextest does not support being installed without --locked. To install nextest from source, run:

       cargo install --locked cargo-nextest

       For more, see https://nexte.st/docs/installation/from-source/.
```

I assume the file I edited now is the file that creates the page.

