### PR TITLE
Structured concurrency & observability

### DIFF
--- a/crux_core/src/command/context.rs
+++ b/crux_core/src/command/context.rs
@@ -8,6 +8,7 @@ use crossbeam_channel::Sender;
 use futures::channel::mpsc;
 use futures::future::Fuse;
 use futures::stream::StreamFuture;
+use futures::task::AtomicWaker;
 use futures::{FutureExt as _, Stream, StreamExt};
 
 use crate::Request;
@@ -20,11 +21,30 @@ use super::executor::{JoinHandle, Task};
 // ANCHOR: command_context
 pub struct CommandContext<Effect, Event> {
     pub(crate) effects: Sender<Effect>,
-    pub(crate) events: Sender<Event>,
+    pub(crate) events: Sender<CommandEvent<Effect, Event>>,
     pub(crate) tasks: Sender<Task>,
     pub(crate) rc: Arc<()>,
+    pub(crate) host_waker: Arc<AtomicWaker>,
 }
 // ANCHOR_END: command_context
+
+/// Event emitted by a Command, alongside the `CommandContext` of the
+/// Command which emitted it, so that follow-up commands can be
+/// spawned back on the same command.
+pub(crate) struct CommandEvent<Effect, Event> {
+    pub(crate) event: Event,
+    pub(crate) owner: CommandContext<Effect, Event>,
+}
+
+impl<Effect, Event> CommandEvent<Effect, Event> {
+    pub(crate) fn into_event(self) -> Event {
+        let Self { event, owner } = self;
+        owner.host_waker.wake();
+        drop(owner);
+
+        event
+    }
+}
 
 // derive(Clone) wants Effect and Event to be clone which is not actually necessary
 impl<Effect, Event> Clone for CommandContext<Effect, Event> {
@@ -34,6 +54,7 @@ impl<Effect, Event> Clone for CommandContext<Effect, Event> {
             events: self.events.clone(),
             tasks: self.tasks.clone(),
             rc: self.rc.clone(),
+            host_waker: self.host_waker.clone(),
         }
     }
 }
@@ -132,7 +153,10 @@ impl<Effect, Event> CommandContext<Effect, Event> {
     #[allow(clippy::missing_panics_doc)]
     pub fn send_event(&self, event: Event) {
         self.events
-            .send(event)
+            .send(CommandEvent {
+                event,
+                owner: self.clone(),
+            })
             .expect("Command could not send event, event channel disconnected");
     }
 
@@ -169,6 +193,10 @@ impl<Effect, Event> CommandContext<Effect, Event> {
         self.tasks
             .send(task)
             .expect("Command could not spawn task, tasks channel disconnected");
+
+        // spawn can be called outside of the run loop, we need to make
+        // sure the host of this command knows to poll it again
+        self.host_waker.wake();
 
         handle
     }

--- a/crux_core/src/command/mod.rs
+++ b/crux_core/src/command/mod.rs
@@ -255,6 +255,7 @@ use stream::CommandStreamExt as _;
 
 pub use builder::{NotificationBuilder, RequestBuilder, StreamBuilder};
 pub use context::CommandContext;
+pub(crate) use context::CommandEvent;
 pub use executor::AbortHandle;
 pub use stream::CommandOutput;
 
@@ -265,7 +266,7 @@ use crate::capability::Operation;
 #[must_use = "Unused commands never execute. Return the command from your app's update function or combine it with other commands with Command::and or Command::all"]
 pub struct Command<Effect, Event> {
     effects: Receiver<Effect>,
-    events: Receiver<Event>,
+    events: Receiver<CommandEvent<Effect, Event>>,
     context: CommandContext<Effect, Event>,
 
     // Executor internals
@@ -315,11 +316,14 @@ where
         let (spawn_sender, spawn_receiver) = crossbeam_channel::unbounded();
         let (_, waker_receiver) = crossbeam_channel::unbounded();
 
+        let waker: Arc<AtomicWaker> = Arc::default();
+
         let context = context::CommandContext {
             effects: effect_sender,
             events: event_sender,
             tasks: spawn_sender,
             rc: Arc::default(),
+            host_waker: waker.clone(),
         };
 
         let aborted: Arc<AtomicBool> = Arc::default();
@@ -345,7 +349,7 @@ where
             spawn_queue: spawn_receiver,
             ready_sender,
             tasks,
-            waker: Arc::default(),
+            waker,
             aborted,
         }
     }
