### PR TITLE
chore(deps): take facet_generate 0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3799ad16bb15772f993add1355154bea812a99c37307cd8035bf8692ce145ad0"
+checksum = "106f54588fa567816c147c77fb02269aec3d5adc250a64221e3040c3d8656f96"
 dependencies = [
  "derive_builder",
  "facet 0.46.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ categories = ["gui", "wasm", "development-tools::ffi"]
 [workspace.dependencies]
 anyhow = "1.0"
 facet = "=0.46.5"
-facet_generate = "0.19"
+facet_generate = "0.20"
 facet-generate-attrs = "0.18"
 # facet_generate = { path = "../facet-generate/crates/facet_generate" }
 # facet-generate-attrs = { path = "../facet-generate/crates/facet-generate-attrs" }

--- a/examples/counter-http/Cargo.lock
+++ b/examples/counter-http/Cargo.lock
@@ -1050,9 +1050,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3799ad16bb15772f993add1355154bea812a99c37307cd8035bf8692ce145ad0"
+checksum = "106f54588fa567816c147c77fb02269aec3d5adc250a64221e3040c3d8656f96"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/counter-middleware/Cargo.lock
+++ b/examples/counter-middleware/Cargo.lock
@@ -960,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3799ad16bb15772f993add1355154bea812a99c37307cd8035bf8692ce145ad0"
+checksum = "106f54588fa567816c147c77fb02269aec3d5adc250a64221e3040c3d8656f96"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/counter-routing/Cargo.lock
+++ b/examples/counter-routing/Cargo.lock
@@ -960,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3799ad16bb15772f993add1355154bea812a99c37307cd8035bf8692ce145ad0"
+checksum = "106f54588fa567816c147c77fb02269aec3d5adc250a64221e3040c3d8656f96"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/counter/Cargo.lock
+++ b/examples/counter/Cargo.lock
@@ -2282,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3799ad16bb15772f993add1355154bea812a99c37307cd8035bf8692ce145ad0"
+checksum = "106f54588fa567816c147c77fb02269aec3d5adc250a64221e3040c3d8656f96"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/notes/Cargo.lock
+++ b/examples/notes/Cargo.lock
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3799ad16bb15772f993add1355154bea812a99c37307cd8035bf8692ce145ad0"
+checksum = "106f54588fa567816c147c77fb02269aec3d5adc250a64221e3040c3d8656f96"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/notes/shared/src/app.rs
+++ b/examples/notes/shared/src/app.rs
@@ -311,7 +311,7 @@ impl CursorObserver {
 
 #[cfg(test)]
 mod editing_tests {
-    use crux_core::{App as _, assert_effect};
+    use crux_core::assert_effect;
 
     use super::*;
 
@@ -554,7 +554,7 @@ mod editing_tests {
 
 #[cfg(test)]
 mod save_load_tests {
-    use crux_core::{App as _, assert_effect};
+    use crux_core::assert_effect;
     use crux_kv::{KeyValueOperation, KeyValueResponse, KeyValueResult, value::Value};
     use crux_time::{TimeRequest, TimerId};
 
@@ -742,7 +742,7 @@ mod save_load_tests {
 mod sync_tests {
     use std::collections::VecDeque;
 
-    use crux_core::{App as _, Request};
+    use crux_core::Request;
 
     use crate::capabilities::pub_sub::{Message, PubSubOperation};
 

--- a/examples/weather/Cargo.lock
+++ b/examples/weather/Cargo.lock
@@ -920,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "facet_generate"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3799ad16bb15772f993add1355154bea812a99c37307cd8035bf8692ce145ad0"
+checksum = "106f54588fa567816c147c77fb02269aec3d5adc250a64221e3040c3d8656f96"
 dependencies = [
  "derive_builder",
  "facet",

--- a/examples/weather/shared/src/app.rs
+++ b/examples/weather/shared/src/app.rs
@@ -35,8 +35,6 @@ impl App for Weather {
 
 #[cfg(test)]
 mod tests {
-    use crux_core::App as _;
-
     use crate::{
         effects::{EffectTestExt, secret},
         model::initializing::InitializingModel,


### PR DESCRIPTION
Takes [facet_generate 0.20](https://github.com/redbadger/facet-generate/pull/122), which fixes the Kotlin generator qualifying a type in a *sibling* namespace with the current module's name instead of the root package (redbadger/facet-generate#121).

Before the fix, a reference from one named namespace into another gained an extra segment:

```kotlin
package com.example.feature

data class FeatureView(
    val rows: List<com.example.feature.kit.Row>,   // declared in com.example.kit
)
```

so the generated Kotlin did not compile. It affects any core that groups its types into more than one namespace — the normal shape once an app has several features. Found bringing up a Jetpack Compose shell for a core with 24 namespaces, where it produced 11 broken references across 8 files.

## Compatibility

`facet_generate` 0.20 is semver-breaking only because the fix adds a public field (`parent`) to `CodeGeneratorConfig`, so struct-literal construction breaks. `crux_core` builds facet configs through `Config::builder(...)` and never as a literal — the only literal `CodeGeneratorConfig::new` calls in this crate are `serde_generate`'s, a different crate — so this is a one-line bump.

`facet = "=0.46.5"` and `facet-generate-attrs = "0.18"` are unchanged; 0.20 pins the same versions.

`cargo test -p crux_core --features facet_typegen` passes.