@@ -465,6 +469,12 @@ where
 
     /// Run the effect state machine until it settles and return an iterator over the events
     pub fn events(&mut self) -> impl Iterator<Item = Event> + '_ {
+        self.events_with_origin().map(CommandEvent::into_event)
+    }
+
+    pub(crate) fn events_with_origin(
+        &mut self,
+    ) -> impl Iterator<Item = CommandEvent<Effect, Event>> + '_ {
         self.run_until_settled();
 
         self.events.try_iter()
@@ -478,10 +488,15 @@ where
         Effect: Unpin + Send + 'static,
         Event: Unpin + Send + 'static,
     {
-        self.host(ctx.effects, ctx.events).map(|_| ())
+        self.host(ctx).map(|_| ())
     }
 
-    /// Create a command running self and the other command in sequence
+    /// Create a command running `self` and `other` in sequence.
+    ///
+    /// `other` starts after `self` settles. If `self` emits events and the app
+    /// returns follow-up commands from `App::update` for those events, those
+    /// follow-up commands are hosted by `self` and must also settle before
+    /// `other` starts.
     // RFC: is this actually _useful_? Unlike `.then` on `CommandBuilder` this doesn't allow using
     // the output of the first command in building the second one, it just runs them in sequence,
     // and the benefit is unclear.
@@ -539,12 +554,17 @@ where
         Event: Unpin,
     {
         Command::new(move |ctx| {
-            self.map(move |output| match output {
-                CommandOutput::Effect(effect) => CommandOutput::Effect(map(effect)),
-                CommandOutput::Event(event) => CommandOutput::Event(event),
-            })
-            .host(ctx.effects, ctx.events)
-            .map(|_| ())
+            let owner = ctx.clone();
+            self.into_stream_with_origin()
+                .map(move |output| match output {
+                    CommandOutput::Effect(effect) => CommandOutput::Effect(map(effect)),
+                    CommandOutput::Event(event) => CommandOutput::Event(CommandEvent {
+                        event: event.into_event(),
+                        owner: owner.clone(),
+                    }),
+                })
+                .host(ctx)
+                .map(|_| ())
         })
     }
 
@@ -560,12 +580,17 @@ where
         Event: Unpin,
     {
         Command::new(move |ctx| {
-            self.map(move |output| match output {
-                CommandOutput::Effect(effect) => CommandOutput::Effect(effect),
-                CommandOutput::Event(event) => CommandOutput::Event(map(event)),
-            })
-            .host(ctx.effects, ctx.events)
-            .map(|_| ())
+            let owner = ctx.clone();
+            self.into_stream_with_origin()
+                .map(move |output| match output {
+                    CommandOutput::Effect(effect) => CommandOutput::Effect(effect),
+                    CommandOutput::Event(event) => CommandOutput::Event(CommandEvent {
+                        event: map(event.into_event()),
+                        owner: owner.clone(),
+                    }),
+                })
+                .host(ctx)
+                .map(|_| ())
         })
     }
 

--- a/crux_core/src/command/stream.rs
+++ b/crux_core/src/command/stream.rs
@@ -1,5 +1,9 @@
 #![allow(clippy::redundant_pub_crate)]
-// Command is an async Stream
+//! Stream support for [`Command`].
+//!
+//! Commands implement [`Stream`], yielding effect requests and events as they
+//! become available. This is useful for testing, manual orchestration, and
+//! advanced command composition.
 
 use std::future::Future;
 use std::ops::DerefMut as _;
@@ -9,15 +13,47 @@ use std::pin::Pin;
 
 use futures::{Sink, Stream, StreamExt as _};
 
-use crossbeam_channel::Sender;
 use thiserror::Error;
 
-use super::Command;
+use super::{Command, CommandContext, CommandEvent};
 
-/// An item emitted from a Command when used as a Stream.
+impl<Effect, Event> Command<Effect, Event>
+where
+    Effect: Unpin + Send + 'static,
+    Event: Unpin + Send + 'static,
+{
+    /// Borrow this command as a stream which preserves event origin.
+    pub(crate) fn stream_with_origin(&mut self) -> CommandStreamWithOrigin<'_, Effect, Event> {
+        CommandStreamWithOrigin { command: self }
+    }
+
+    /// Convert this command into a stream which preserves event origin.
+    pub(crate) fn into_stream_with_origin(self) -> IntoCommandStreamWithOrigin<Effect, Event> {
+        IntoCommandStreamWithOrigin { command: self }
+    }
+
+    /// Host this command inside another command context.
+    ///
+    /// Effects and structured command events emitted by `self` are forwarded
+    /// into `context`. Event ownership is preserved, so events emitted by
+    /// nested commands can receive their follow-up commands in the same
+    /// command subtree.
+    pub(crate) fn host(self, context: CommandContext<Effect, Event>) -> impl Future {
+        self.into_stream_with_origin().host(context)
+    }
+}
+
+/// An item emitted from a [`Command`] stream.
+///
+/// The public [`Stream`] implementation for [`Command`] uses `Event` as the
+/// event payload. Crux runtime internals use the same enum with
+/// [`CommandEvent`] as the event payload, preserving the event's originating
+/// command context.
 #[derive(Debug)]
 pub enum CommandOutput<Effect, Event> {
+    /// An effect request for the shell or an effect handler to process.
     Effect(Effect),
+    /// An event emitted by a command.
     Event(Event),
 }
 
@@ -29,23 +65,53 @@ where
     type Item = CommandOutput<Effect, Event>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.waker.register(cx.waker());
+        self.deref_mut()
+            .stream_with_origin()
+            .poll_next_unpin(cx)
+            .map(|output| {
+                output.map(|output| match output {
+                    CommandOutput::Effect(effect) => CommandOutput::Effect(effect),
+                    CommandOutput::Event(event) => CommandOutput::Event(event.into_event()),
+                })
+            })
+    }
+}
+
+/// A borrowed stream over a command which preserves event origin.
+///
+/// Polling this stream advances the command executor until it settles, then
+/// yields one queued event or effect. It registers the caller's waker
+/// so nested commands can wake their host when new work is spawned through a
+/// saved [`CommandContext`].
+pub(crate) struct CommandStreamWithOrigin<'a, Effect, Event> {
+    command: &'a mut Command<Effect, Event>,
+}
+
+impl<Effect, Event> Stream for CommandStreamWithOrigin<'_, Effect, Event>
+where
+    Effect: Unpin + Send + 'static,
+    Event: Unpin + Send + 'static,
+{
+    type Item = CommandOutput<Effect, CommandEvent<Effect, Event>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.command.waker.register(cx.waker());
 
         // run_until_settled is idempotent
-        self.deref_mut().run_until_settled();
+        self.command.run_until_settled();
 
         // Check events first to preserve the order in which items were emitted. This is because
         // sending events doesn't yield, and the next request/stream await point will be
         // reached in the same poll, so any follow up effects will _also_ be available
-        if let Ok(event) = self.events.try_recv() {
+        if let Ok(event) = self.command.events.try_recv() {
             return Poll::Ready(Some(CommandOutput::Event(event)));
         }
 
-        if let Ok(effect) = self.effects.try_recv() {
+        if let Ok(effect) = self.command.effects.try_recv() {
             return Poll::Ready(Some(CommandOutput::Effect(effect)));
         }
 
-        if self.is_done() {
+        if self.command.is_done() {
             Poll::Ready(None)
         } else {
             Poll::Pending
@@ -53,27 +119,55 @@ where
     }
 }
 
-/// A sink for a Command stream, sending all emitted effects and events into a pair of channels
+/// An owned stream over a command which preserves event origin.
+///
+/// This is the consumed form used when commands are hosted or mapped.
+pub(crate) struct IntoCommandStreamWithOrigin<Effect, Event> {
+    command: Command<Effect, Event>,
+}
+
+impl<Effect, Event> Stream for IntoCommandStreamWithOrigin<Effect, Event>
+where
+    Effect: Unpin + Send + 'static,
+    Event: Unpin + Send + 'static,
+{
+    type Item = CommandOutput<Effect, CommandEvent<Effect, Event>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+
+        this.command.stream_with_origin().poll_next_unpin(cx)
+    }
+}
+
+/// A sink for an origin-preserving command stream.
+///
+/// The sink forwards effects and structured command events into a
+/// [`CommandContext`]. It expects events to already have the correct owner
+/// context for the destination command type.
 pub(crate) struct CommandSink<Effect, Event> {
-    pub(crate) effects: Sender<Effect>,
-    pub(crate) events: Sender<Event>,
+    pub(crate) context: CommandContext<Effect, Event>,
 }
 
 impl<Effect, Event> CommandSink<Effect, Event> {
-    pub(crate) const fn new(effects: Sender<Effect>, events: Sender<Event>) -> Self {
-        Self { effects, events }
+    pub(crate) const fn new(context: CommandContext<Effect, Event>) -> Self {
+        Self { context }
     }
 }
 
 #[derive(Debug, Error)]
 pub(crate) enum HostedCommandError {
+    /// The host command's effect queue has been disconnected.
     #[error("Cannot send effect to host")]
     CannotSendEffect,
+    /// The host command's event queue has been disconnected.
     #[error("Cannot send event to host")]
     CannotSendEvent,
 }
 
-impl<Effect, Event> Sink<CommandOutput<Effect, Event>> for CommandSink<Effect, Event> {
+impl<Effect, Event> Sink<CommandOutput<Effect, CommandEvent<Effect, Event>>>
+    for CommandSink<Effect, Event>
+{
     type Error = HostedCommandError;
 
     fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -82,14 +176,16 @@ impl<Effect, Event> Sink<CommandOutput<Effect, Event>> for CommandSink<Effect, E
 
     fn start_send(
         self: Pin<&mut Self>,
-        item: CommandOutput<Effect, Event>,
+        item: CommandOutput<Effect, CommandEvent<Effect, Event>>,
     ) -> Result<(), Self::Error> {
         match item {
             CommandOutput::Effect(effect) => self
+                .context
                 .effects
                 .send(effect)
                 .map_err(|_| HostedCommandError::CannotSendEffect),
             CommandOutput::Event(event) => self
+                .context
                 .events
                 .send(event)
                 .map_err(|_| HostedCommandError::CannotSendEvent),
@@ -106,21 +202,21 @@ impl<Effect, Event> Sink<CommandOutput<Effect, Event>> for CommandSink<Effect, E
 }
 
 pub(crate) trait CommandStreamExt<Effect, Event>:
-    Stream<Item = CommandOutput<Effect, Event>>
+    Stream<Item = CommandOutput<Effect, CommandEvent<Effect, Event>>>
 {
-    /// Connect this command to a pair of effect and event channels
+    /// Forward this origin-preserving command stream into a command context.
     ///
-    /// This is useful if you need to multiplex several commands into the same stream of
-    /// effects and events - like Crux does.
-    fn host(self, effects: Sender<Effect>, events: Sender<Event>) -> impl Future
+    /// This is used to multiplex hosted or mapped commands into the effect and
+    /// event queues of their host command.
+    fn host(self, context: CommandContext<Effect, Event>) -> impl Future
     where
         Self: Send + Sized,
     {
-        self.map(Ok).forward(CommandSink::new(effects, events))
+        self.map(Ok).forward(CommandSink::new(context))
     }
 }
 
 impl<S, Effect, Event> CommandStreamExt<Effect, Event> for S where
-    S: Stream<Item = CommandOutput<Effect, Event>>
+    S: Stream<Item = CommandOutput<Effect, CommandEvent<Effect, Event>>>
 {
 }

--- a/crux_core/src/command/tests/mod.rs
+++ b/crux_core/src/command/tests/mod.rs
@@ -5,5 +5,6 @@ mod capability_api;
 mod combinators;
 mod composition;
 mod executor;
+mod runtime_structure;
 
 mod integration;

--- a/crux_core/src/command/tests/runtime_structure.rs
+++ b/crux_core/src/command/tests/runtime_structure.rs
@@ -1,0 +1,75 @@
+use crate::{Command, Core, Request, capability::Operation};
+
+#[derive(Default)]
+struct TestApp;
+
+#[derive(Debug, PartialEq, Eq)]
+enum Event {
+    Start,
+    FollowUp,
+    FollowUpDone,
+    AfterDone,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Op {
+    FollowUp,
+    After,
+}
+
+impl Operation for Op {
+    type Output = ();
+}
+
+enum Effect {
+    Op(Request<Op>),
+}
+
+impl crate::Effect for Effect {}
+
+impl From<Request<Op>> for Effect {
+    fn from(value: Request<Op>) -> Self {
+        Self::Op(value)
+    }
+}
+
+impl crate::App for TestApp {
+    type Event = Event;
+    type Model = ();
+    type ViewModel = ();
+    type Effect = Effect;
+
+    fn update(
+        &self,
+        event: Self::Event,
+        _model: &mut Self::Model,
+    ) -> Command<Self::Effect, Self::Event> {
+        match event {
+            Event::Start => Command::event(Event::FollowUp)
+                .then(Command::request_from_shell(Op::After).then_send(|()| Event::AfterDone)),
+            Event::FollowUp => {
+                Command::request_from_shell(Op::FollowUp).then_send(|()| Event::FollowUpDone)
+            }
+            Event::FollowUpDone | Event::AfterDone => Command::done(),
+        }
+    }
+
+    fn view(&self, _model: &Self::Model) -> Self::ViewModel {}
+}
+
+#[test]
+fn follow_up_commands_are_hosted_in_the_command_that_emitted_the_event() {
+    let core = Core::new_with(TestApp, ());
+
+    let mut effects = core.process_event(Event::Start);
+    assert_eq!(effects.len(), 1);
+
+    let Effect::Op(mut request) = effects.remove(0);
+    assert_eq!(request.operation, Op::FollowUp);
+
+    let mut effects = core.resolve(&mut request, ()).unwrap();
+    assert_eq!(effects.len(), 1);
+
+    let Effect::Op(request) = effects.remove(0);
+    assert_eq!(request.operation, Op::After);
+}

--- a/crux_core/src/core/mod.rs
+++ b/crux_core/src/core/mod.rs
@@ -147,16 +147,23 @@ where
             .lock()
             .expect("Capability runtime lock was poisoned");
 
-        let mut events: VecDeque<_> = root_command.events().collect();
+        let mut events: VecDeque<_> = root_command.events_with_origin().collect();
 
-        while let Some(event_from_commands) = events.pop_front() {
+        while let Some(command_event) = events.pop_front() {
+            let event_from_commands = command_event.event;
+            // event_owner is the command which emitted the event
+            let event_owner = command_event.owner;
+
             let mut model = self.model.write().expect("Model RwLock was poisoned.");
             let command = self.app.update(event_from_commands, &mut model);
             drop(model);
 
-            root_command.spawn(|ctx| command.into_future(ctx));
+            // the follow-up command is spawned on the owner to be a logical
+            // part of the original command process
+            event_owner.spawn(|ctx| command.into_future(ctx));
+            drop(event_owner);
 
-            events.extend(root_command.events());
+            events.extend(root_command.events_with_origin());
         }
 
         root_command.effects().collect()

--- a/examples/notes/shared/src/app.rs
+++ b/examples/notes/shared/src/app.rs
@@ -556,7 +556,7 @@ mod editing_tests {
 mod save_load_tests {
     use crux_core::{App as _, assert_effect};
     use crux_kv::{KeyValueOperation, KeyValueResponse, KeyValueResult, value::Value};
-    use crux_time::{TimeRequest, TimerId};
+    use crux_time::TimeRequest;
 
     use super::*;
 
@@ -727,13 +727,13 @@ mod save_load_tests {
 
         let _publish = effects.next().unwrap().expect_pub_sub();
         let timer = effects.next().unwrap().expect_time();
-        assert_eq!(
-            timer.operation,
-            TimeRequest::NotifyAfter {
-                id: TimerId(3),
-                duration: crux_time::Duration::from_millis(1000)
-            }
-        );
+        let TimeRequest::NotifyAfter { id, duration } = timer.operation else {
+            panic!("expected a NotifyAfter");
+        };
+
+        assert_ne!(id, first_id);
+        assert_ne!(id, second_id);
+        assert_eq!(duration, crux_time::Duration::from_millis(1000));
     }
     // ANCHOR_END: starts_a_timer_after_an_edit
 }


### PR DESCRIPTION
This is an attempt to support something along the lines of #530.

### Core change

When commands emit `Event`s, they are sent through `update`, which returns another Command – a "follow-up" command.

When `Event`s are sent from the shell, these commands are run hosted in a "root" Command. Previously, so did the follow up commands, but instead, the follow up commands are now hosted in the original Command which caused them.

This means Commands are not fully done, until _all_ their consequences are considered done.

**Breaking change**: This also changes the semantics of `.then()`. In `cmd_1.then(cmd_2)`, `cmd_2` will now waits for all consequences of `cmd_1` to complete and only then execute.

### Observability

On top of the runtime change, I've added an effect runtime observability layer, which emits events whenever something important happens in the runtime. The events are shaped like `tracing` or OpenTelemetry – there are spans and events – and their relationships are tracked along the parent/child (where am I executing) and causal (what triggered me) axes.

Observers can be registered from outside the core, or from the inside (although the latter is a little bit dangerous, because it will itself become observable, potentially causing infinite loops).

I'm planning to implement a `tracing` adapter under a feature flag, which should then enable translating this to a format that can be visualised.